### PR TITLE
fix: Increase max width to 1600px for larger displays

### DIFF
--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -178,7 +178,7 @@ pre {
   }
 
   .site-container {
-    max-width: 1460px;
+    max-width: 1600px;
     margin: 0 auto;
   }
 }


### PR DESCRIPTION
## Description
As I've been playing with the site, it feels a bit cramped on larger displays. This PR increases the max width from 1460px to 1600px for just a bit more breathing space when available.

## Screenshot(s)

### Before

<img width="1904" alt="Screen Shot 2020-06-25 at 5 20 21 PM" src="https://user-images.githubusercontent.com/186715/85807920-37158500-b708-11ea-867e-99b294394a69.png">

### After

<img width="1904" alt="Screen Shot 2020-06-25 at 5 20 38 PM" src="https://user-images.githubusercontent.com/186715/85807923-3aa90c00-b708-11ea-9857-146a551d19fd.png">

