### PR TITLE
Create publish-deploy.mdx

### DIFF
--- a/src/markdown-pages/publish-deploy.mdx
+++ b/src/markdown-pages/publish-deploy.mdx
@@ -1,0 +1,98 @@
+---
+path: '/build-apps/publish-deploy'
+duration: '20 min'
+title: 'Serve, publish, and deploy your New Relic One app'
+template: 'GuideTemplate'
+description: 'Start sharing and using the custom New Relic One apps you build.'
+---
+
+<Intro>
+
+When you build a New Relic One app, chances are you'll want to share it with others in your company. You might even want to share it through our open source channel. But first, you probably want to try it out locally to make sure it's working properly. The following sections describe how to serve your app locally, add it to New Relic One, and then share it with coworkers. 
+
+-   [Serve it locally](#serve-locally). During development, you can locally serve it locally to test it out.
+    
+-   [Publish it](#publish-app). When your application is ready for the world, you can publish it and [deploy it](#deploy-app), and users can  [subscribe](#Subscribe) to it.
+
+
+</Intro>
+
+## Before you begin
+
+This guide requires the following:
+
+- A New Relic One app or Nerdpack
+- New Relic One CLI 
+
+<br/>
+
+<Steps>
+
+<Step>
+
+## Serve your app locally
+
+While developing your application, you can locally serve the Nerdpack, which will display it in New Relic One. 
+
+
+1.  Run the following in the parent root folder of your Nerdpack:  `nr1 nerdpack:serve`.  
+    
+2.  Go to [one.newrelic.com/?nerdpacks=local](http://one.newrelic.com/?nerdpack=local). The  `?nerdpacks=local`  URL suffix will load any locally served Nerdpacks that are available.
+    
+
+When you make a change to a locally served Nerdpack, New Relic One will automatically reload it.
+
+For more on this, see [Local development](https://developer.newrelic.com/client-side-sdk/index.html#cli/LocalDevelopment).
+
+
+</Step>
+
+<Step>
+
+## Publish
+
+The [CLI command](https://developer.newrelic.com/build-tools/new-relic-one-applications/cli#Commands) `nerdpack:publish` places your Nerdpack in New Relic One. To publish and deploy, you must be a Nerdpack manager (a type of [New Relic add-on role](https://docs.newrelic.com/docs/accounts/accounts/roles-permissions/add-roles-permissions)). Your New Relic account administrator can grant this role. For more on permissions, see [Authentication and permissions](https://developer.newrelic.com/build-tools/new-relic-one-applications/guide-to-authentication--data-access--and-permissions).
+
+**Note**: New Relic One requires that only one version (following semantic versioning) of a Nerdpack can be published. Thus, the `nr1 nerdpack:publish` command expects the correct permissions (the aforementioned Nerdpack Manager role and a unique version (as specified in the package.json's version attribute).
+
+To publish, run: `nr1 nerdpack:publish`.
+
+To learn how to switch the account a Nerdpack is associated with, see  [App access to data](https://developer.newrelic.com/build-tools/new-relic-one-applications/guide-to-authentication--data-access--and-permissions#Appaccesstodata).
+
+To learn more about the command's capabilities, run: `nr1 nerdpack:publish --help`
+
+</Step>
+
+<Step>
+
+## Deploy
+
+One of the [CLI commands](https://developer.newrelic.com/build-tools/new-relic-one-applications/cli#Commands) is  `nerdpack:deploy`. Deploying a Nerdpack is how you choose which New Relic accounts have access to your application, and how you control which version of the application they’ll see.
+
+When you deploy a Nerdpack, you choose its "channel." A channel represents the development status of an application. There are three-channel choices: DEV, BETA, and STABLE. When you deploy your application (or a new version of your application) you assign it to one of these channels. Channels are meant to be an easier way to control application version access than having to be concerned with many specific version numbers.
+
+For more on permissions, see  [Authentication and permissions](https://developer.newrelic.com/build-tools/new-relic-one-applications/guide-to-authentication--data-access--and-permissions).
+
+</Step>
+
+<Step>
+
+## Subscribe
+
+Once an app is deployed, a user with a Nerdpack Manager role can use the [nr1 nerdpack:subscribe](https://developer.newrelic.com/build-tools/new-relic-one-applications/cli#Commands) command to subscribe the owner account, or any of its subaccounts, to that app. This is what allows the app to be accessible in New Relic One.
+
+For details on subscribe permissions, see  [Authentication and permissions](https://developer.newrelic.com/build-tools/new-relic-one-applications/guide-to-authentication--data-access--and-permissions).
+
+</Step>
+
+</Steps>
+
+### Next steps
+
+Learn more about subscribing users to apps in the [New Relic One Catalog](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/build-new-relic-one/discover-manage-applications-new-relic-one-catalog). 
+
+
+### Related info
+
+- [Discover and manage applications with New Relic One](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/build-new-relic-one/discover-manage-applications-new-relic-one-catalog)
+- [Build a custom application](/build-apps/build-a-custom-app)


### PR DESCRIPTION
Migrating the publish and deploy page.

## Description
This is publish and deploy page from the docs migration swarm.

## Reviewer Notes
If there are links or steps needed to test this work, add them here.


