### PR TITLE
fix: Removes font size override for bare h2 tag

### DIFF
--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -119,10 +119,6 @@ h6 {
   font-family: var(--primary-font-family);
 }
 
-h2 {
-  font-size: 1.3em;
-}
-
 button,
 input,
 optgroup,


### PR DESCRIPTION
## Description
I noticed that bare `<h2>` tags had a font size override that made them too similar to `<h3>` tags. This PR removes the override so they get the default user agent stylesheet.

## Screenshot(s)

### Before

<img width="880" alt="Screen Shot 2020-06-08 at 1 41 54 PM" src="https://user-images.githubusercontent.com/186715/84079184-0525c400-a98f-11ea-81f7-674e6abbf76c.png">

### After

<img width="876" alt="Screen Shot 2020-06-08 at 1 42 11 PM" src="https://user-images.githubusercontent.com/186715/84079161-fc34f280-a98e-11ea-99e9-877657111a77.png">