### PR TITLE
Hide duration on guides when there is no duration specified

### DIFF
--- a/src/templates/GuideTemplate.js
+++ b/src/templates/GuideTemplate.js
@@ -38,10 +38,12 @@ const GuideTemplate = ({ data }) => {
         <SEO title={title} description={description} />
         <div className={styles.header}>
           <PageTitle>{title}</PageTitle>
-          <div className={styles.duration}>
-            <FeatherIcon name="clock" className={styles.clock} />
-            {duration}
-          </div>
+          {duration && (
+            <div className={styles.duration}>
+              <FeatherIcon name="clock" className={styles.clock} />
+              {duration}
+            </div>
+          )}
         </div>
         <div className={styles.mdxContainer}>
           <MDXProvider components={components}>


### PR DESCRIPTION
## Description
Removes the duration element when there is no duration specified for a guide.

## Screenshot(s)
**Before**
<img width="1183" alt="Screen Shot 2020-06-17 at 11 16 17 PM" src="https://user-images.githubusercontent.com/565661/84984967-be536f00-b0f0-11ea-83c1-e3a73bb92e54.png">


**After**
<img width="1207" alt="Screen Shot 2020-06-17 at 11 16 22 PM" src="https://user-images.githubusercontent.com/565661/84984970-c0b5c900-b0f0-11ea-82eb-094221c02167.png">
