### PR TITLE
Headings design fixes

### DIFF
--- a/src/templates/GuideTemplate.module.scss
+++ b/src/templates/GuideTemplate.module.scss
@@ -14,7 +14,6 @@
   }
   h1,
   h2 {
-    margin-top: 1rem;
     font-weight: bold;
 
     &:not(:first-child) {


### PR DESCRIPTION
## Description
just added bolding to the heading tags to make it match the other pages

## Reviewer Notes
So it appears the reason that there are differences across the pages is because in `GuideTemplate.js` there is a class being added to an outside div and then applied to the child `h1`, `h2`, ect tags. In the `ComponentReferenceTemplate` and `ApiReferenceTemplate` there are heading tags outside of the markdown and then markdown being rendered from the SDK. I don't know how we want to standardize this across these two pages but for right now just adding bolding fixes it! 

## Related Issue(s) / Ticket(s)
* [DEVEX-980](https://newrelic.atlassian.net/browse/DEVEX-980)

## Screenshot(s)
### Before 
<img width="1415" alt="Screen Shot 2020-06-18 at 10 09 54 AM" src="https://user-images.githubusercontent.com/38332422/85031584-dbb62680-b14c-11ea-8638-8206697ec94b.png">

### After
<img width="1408" alt="Screen Shot 2020-06-18 at 10 09 30 AM" src="https://user-images.githubusercontent.com/38332422/85031604-e07ada80-b14c-11ea-97d3-f79a7931d811.png">

