### PR TITLE
Fix prop overlap issue on mobile

### DIFF
--- a/src/components/PropList.module.scss
+++ b/src/components/PropList.module.scss
@@ -10,7 +10,7 @@
   }
 
   @media (max-width: 1080px) {
-    grid-template-columns: 1fr;
+    grid-template-columns: 100%;
   }
 }
 

--- a/src/components/PropList.module.scss
+++ b/src/components/PropList.module.scss
@@ -8,6 +8,10 @@
     padding-bottom: 2rem;
     border-bottom: solid var(--color-neutrals-200) 1px;
   }
+
+  @media (max-width: 1080px) {
+    grid-template-columns: 1fr;
+  }
 }
 
 .propName {


### PR DESCRIPTION
## Description
Fixes an issue where prop definitions were overlapping on mobile. The prop name / required flag were overlapping with the description due to being in a two-column layout.

## Reviewer Notes
On very narrow displays, the page has a sideways scrollbar. I was unable to determine which element was pushing out the width, but I wanted to get the fix in place for the prop overlap since it's a high-priority issue.

## Related Issue(s) / Ticket(s)
Closes #343

## Screenshot(s)
**BEFORE**
![Screen Shot 2020-06-30 at 2 47 01 PM](https://user-images.githubusercontent.com/1946433/86183866-cb586100-bae7-11ea-8d6a-e39df909c3c9.png)

**AFTER**
![Screen Shot 2020-06-30 at 2 50 13 PM](https://user-images.githubusercontent.com/1946433/86183873-cf847e80-bae7-11ea-91c4-f4e43493b247.png)
