### PR TITLE
Header & Footer Navigation

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -33,14 +33,4 @@ Footer.propTypes = {
   pages: PropTypes.arrayOf(link),
 };
 
-Footer.defaultProps = {
-  pages: [
-    { displayName: 'Collect Data', url: '' },
-    { displayName: 'Explore Data', url: 'explore-data' },
-    { displayName: 'Build Apps', url: '' },
-    { displayName: 'Automate Workflows', url: '' },
-    { displayName: 'Developer Docs', url: '' },
-  ],
-};
-
 export default Footer;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -85,14 +85,4 @@ Header.propTypes = {
   pages: PropTypes.arrayOf(link),
 };
 
-Header.defaultProps = {
-  pages: [
-    { displayName: 'Collect Data', url: '' },
-    { displayName: 'Explore Data', url: 'explore-data' },
-    { displayName: 'Build Apps', url: '' },
-    { displayName: 'Automate Workflow', url: '' },
-    { displayName: 'Developer Docs', url: '' },
-  ],
-};
-
 export default Header;

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -5,11 +5,19 @@ import Footer from './Footer';
 import Header from './Header';
 import './styles.scss';
 
+const pages = [
+  { displayName: 'Collect Data', url: 'collect-data' },
+  { displayName: 'Explore Data', url: 'explore-data' },
+  { displayName: 'Build Apps', url: 'build-apps' },
+  { displayName: 'Automate Workflows', url: 'automate-workflows' },
+  { displayName: 'Developer Docs', url: 'docs' },
+];
+
 const Layout = ({ children }) => (
   <div className="Layout">
-    <Header />
+    <Header pages={pages} />
     <main>{children}</main>
-    <Footer />
+    <Footer pages={pages} />
   </div>
 );
 


### PR DESCRIPTION
## Description
Rather than relying on default props, and hard-coding in two locations, this PR hoists up the top-level navigation to the `Layout` component (common parent of the `Header` and `Footer` components).

To maintain control over the presentation of the main navigation, this is explicitly defined rather than queried. Which is a fancy way of me saying that it's hard-coded for a reason.

## Related Ticket(s)
* [DEVEX-609](https://newrelic.atlassian.net/browse/DEVEX-609)