### PR TITLE
fix: Reduce spacing between guide step and title

### DIFF
--- a/src/components/Step.module.scss
+++ b/src/components/Step.module.scss
@@ -7,6 +7,7 @@
   .stepNumber {
     font-size: 0.75rem;
     color: var(--accent-text-color);
+    margin-bottom: 0;
   }
 }
 


### PR DESCRIPTION
## Description

The guide step number and title should be connected visually, which we accomplish by reducing the spacing between these elements.

## Screenshot(s)

### Before

<img width="624" alt="Screen Shot 2020-07-01 at 2 55 02 PM" src="https://user-images.githubusercontent.com/186715/86295376-4fbfe800-bbab-11ea-80b5-b5babd872030.png">


### After

<img width="621" alt="Screen Shot 2020-07-01 at 2 55 10 PM" src="https://user-images.githubusercontent.com/186715/86295380-52224200-bbab-11ea-9849-4508b25df932.png">
