### PR TITLE
Updated how the sidebar is positioned

### DIFF
--- a/src/components/Layout.module.scss
+++ b/src/components/Layout.module.scss
@@ -11,6 +11,7 @@
   display: grid;
   grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
   width: 100%;
+  position: relative;
 
   @media screen and (max-width: 760px) {
     grid-template-columns: minmax(0, 1fr);
@@ -24,11 +25,10 @@
 }
 
 .sidebar {
-  position: fixed;
-  top: var(--global-header-height);
-  bottom: 0;
+  position: absolute;
+  top: 0;
   width: var(--sidebar-width);
-  height: calc(100vh - var(--global-header-height));
+  max-height: 100%;
   overflow: auto;
 }
 


### PR DESCRIPTION
## Description
On iOS, you can "pull down" on the page to refresh the site. When you do this, the site and top-bar navigation get pulled down, but the sidebar does _not_. This is because the sidebar had `position: fixed;`. I've updated it to use an abolute positioning-based approach. There are some caveats with this approach (see next section).

## Reviewer Notes
By removing `position: fixed;` we are slightly changing how the sidebar scrolls. This is a draft PR because I would like some :eyes: on this to ensure we are alright with the new scrolling behavior.

## Related Issue(s) / Ticket(s)
Fixes #327
