### PR TITLE
Icon component page no longer too wide

### DIFF
--- a/src/components/IconReference.module.scss
+++ b/src/components/IconReference.module.scss
@@ -34,5 +34,6 @@
   position: absolute;
   font-size: 0.85rem;
   top: calc(100% + 0.5rem);
+  right: 0;
   z-index: 1;
 }


### PR DESCRIPTION
## Description
The icon component page was too wide that was enabling a horizontal scroll to happen on the page due to the length of the tooltips. I just changed the alignment of the tooltips, but I'm not sure if this is the fix we want.

## Reviewer Notes
To reproduce the bug, go to the icon page and horizontally scroll to the right.

## Related Issue(s) / Ticket(s)
If there are any related [GitHub Issues](https://github.com/newrelic/developer-website/issues) or JIRA tickets, add links to them here.
* [DEVEX-1094](https://newrelic.atlassian.net/browse/DEVEX-1094)

## Screenshot(s)
### Before 
<img width="1435" alt="Screen Shot 2020-06-25 at 6 23 12 AM" src="https://user-images.githubusercontent.com/38332422/85702514-7d3cfb00-b6ac-11ea-8f8f-a375268a86fb.png">

### After
<img width="1438" alt="Screen Shot 2020-06-25 at 6 23 38 AM" src="https://user-images.githubusercontent.com/38332422/85702550-875ef980-b6ac-11ea-8fcb-cd5c15043e81.png">

