### PR TITLE
Remove optimize cloud usage

### DIFF
--- a/src/data/sidenav.json
+++ b/src/data/sidenav.json
@@ -43,10 +43,6 @@
         "url": "/build-apps/map-pageviews-by-region"
       },
       {
-        "displayName": "Optimize cloud usage",
-        "url": "/build-apps/optimize-cloud-usage"
-      },
-      {
         "displayName": "Add a time picker",
         "url": "/build-apps/add-time-picker-guide"
       },


### PR DESCRIPTION
## Description
This PR removes the optimize cloud usage guide placeholder since it won't be in the site's first iteration
