### PR TITLE
styles: Mobile nav improvments

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -5,9 +5,10 @@ import ExternalLink from './ExternalLink';
 import styles from './Footer.module.scss';
 import FeatherIcon from './FeatherIcon';
 import Logo from './Logo';
+import PropTypes from 'prop-types';
 
-const Footer = () => (
-  <footer className={styles.footer}>
+const Footer = ({ className }) => (
+  <footer className={cx(styles.footer, className)}>
     <div className={cx('site-container', styles.container)}>
       <div className={styles.left}>
         <Link to="/">
@@ -35,5 +36,9 @@ const Footer = () => (
     </div>
   </footer>
 );
+
+Footer.propTypes = {
+  className: PropTypes.string,
+};
 
 export default Footer;

--- a/src/components/GlobalHeader.module.scss
+++ b/src/components/GlobalHeader.module.scss
@@ -82,13 +82,3 @@
   display: flex;
   align-items: center;
 }
-
-// ==============================================================
-// Responsive styles
-// ==============================================================
-
-@media screen and (max-width: 1240px) {
-  .globalHeaderContainer {
-    padding: 0 1.75rem;
-  }
-}

--- a/src/components/HamburgerMenu.module.scss
+++ b/src/components/HamburgerMenu.module.scss
@@ -3,8 +3,9 @@ button.hamburgerMenu {
   background: none;
   border: 0;
   cursor: pointer;
-  width: 4rem;
+  width: 2rem;
   outline: none;
+  padding: 0;
 
   div {
     width: 100%;

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -30,7 +30,11 @@ const Layout = ({ children }) => {
           {children}
         </main>
       </div>
-      <Footer />
+      <Footer
+        className={cx({
+          [styles.hideOnMobile]: isMobileNavOpen,
+        })}
+      />
     </div>
   );
 };

--- a/src/components/MobileHeader.module.scss
+++ b/src/components/MobileHeader.module.scss
@@ -1,6 +1,7 @@
 .container {
   position: relative;
   border-bottom: 1px solid var(--color-neutrals-100);
+  padding: 0 2rem;
 }
 
 .menuBar {
@@ -8,7 +9,6 @@
   align-items: center;
   justify-content: space-between;
   height: var(--height-mobile-nav-bar);
-  padding: 0 1rem;
 }
 
 .logo {


### PR DESCRIPTION
## Description
Two tweaks in this PR:
1. Corrects alignment of the mobile header and global header to fit with the rest of the content when at those widths.
2. Hides the footer when the mobile nav is opened.

## Screenshot(s)
<img width="496" alt="Screen Shot 2020-06-17 at 11 35 01 AM" src="https://user-images.githubusercontent.com/3023056/84936470-1eb1c480-b08f-11ea-875b-7c81eccaf5f4.png">

<img width="497" alt="Screen Shot 2020-06-17 at 11 32 30 AM" src="https://user-images.githubusercontent.com/3023056/84936519-37ba7580-b08f-11ea-835f-ce4b76dc5f2d.png">

