### PR TITLE
Fix height issue when expanding nav sections on pages without much content

### DIFF
--- a/src/components/Layout.module.scss
+++ b/src/components/Layout.module.scss
@@ -5,7 +5,6 @@
 }
 
 .main {
-  min-height: 100%;
   display: grid;
   grid-template-columns: 300px minmax(0, 1fr);
   width: 100%;


### PR DESCRIPTION
## Description
Fixes the issue where expanding the nav on pages without much content results in the screen with a giant height that does not collapse when the nav collapses.

Note that this undoes the fix that centers the content in the middle of the row when on monitors with tall screens and pages without content. The proper fix is addressed in #170 (source: https://github.com/newrelic/developer-website/pull/170/files#diff-d4568ef5e9b6d073e873c5a5dec5ec32R189). 

## Screenshot(s)
### Steps
#### Start
<img width="1680" alt="Screen Shot 2020-06-17 at 10 36 04 PM" src="https://user-images.githubusercontent.com/565661/84982281-36b73180-b0eb-11ea-8ddf-b095c4b2e1f7.png">

#### Expand nav
<img width="1680" alt="Screen Shot 2020-06-17 at 10 36 11 PM" src="https://user-images.githubusercontent.com/565661/84982287-3a4ab880-b0eb-11ea-93c6-677f59b895f9.png">


#### Collapse the nav and now there is a giant gap at the bottom of the screen
<img width="1679" alt="Screen Shot 2020-06-17 at 10 36 19 PM" src="https://user-images.githubusercontent.com/565661/84982271-328b1400-b0eb-11ea-9255-6dcf286a40fd.png">
