### PR TITLE
removed TOC section for code editors

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -47,7 +47,6 @@
   * [Use active voice](#use-active-voice)
   * [Make lists clear with the Oxford Comma](#make-lists-clear-with-the-oxford-comma)
   * [Prefer US English](#prefer-us-english)
-  * [Recommended code editors](#recommended-code-editors)
 - [References](#references)
 
 # Welcome!


### PR DESCRIPTION
## Description
The TOC still had a reference to the code editor section which was removed. 

## Reviewer Notes

A quick code review and approval is all that is needed. 

## Related Issue(s) / Ticket(s)
N/A

## Screenshot(s)
N/A