### PR TITLE
Portal SDK components with isolated styles

### DIFF
--- a/src/components/ReferencePreview.js
+++ b/src/components/ReferencePreview.js
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import root from 'react-shadow';
 import { LivePreview } from 'react-live';
 import { CSS_BUNDLE } from '../utils/sdk';
+import useSdkPortalTarget from '../hooks/useSdkPortalTarget';
 
 const EXAMPLE_CSS = `
 .nr1-ReferenceExample {
@@ -86,69 +87,12 @@ const EXAMPLE_CSS = `
 }
 `;
 
-const hostId = 'nr1SdkShadowDomHost';
-
-/**
- * Add a singleton shadow DOM element to body with SDK styles added.
- */
-const getShadowDomHost = () => {
-  function createShadowDomHost() {
-    // Create host div
-    const bodyElement = document.querySelector('body');
-    const host = document.createElement('div');
-    host.id = hostId;
-    bodyElement.appendChild(host);
-
-    // Make it a shadow dom host
-    host.attachShadow({ mode: 'open' });
-
-    // Add sdk styles to the shadow dom
-    const sdkStyles = document.createElement('link');
-    sdkStyles.rel = 'stylesheet';
-    sdkStyles.href = CSS_BUNDLE;
-    host.appendChild(sdkStyles);
-
-    return host;
-  }
-
-  return document.querySelector(`#${hostId}`) || createShadowDomHost();
-};
-
 const ReferencePreview = ({ className, style, useToastManager }) => {
   const [stylesLoaded, setStylesLoaded] = useState(false);
 
   const { ToastManager } = window.__NR1_SDK__;
 
-  useEffect(() => {
-    const hostDiv = getShadowDomHost();
-
-    const observer = new MutationObserver(function (mutations) {
-      const additions = mutations
-        .filter(
-          ({ type, addedNodes }) =>
-            type === 'childList' && addedNodes && addedNodes.length > 0
-        )
-        .flatMap(({ addedNodes }) => {
-          return [...addedNodes.values()].filter(({ className }) =>
-            // This catches the Modal and Tooltip. Would need to reach
-            // another layer of children to detect the Dropdown.
-            className.includes('-wnd-')
-          );
-        });
-
-      // Move nodes to shadow dom host
-      additions.forEach((node) => {
-        hostDiv.appendChild(node);
-      });
-    });
-
-    const body = document.querySelector('body');
-    observer.observe(body, { childList: true });
-
-    return function cleanup() {
-      observer.disconnect();
-    };
-  }, []);
+  useSdkPortalTarget();
 
   return (
     <root.div className={className}>

--- a/src/hooks/useSdkPortalTarget.js
+++ b/src/hooks/useSdkPortalTarget.js
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import { CSS_BUNDLE } from '../utils/sdk';
+
+/**
+ * The SDK looks for this ID. If found it treats it as the target for
+ * portal components.
+ */
+const hostId = 'nr1-sdk-docs-portal-target';
+
+/**
+ * Ensures existense of the portal target that the sdk looks for when calling
+ * React.createPortal(). The sdk portal target is a shadow DOM element for the
+ * purpose of isolating SDK styles.
+ */
+const useSdkPortalTarget = () => {
+  useEffect(() => {
+    document.querySelector(`#${hostId}`) || createShadowDomHost();
+  }, []);
+};
+
+function createShadowDomHost() {
+  // Create host div on body
+  const host = document.createElement('div');
+  host.id = hostId;
+  document.querySelector('body').appendChild(host);
+
+  // Make it a shadow dom host
+  host.attachShadow({ mode: 'open' });
+
+  // Add sdk styles to the shadow dom
+  const sdkStyles = document.createElement('link');
+  sdkStyles.rel = 'stylesheet';
+  sdkStyles.href = CSS_BUNDLE;
+  host.shadowRoot.appendChild(sdkStyles);
+
+  return host;
+}
+
+export default useSdkPortalTarget;

--- a/src/utils/sdk.js
+++ b/src/utils/sdk.js
@@ -1,6 +1,24 @@
-const BASE_URL =
-  '//hypertext-sandbox.nr-assets.net/wanda--wanda-ec-ui--nr1-docs';
 const RELEASE = 'release-1093';
+const PROD_BASE_URL = '//hypertext-sandbox.nr-assets.net';
+const LOCAL_BASE_URL = 'https://nr-local.net:4000';
 
-export const JS_BUNDLE = `${BASE_URL}-${RELEASE}.js`;
-export const CSS_BUNDLE = `${BASE_URL}-${RELEASE}.css`;
+function getBundleUrls() {
+  // TODO: detect whether to load local version. This is used both at build time and run time
+  // so perhaps an env var for build time that also injects some flag for runtime so the
+  // developer doesn't have to do both a different command to start and remember to apply a
+  // use_version query string.
+  const useLocalSdk = true;
+
+  const baseUrl = useLocalSdk ? LOCAL_BASE_URL : PROD_BASE_URL;
+  const releasePath = useLocalSdk ? 'latest' : RELEASE;
+
+  return {
+    cssBundleUrl: `${baseUrl}/wanda--wanda-ec-ui--nr1-docs-${releasePath}.css`,
+    jsBundleUrl: `${baseUrl}/wanda--wanda-ec-ui--nr1-docs-${releasePath}.js`,
+  };
+}
+
+const { cssBundleUrl, jsBundleUrl } = getBundleUrls();
+
+export const JS_BUNDLE = jsBundleUrl;
+export const CSS_BUNDLE = cssBundleUrl;


### PR DESCRIPTION
## Description
For stability and maintainability, it is important that the sdk styles stay isolated from the styles of the doc site and vice versa. This PR fixes rendering of component examples that use React.createPortal while keeping to our need to isolate SDK styles from the website styles. Without this PR, it was already possible to render most components in shadow dom, but any components that utilize React.createPortal() were left broken because the portal target is the document.body which lives outside of the shadow dom without access to the isolated sdk styles. 

We have a corresponding PR into the SDK to look for the `#nr1-sdk-docs-portal-target` element and it's shadow root. Ideally that ID would be provided by the SDK, but before doing so I want to discuss it a bit more.

This PR also sets up the ability to load a locally served SDK bundle in order to facilitate this kind of work that depends on checking changes to the SDK. It'll come in handy for confirming future releases of the SDK as well.

## Reviewer Notes
To test:
1. Pull down the sdk repo, run `npm run dev:docs`
2. Ether pull down this branch, run 'npm start`, or while this PR is still hard coded to always load from local, you can just run this PR build.
3. You can open dev tools to see the shadow dom element added to body and see component portal content placed there as you interact with the Tooltip, Modal or Dropdown components.

## Related Issue(s) / Ticket(s)
* [JIRA ticket](https://newrelic.atlassian.net/browse/DEVEX-832)

## Screenshot(s)
<img width="585" alt="Screen Shot 2020-06-09 at 8 47 34 PM" src="https://user-images.githubusercontent.com/3023056/84224877-82862d00-aa92-11ea-8af9-935b0e08921c.png">

