### PR TITLE
Get started section spacing and heading at thin widths

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -91,20 +91,14 @@ const IndexPage = ({ pageContext }) => (
 
       <Section backgroundBanner>
         <GuideListing className={styles.guideListing}>
-          <GuideListing.Heading
-            className={cx(
-              styles.guideListingHeading,
-              styles.gettingStartedHeading
-            )}
-          >
-            <div>
-              Get started{' '}
-              <span className={styles.getStartedTextFull}>in minutes</span>
-            </div>
+          <header className={styles.guideListingHeader}>
+            <GuideListing.Heading className={cx(styles.guideListingHeading)}>
+              Get started in minutes
+            </GuideListing.Heading>
             <ExternalLink href="https://newrelic.com/signup?partner=Developer+Edition">
               <button type="button">Create a free account</button>
             </ExternalLink>
-          </GuideListing.Heading>
+          </header>
           <GuideListing.List>
             {getStartedGuides.map((guide, index) => (
               <GuideTile key={index} {...guide} />

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -34,16 +34,20 @@
   margin-top: 6rem;
 }
 
-.guideListingHeading {
+.guideListingHeader {
   display: flex;
   justify-content: space-between;
-  margin-top: 0rem;
-  margin-bottom: 1rem;
-  font-size: 2.5rem;
+  align-items: center;
+  margin-bottom: 4rem;
 }
 
-.gettingStartedHeading {
-  margin-bottom: 4rem;
+.guideListingHeading {
+  margin: 0;
+  margin-right: 1rem;
+  font-size: 2.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 @media screen and (max-width: 980px) {


### PR DESCRIPTION
## Description
Improves spacing for get started section now that the icons are at top of the guide tiles.

Also fixes layout for the get started section's heading message and the button in that heading. The solution feels very specific to this situation but is what I'm proposing until we have further design thought considering this is the only section that has anything other than the text.

