### PR TITLE
Add max height to prop enums

### DIFF
--- a/src/components/PropList.module.scss
+++ b/src/components/PropList.module.scss
@@ -72,6 +72,8 @@
   font-family: var(--code-font);
   font-size: 0.875rem;
   color: var(--color-neutrals-600);
+  max-height: 320px;
+  overflow-y: auto;
 }
 
 .shape {


### PR DESCRIPTION
## Description
Adds a max height and scroll bar to prop enum lists

## Related Issue(s) / Ticket(s)
* [DEVEX-823](https://newrelic.atlassian.net/browse/DEVEX-823)

## Screenshot(s)
### before
<img width="901" alt="Screen Shot 2020-06-11 at 12 00 49 PM" src="https://user-images.githubusercontent.com/39655074/84428570-8c677780-abdb-11ea-8b15-6097528cac75.png">

### after
<img width="970" alt="Screen Shot 2020-06-11 at 12 00 39 PM" src="https://user-images.githubusercontent.com/39655074/84428575-8e313b00-abdb-11ea-9a6f-dec9cd5f9fb1.png">

