### PR TITLE
styles: Global header improvement for mobile

### DIFF
--- a/src/components/GlobalHeader.module.scss
+++ b/src/components/GlobalHeader.module.scss
@@ -1,5 +1,6 @@
 .globalHeaderContainer {
   background-color: var(--color-neutrals-100);
+  overflow: hidden;
 
   :global(.site-container) {
     padding: 0 2rem;
@@ -30,6 +31,7 @@
   padding: 0;
   display: flex;
   list-style-type: none;
+  white-space: nowrap;
 
   &:hover .active .left-side-link {
     background-color: transparent;
@@ -81,4 +83,10 @@
 .githubButtonLink {
   display: flex;
   align-items: center;
+}
+
+@media screen and (max-width: 440px) {
+  .githubButtonLink {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Description
At mobile widths the Open Source link was wrapping and the header was causing the page width to be wider than the phone width (which makes the page slide around awkwardly).

## Reviewer Notes
You can compare the PR build for this against master when using chrome tools in mobile view mode and sliding the width of the view down to around 440px. There's a handle directly to the right of the mobile view that can be hard to see at least in dark mode as I have it. Use that handle instead of resizing the whole browser window.

## Screenshot(s)
If relevant, add screenshots here.
