### PR TITLE
Change typeDef return value key name

### DIFF
--- a/src/hooks/useComponentDoc.js
+++ b/src/hooks/useComponentDoc.js
@@ -56,8 +56,7 @@ const getTypeDefs = (component) => {
 
   const structuredTypeDefs = typeDefs.map((typeDef) => ({
     properties: typeDef.tags.property,
-    identifier: typeDef.tags.typedef.find((tag) => tag.identifier).identifier
-      .name,
+    name: typeDef.tags.typedef.find((tag) => tag.identifier).identifier.name,
   }));
 
   return structuredTypeDefs;


### PR DESCRIPTION
## Description
After refactoring, a key name slipped through and didn't get changed from `identifier` to `name` in useComponentDoc, which caused type def names not to show up

## Reviewer Notes
See AccountQuery type defs section

## Screenshot(s)
### before
<img width="601" alt="Screen Shot 2020-06-11 at 2 51 50 PM" src="https://user-images.githubusercontent.com/39655074/84442761-1838ce00-abf3-11ea-86cc-5bd1cc98e7c6.png">

### after
<img width="573" alt="Screen Shot 2020-06-11 at 2 51 33 PM" src="https://user-images.githubusercontent.com/39655074/84442794-2981da80-abf3-11ea-8730-10d54fabea24.png">


