### PR TITLE
Add wistia support for embedded video

### DIFF
--- a/src/components/Video.js
+++ b/src/components/Video.js
@@ -3,17 +3,15 @@ import PropTypes from 'prop-types';
 
 import styles from './Video.module.scss';
 
-const Video = ({ wistiaId, youtubeId, title }) => {
-  const embedYoutube = youtubeId
-    ? `//www.youtube.com/embed/${youtubeId}?modestbranding=1`
-    : null;
-  const embedWistia = wistiaId
-    ? `//fast.wistia.net/embed/iframe/${wistiaId}`
-    : null;
+const Video = ({ id, type, title }) => {
+  const src = {
+    youtube: `//www.youtube.com/embed/${id}?modestbranding=1`,
+    wistia: `//fast.wistia.net/embed/iframe/${id}`,
+  };
   return (
     <div className={styles.Video}>
       <iframe
-        src={embedYoutube || embedWistia}
+        src={src[type]}
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
         title={title}
         frameBorder="0"
@@ -24,9 +22,8 @@ const Video = ({ wistiaId, youtubeId, title }) => {
 };
 
 Video.propTypes = {
-  // NOTE: we should expand this allow for other video sources in the future
-  youtubeId: PropTypes.string,
-  wistiaId: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
   title: PropTypes.string,
 };
 

--- a/src/markdown-pages/example.mdx
+++ b/src/markdown-pages/example.mdx
@@ -21,6 +21,6 @@ export default FooBar;
 
 Integer aliquam convallis scelerisque. Donec auctor dictum viverra. Praesent commodo porttitor tortor. Fusce eget sem arcu. Praesent convallis augue est. `Vestibulum` in mi sollicitudin, rhoncus est eu, rutrum augue. Ut in elit ac odio ultrices pharetra eget id magna. Donec tellus dui, volutpat ut malesuada eget, pharetra eget metus. Proin tortor lacus, vestibulum dignissim urna ac, rutrum vulputate orci. Sed justo tellus, convallis eu tincidunt at, euismod eu enim. Sed interdum viverra volutpat. Suspendisse eget accumsan nunc. Aliquam tempor in magna ut lobortis.
 
-<Video youtubeId="ZagZfNQYJEU" />
+<Video id="ZagZfNQYJEU" type="youtube" />
 
-<Video wistiaId="zxunt1u1as" />
+<Video id="zxunt1u1as" type="wistia"/>


### PR DESCRIPTION
## Description
This is a quick edit of our video component to add support for wistia videos. 

## Reviewer Notes
The example mdx file now also includes a wistia video. We may want to expand on this later but it could be nice to add now for early contributors 

## Screenshot(s)
<img width="588" alt="Screen Shot 2020-05-27 at 1 33 58 PM" src="https://user-images.githubusercontent.com/39655074/83069438-bc7d1b00-a01e-11ea-801f-fea9ffabc698.png">
