### PR TITLE
Add OSS banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Community Project header](https://github.com/newrelic/open-source-office/raw/master/examples/categories/images/Community_Project.png)](https://github.com/newrelic/open-source-office/blob/master/examples/categories/index.md#category-community-project)
+
 # developer.newrelic.com
 
 ## 🚀 Local development


### PR DESCRIPTION
## Description
Adds the OSS banner to the README

[Rendered](https://github.com/newrelic/developer-website/blob/jerel/oss-banner/README.md)
