### PR TITLE
Add the NerdGraph getting started video

### DIFF
--- a/src/markdown-pages/collect-data/get-started-nerdgraph-api-explorer.mdx
+++ b/src/markdown-pages/collect-data/get-started-nerdgraph-api-explorer.mdx
@@ -15,11 +15,13 @@ NerdGraph is New Relic's [GraphQL](https://graphql.org/) API. It allows you to g
 
 With NerdGraph API Explorer you don't need to know the query format: using the Query Builder you can browse our entire graph and compose queries just by selecting the items you want and filling out their required values.
 
+<Video id='oo1lbw991a' type='wistia' />
+
 </Intro>
 
 ## Before you begin
 
-Go to [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql) and log in using your New Relic user ID and password: the NerdGraph API Explorer loads up. 
+Go to [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql) and log in using your New Relic user ID and password: the NerdGraph API Explorer loads up.
 
 Make sure you have a valid New Relic API key. You can create one directly from the NerdGraph API Explorer.
 
@@ -95,7 +97,7 @@ Ready for your first mutation?
 In this case, you're trying to add a custom tag to an entity. Notice that the editor complains if you don't select `errors`: mutations must have a way of telling you how the operation performed in the backend (failed requests result in null responses).
 
 <Tip>
-  
+
 Unlike REST, GraphQL APIs like NerdGraph can return partial responses. For example, if you try adding tags to multiple entities, some mutations can fail and others succeed; all is logged in the GraphQL response you get.
 
 </Tip>


### PR DESCRIPTION
Closes #280

## Description
Adds the getting started video for the NerdGraph API doc.

## Screenshot(s)
<img width="1388" alt="Screen Shot 2020-06-29 at 4 46 23 PM" src="https://user-images.githubusercontent.com/565661/86066828-1874fe00-ba28-11ea-8f05-71ffc0e6dd50.png">