### PR TITLE
Resolve iOS sticky global header issues

### DIFF
--- a/src/components/Layout.module.scss
+++ b/src/components/Layout.module.scss
@@ -5,6 +5,7 @@
   min-height: 100vh;
   display: grid;
   grid-template-rows: auto 1fr;
+  position: relative;
 }
 
 .main {


### PR DESCRIPTION
## Description
On iOS devices, the user can "pull down" the site to refresh the page. When they do this, the global navigation (top-bar) gets pulled down, but the rest of the site does not. See attached image for an example of what this looks like.

## Reviewer Notes
I was unable to browse to my mac's development environment on my iPad (despite being on the same network and having the IP handy). I was also unable to run the development environment locally on my iPad (but I got _so_ close). All that to be said, I'm going to use the PR build on this PR to test / verify this fix works.

I'll remove the `work in progress` label when I've sorted it out.

## Related Issue(s) / Ticket(s)
* [DEVEX-1084](https://newrelic.atlassian.net/browse/DEVEX-1084)

## Screenshot(s)
**BEFORE**
![2020-06-24](https://user-images.githubusercontent.com/1946433/85906311-c41d1480-b7c2-11ea-8994-bd705585069b.jpeg)