### PR TITLE
Fix background on code snippets in guides

### DIFF
--- a/src/components/CodeSnippet.module.scss
+++ b/src/components/CodeSnippet.module.scss
@@ -15,7 +15,7 @@
   code {
     display: block;
     padding: 0;
-    background: none;
+    background: none !important;
   }
 }
 


### PR DESCRIPTION
## Description
Fixes the background color on code snippets on guide pages.

## Screenshot(s)
**BEFORE**
<img width="649" alt="Screen Shot 2020-06-26 at 4 02 09 PM" src="https://user-images.githubusercontent.com/565661/85907527-afdb1680-b7c6-11ea-9fce-4c9374e5c514.png">


**AFTER**
<img width="636" alt="Screen Shot 2020-06-26 at 4 02 26 PM" src="https://user-images.githubusercontent.com/565661/85907531-b2d60700-b7c6-11ea-8762-b9b87c950835.png">
