### PR TITLE
Moves the guide time estimation to be below the tile on smaller screens 

### DIFF
--- a/src/templates/GuideTemplate.module.scss
+++ b/src/templates/GuideTemplate.module.scss
@@ -47,6 +47,10 @@
   margin-bottom: 2rem;
   align-items: center;
   justify-content: space-between;
+  @media screen and (max-width: 1080px) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 
 .duration {


### PR DESCRIPTION
## Description
Moves the guide time estimation to be below the title on smaller screens.

## Reviewer Notes
Horizontally shrink the screen.

## Related Issue(s) / Ticket(s)
* [DEVEX-1099](https://newrelic.atlassian.net/browse/DEVEX-1099)

## Screenshot(s)

### Before 
<img width="495" alt="Screen Shot 2020-06-25 at 4 12 48 PM" src="https://user-images.githubusercontent.com/38332422/85790777-cfa70780-b6fe-11ea-91b9-67ea7d9486c9.png">


### After
<img width="502" alt="Screen Shot 2020-06-25 at 4 13 24 PM" src="https://user-images.githubusercontent.com/38332422/85790786-d2a1f800-b6fe-11ea-88cc-959164ee33c6.png">
