### PR TITLE
Remove github and edit button from global nav

### DIFF
--- a/src/components/GlobalHeader.module.scss
+++ b/src/components/GlobalHeader.module.scss
@@ -75,6 +75,9 @@
   display: flex;
   list-style-type: none;
   align-items: center;
+  @media (max-width: 600px) {
+    display: none;
+  }
 }
 
 .rightSideButton {


### PR DESCRIPTION
## Description
Removes the github and edit button from the global nav so that the global nav can fit the links.

## Reviewer Notes
Look at the global nav! 

## Related Issue(s) / Ticket(s)
If there are any related [GitHub Issues](https://github.com/newrelic/developer-website/issues) or JIRA tickets, add links to them here.
* [DEVEX-1096](https://newrelic.atlassian.net/browse/DEVEX-1096)

## Screenshot(s)
<img width="459" alt="Screen Shot 2020-06-26 at 5 39 37 PM" src="https://user-images.githubusercontent.com/38332422/85903331-0c90fe00-b7d4-11ea-8539-341e25b91936.png">

