### PR TITLE
Remove "Request a demo" button from homepage

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -78,11 +78,6 @@ const IndexPage = ({ pageContext }) => (
           <ExternalLink href="https://newrelic.com/signup?partner=Developer+Edition">
             <button type="button">Create a free account</button>
           </ExternalLink>
-          <ExternalLink href="https://newrelic.com/request-demo">
-            <button type="button" className="secondary">
-              Request a demo
-            </button>
-          </ExternalLink>
         </div>
         <Video
           className={styles.introVideo}


### PR DESCRIPTION
## Description
Does what it says on the tin.

## Reviewer Notes
There should only be one button on the home page in the intro section.

## Related Issue(s) / Ticket(s)
* [DEVEX-994](https://newrelic.atlassian.net/browse/DEVEX-994)

## Screenshot(s)
![Screen Shot 2020-06-19 at 12 40 08 PM](https://user-images.githubusercontent.com/1946433/85174342-06c27800-b22a-11ea-88b8-ff7332fbb575.png)

