### PR TITLE
Hide duration if its not specified

### DIFF
--- a/src/components/GuideTile/GuideTile.js
+++ b/src/components/GuideTile/GuideTile.js
@@ -27,7 +27,11 @@ const GuideTile = ({
       </div>
     )}
     <div className={styles.timeEstimate}>
-      <FeatherIcon className={styles.timeIcon} name="clock" />
+      {duration ? (
+        <FeatherIcon className={styles.timeIcon} name="clock" />
+      ) : (
+        <span>&nbsp;</span>
+      )}
       {duration}
     </div>
     <h3 className={styles.title}>{title}</h3>


### PR DESCRIPTION
## Description
Hides the duration on the guide tile if not specified

## Screenshot(s)
**BEFORE**
<img width="1347" alt="Screen Shot 2020-06-26 at 5 31 53 PM" src="https://user-images.githubusercontent.com/565661/85910323-f7679f80-b7d2-11ea-8bb7-f206a493ae23.png">

**AFTER**
<img width="1314" alt="Screen Shot 2020-06-26 at 5 30 30 PM" src="https://user-images.githubusercontent.com/565661/85910320-f46caf00-b7d2-11ea-8c9e-0d806c17376b.png">

