### PR TITLE
Stack items in GuideListing header on smaller displays

### DIFF
--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -39,6 +39,10 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 4rem;
+
+  @media (max-width: 789px) {
+    flex-direction: column;
+  }
 }
 
 .guideListingHeading {
@@ -48,6 +52,10 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  @media (max-width: 789px) {
+    margin-right: 0rem;
+  }
 }
 
 @media screen and (max-width: 980px) {


### PR DESCRIPTION
## Description
The "Get Coding" text is getting cut off on smaller displays in the GuideListing header component. This change stacks the "Create an account" button below allowing the text to fully render. The text starts getting cut off at 789px so I set the breakpoint there but happy to change it to something more standard.

## Reviewer Notes
If there are links or steps needed to test this work, add them here.

## Related Issue(s) / Ticket(s)
If there are any related [GitHub Issues](https://github.com/newrelic/developer-website/issues) or JIRA tickets, add links to them here.
* [DEVEX-1098](https://newrelic.atlassian.net/browse/DEVEX-1098)

## Screenshot(s)
![Screen Shot 2020-06-25 at 4 10 13 PM](https://user-images.githubusercontent.com/1663955/85804424-6cb57080-b6fe-11ea-96a6-3bde5262a2fc.png)
