### PR TITLE
Replace build apps icon with product icon

### DIFF
--- a/src/components/NewRelicIcon.js
+++ b/src/components/NewRelicIcon.js
@@ -41,9 +41,10 @@ const NEWRELIC_ICONS = {
   ),
   buildApps: (
     <>
-      <polygon points="11.5,7.5 .5,4.5 12,1.5 23.5,4.5" />
-      <polyline points="23.5,4.463 23.5,18.5 11.5,22.5 .5,18.5 .5,4.463" />
-      <line x1="11.5" x2="11.5" y1="7.5" y2="22.5" />
+      <rect x="14" y="1" width="9" height="9"/>
+      <rect x="14" y="14" width="9" height="9"/>
+      <rect x="1" y="14" width="9" height="9"/>
+      <rect x="1" y="1" width="9" height="9"/>
     </>
   ),
   collectData: (

--- a/src/components/NewRelicIcon.js
+++ b/src/components/NewRelicIcon.js
@@ -41,10 +41,10 @@ const NEWRELIC_ICONS = {
   ),
   buildApps: (
     <>
-      <rect x="14" y="1" width="9" height="9"/>
-      <rect x="14" y="14" width="9" height="9"/>
-      <rect x="1" y="14" width="9" height="9"/>
-      <rect x="1" y="1" width="9" height="9"/>
+      <rect x="14" y="1" width="9" height="9" />
+      <rect x="14" y="14" width="9" height="9" />
+      <rect x="1" y="14" width="9" height="9" />
+      <rect x="1" y="1" width="9" height="9" />
     </>
   ),
   collectData: (


### PR DESCRIPTION
## Description
Replaces the 'Build apps' icon with the Apps icon from the product for consistency.

## Related Issue(s) / Ticket(s)
* [DEVEX-1119](https://newrelic.atlassian.net/browse/DEVEX-1119)

## Screenshot(s)

### Before

<img width="1352" alt="Screen Shot 2020-06-30 at 9 39 38 AM" src="https://user-images.githubusercontent.com/186715/86152951-c8447d00-bab5-11ea-9283-17ffd0d6350e.png">

### After

<img width="1352" alt="Screen Shot 2020-06-30 at 9 38 54 AM" src="https://user-images.githubusercontent.com/186715/86152928-c24e9c00-bab5-11ea-9a28-c23cefaf3d97.png">
