### PR TITLE
fix: Add check for propTypes in getTypeDefs

### DIFF
--- a/src/hooks/useComponentDoc.js
+++ b/src/hooks/useComponentDoc.js
@@ -23,9 +23,11 @@ const getTypeDefs = (component) => {
     .map((key) => component[key]?.__docs__?.tags)
     .filter(Boolean);
 
-  const tagsFromPropTypes = Object.getOwnPropertyNames(component.propTypes).map(
-    (key) => component.propTypes[key]?.__docs__?.tags
-  );
+  const tagsFromPropTypes = component.propTypes
+    ? Object.getOwnPropertyNames(component.propTypes).map(
+        (key) => component.propTypes[key]?.__docs__?.tags
+      )
+    : [];
 
   const componentTypeDefNames = tagsFromComponentProperties
     .concat(tagsFromPropTypes)


### PR DESCRIPTION
## Description
fixes broken pages for components that don't have proptypes

## Reviewer Notes
check out NerdletStateContext and PlatformStateContext, now rendering!