### PR TITLE
Ignore API-Specific Methods

### DIFF
--- a/src/hooks/useApiDoc.js
+++ b/src/hooks/useApiDoc.js
@@ -7,8 +7,11 @@ const IGNORED_METHODS = [
   'propTypes',
   'getDerivedStateFromProps',
   'defaultProps',
-  'deprecate',
 ];
+
+const IGNORED_METHODS_BY_LIB = {
+  logger: ['deprecate'],
+};
 
 const useApiDoc = (name) => {
   if (typeof window === 'undefined') global.window = {};
@@ -31,6 +34,11 @@ const useApiDoc = (name) => {
           (member) =>
             !IGNORED_METHODS.includes(member) &&
             typeof api[member] === 'function'
+        )
+        .filter(
+          (member) =>
+            !IGNORED_METHODS_BY_LIB[name] ||
+            !IGNORED_METHODS_BY_LIB[name].includes(member)
         )
         .map((member) => {
           const methodDocs = api[member].__docs__;


### PR DESCRIPTION
## Description
Adds the ability to ignore specific methods on specific API docs.

## Reviewer Notes
This can be seen by looking at the `/apis/logger` documentation. The `deprecate` function should not be displayed.

## Related Issue(s) / Ticket(s)
* [DEVEX-882](https://newrelic.atlassian.net/browse/DEVEX-882)
