### PR TITLE
Add `sitemap.xml` via plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,6 +4,7 @@ module.exports = {
     description:
       'Do more on our platform and make New Relic your own with APIs, SDKs, code snippets, tutorials, and more developer tools.',
     author: 'New Relic',
+    siteUrl: 'https://developer.newrelic.com',
   },
   plugins: [
     'gatsby-plugin-react-helmet',
@@ -68,5 +69,6 @@ module.exports = {
         policy: [{ userAgent: '*', allow: '/' }],
       },
     },
+    'gatsby-plugin-sitemap',
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11245,6 +11245,27 @@
         }
       }
     },
+    "gatsby-plugin-sitemap": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-2.4.3.tgz",
+      "integrity": "sha512-XwtXRkUo1tFnr5PzwLlQqAD/Dbnrv0G9HjuUL24UhhCy0e5vqByohcewARUtySK0vSY1dr3msTO+UEKKuGWrFQ==",
+      "requires": {
+        "@babel/runtime": "^7.9.6",
+        "minimatch": "^3.0.4",
+        "pify": "^3.0.0",
+        "sitemap": "^1.13.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "gatsby-react-router-scroll": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.2.2.tgz",
@@ -23318,6 +23339,15 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
+    "sitemap": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-1.13.0.tgz",
+      "integrity": "sha1-Vpy+IYAgKSamKiZs094Jyc60P4M=",
+      "requires": {
+        "underscore": "^1.7.0",
+        "url-join": "^1.1.0"
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -24981,6 +25011,11 @@
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
     },
+    "underscore": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
+      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
+    },
     "underscore.string": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
@@ -25530,6 +25565,11 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
+    },
+    "url-join": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+      "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
     },
     "url-loader": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gatsby-plugin-robots-txt": "^1.5.1",
     "gatsby-plugin-sass": "^2.2.3",
     "gatsby-plugin-sharp": "^2.5.6",
+    "gatsby-plugin-sitemap": "^2.4.3",
     "gatsby-remark-images": "^3.3.8",
     "gatsby-source-filesystem": "^2.2.4",
     "gatsby-transformer-remark": "^2.7.3",


### PR DESCRIPTION
## Description
Adds the [gatsby sitemap plugin](https://www.gatsbyjs.org/docs/creating-a-sitemap/) that will automatically generate a `sitemap.xml` file on build. This is using the base configuration, but can be altered if we need to make adjustments in the future.

## Reviewer Notes
To review this, you can pull down the branch and run `npm run build`. This will create a `public/sitemap.xml` file for review.

## Related Issue(s) / Ticket(s)
* [DEVEX-794](https://newrelic.atlassian.net/browse/DEVEX-794)