### PR TITLE
Fix search input overlap in hamburger menu view.

### DIFF
--- a/src/components/SearchInput.module.scss
+++ b/src/components/SearchInput.module.scss
@@ -3,6 +3,9 @@
   align-items: center;
   width: 100%;
   position: relative;
+  @media (max-width: 760px) {
+    margin: 0.25rem 0;
+  }
 }
 
 .icon {


### PR DESCRIPTION
## Description
Adds a small bit of margin in hamburger view to prevent the overlap from happening


## Related Issue(s) / Ticket(s)
#335 


## Screenshot(s)
### Before 
<img width="449" alt="Screen Shot 2020-07-01 at 11 19 48 AM" src="https://user-images.githubusercontent.com/38332422/86262027-59d2ee00-bb8d-11ea-9a10-9d5553ed1e1d.png">


### After 

<img width="448" alt="Screen Shot 2020-07-01 at 11 19 39 AM" src="https://user-images.githubusercontent.com/38332422/86262037-5ccdde80-bb8d-11ea-8eca-c08b034e9af4.png">

