### PR TITLE
fix: resolve prettier warning message

### DIFF
--- a/src/utils/formatCode.js
+++ b/src/utils/formatCode.js
@@ -10,6 +10,7 @@ const formatCode = (code, formatOptions = {}) =>
     singleQuote: true,
     ...formatOptions,
     plugins: [parserBabel],
+    parser: 'babel',
   });
 
 export default formatCode;


### PR DESCRIPTION
## Description
Resolves a warning from the runtime `prettier` code formatting that in the future a lack of the `parser` config value will result in an error.

## Reviewer Notes
If you load master up you can see this message when loading any of the component example pages.

## Related Issue(s) / Ticket(s)

## Screenshot(s)
<img width="502" alt="Screen Shot 2020-06-10 at 10 55 27 AM" src="https://user-images.githubusercontent.com/3023056/84301627-f7944980-ab08-11ea-9c7e-cf8a039cf4eb.png">

