### PR TITLE
fix: Add border radius to striped sections on the landing page

### DIFF
--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -77,4 +77,5 @@
 .stripedSection {
   padding: 2rem;
   background: var(--color-neutrals-100);
+  border-radius: 4px;
 }


### PR DESCRIPTION
## Description

To soften the striped sections on the landing page a bit, this PR adds a 4px border radius.

## Screenshot(s)

### Before

<img width="278" alt="Screen Shot 2020-06-25 at 5 25 00 PM" src="https://user-images.githubusercontent.com/186715/85808269-33363280-b709-11ea-8112-26cb10abddc8.png">

### After

<img width="277" alt="Screen Shot 2020-06-25 at 5 25 26 PM" src="https://user-images.githubusercontent.com/186715/85808275-36c9b980-b709-11ea-91ec-3c34e138373d.png">

