### PR TITLE
chore: Add word break to prop info styling

### DIFF
--- a/src/components/PropList.module.scss
+++ b/src/components/PropList.module.scss
@@ -7,6 +7,7 @@
 
 .info {
   width: 30%;
+  word-break: break-all;
 
   code {
     font-weight: bold;


### PR DESCRIPTION
## Description
designer approved, temporary fix for default prop styles

## Screenshot(s)

## Related issue(s) / Tickets
* [DEVEX-922](https://newrelic.atlassian.net/browse/DEVEX-922)

### before
<img width="930" alt="Screen Shot 2020-06-11 at 11 37 00 AM" src="https://user-images.githubusercontent.com/39655074/84427645-18789f80-abda-11ea-8a3b-166901541d6b.png">

### after
<img width="905" alt="Screen Shot 2020-06-11 at 11 52 33 AM" src="https://user-images.githubusercontent.com/39655074/84427665-1f071700-abda-11ea-9120-1e027c1e417c.png">

