### PR TITLE
fix: Balances the visual design of the props section

### DIFF
--- a/src/components/PropList.module.scss
+++ b/src/components/PropList.module.scss
@@ -6,6 +6,7 @@
 
   h3 {
     font-size: 1.25rem;
+    margin-top: 0;
   }
 }
 
@@ -27,8 +28,11 @@
 }
 
 .details {
-  font-size: 1.25rem;
   width: 70%;
+
+  p:first-of-type {
+    margin-top: 0;
+  }
 }
 
 .required {


### PR DESCRIPTION
## Description
Minor style tweaks to make the props section feel more balanced visually, including vertical alignment and font size of the details section.

## Screenshot(s)

### Before

<img width="898" alt="Screen Shot 2020-06-08 at 4 07 54 PM" src="https://user-images.githubusercontent.com/186715/84089116-0bbe3680-a9a3-11ea-8070-4595d0f8721e.png">

### After

<img width="898" alt="Screen Shot 2020-06-08 at 4 10 39 PM" src="https://user-images.githubusercontent.com/186715/84089120-0f51bd80-a9a3-11ea-8a3f-f7517b975a01.png">
