### PR TITLE
Add Google verification header for search console

### DIFF
--- a/src/components/Seo.js
+++ b/src/components/Seo.js
@@ -24,7 +24,16 @@ function SEO({ description, lang, meta, title }) {
   const globalMetadata = [
     { name: 'description', content: metaDescription },
     { 'http-equiv': 'Content-Type', content: 'text/html', charset: 'utf-8' },
-    { name: 'type', class: 'swiftype', 'data-type': 'enum', content: 'developer' },
+    {
+      name: 'type',
+      class: 'swiftype',
+      'data-type': 'enum',
+      content: 'developer',
+    },
+    {
+      name: 'google-site-verification',
+      content: 'eT8TSNhvMuDmAtqbtq5jygZKVkhDmz565fYQ3DVop4g',
+    },
   ];
 
   const social = [


### PR DESCRIPTION
## Description
Google Search Console requires us to verify ownership of the domain. This meta tag will handle that for us. This also includes some lint cleanup.

## Reviewer Notes
We can probably remove this once we have gone through the verification process.

## Related Issue(s) / Ticket(s)
Closes #345 
