### PR TITLE
Mobile clear search bug 

### DIFF
--- a/src/components/MobileHeader.js
+++ b/src/components/MobileHeader.js
@@ -30,6 +30,7 @@ const MobileHeader = ({ className, isOpen, toggle }) => {
           <SearchInput
             className={styles.searchInput}
             placeholder="Search developer docs"
+            onClear={() => setSearchTerm('')}
             onChange={(e) => setSearchTerm(e.target.value)}
             value={searchTerm}
           />


### PR DESCRIPTION
## Description
I found a tiny bug in the mobile clear search that (because an onClear prop wasn't passed into the MobileHeader SearchInput) that it wouldn't clear.

## Reviewer Notes
Make the window smaller horizontally and then try clearing text in the searchinput

## Related Issue(s) / Ticket(s)
No ticket! Just found bc I was tested it out. 

## Screenshot(s)
If relevant, add screenshots here.
