### PR TITLE
Fix overview page guide linkage

### DIFF
--- a/src/templates/OverviewTemplate.js
+++ b/src/templates/OverviewTemplate.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { graphql } from 'gatsby';
+import { graphql, Link } from 'gatsby';
 import PropTypes from 'prop-types';
 
 import Layout from '../components/Layout';
@@ -25,6 +25,8 @@ const OverviewTemplate = ({ data }) => {
           <GuideListing.List>
             {guides?.nodes.map(({ frontmatter }, index) => (
               <GuideTile
+                as={Link}
+                to={frontmatter.path}
                 key={index}
                 duration={frontmatter.duration}
                 title={frontmatter.tileShorthand?.title || frontmatter.title}


### PR DESCRIPTION
## Description
Currently, on overview pages, the guide tiles are static boxes on the screen and
do not properly link to their respective guides. This PR fixes the guide tiles
to ensure they link to their respective guides.
