### PR TITLE
Relocate developer champion badge on landing page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -180,7 +180,7 @@ const IndexPage = ({ data, pageContext }) => {
         </p>
 
         <section
-        className={cx(
+          className={cx(
             styles.section,
             styles.stripedSection,
             styles.developerChampions
@@ -190,8 +190,8 @@ const IndexPage = ({ data, pageContext }) => {
             <h1>New Relic developer champions</h1>
             <p>
               New Relic Champions are solving big problems using New Relic as
-              their linchpin and are recognized as experts and leaders in the New
-              Relic technical community.
+              their linchpin and are recognized as experts and leaders in the
+              New Relic technical community.
             </p>
             <Button
               as={ExternalLink}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -179,7 +179,12 @@ const IndexPage = ({ data, pageContext }) => {
           built by the New Relic community.
         </p>
 
-        <section className={cx(styles.section, styles.stripedSection, styles.developerChampions)}>
+        <section className={cx(
+          styles.section,
+          styles.stripedSection,
+          styles.developerChampions
+          )}
+          >
           <div>
             <h1>New Relic developer champions</h1>
             <p>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -179,12 +179,13 @@ const IndexPage = ({ data, pageContext }) => {
           built by the New Relic community.
         </p>
 
-        <section className={cx(
-          styles.section,
-          styles.stripedSection,
-          styles.developerChampions
+        <section
+        className={cx(
+            styles.section,
+            styles.stripedSection,
+            styles.developerChampions
           )}
-          >
+        >
           <div>
             <h1>New Relic developer champions</h1>
             <p>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -179,33 +179,31 @@ const IndexPage = ({ data, pageContext }) => {
           built by the New Relic community.
         </p>
 
-        <section className={cx(styles.section, styles.stripedSection)}>
-          <h1>
-            <img
-              className={styles.img}
-              src={devChampionBadge}
-              alt="developer champion badge"
-              width="5%"
-            />{' '}
-            New Relic developer champions
-          </h1>
-
-          <p>
-            New Relic Champions are solving big problems using New Relic as
-            their linchpin and are recognized as experts and leaders in the New
-            Relic technical community.
-          </p>
-          <Button
-            as={ExternalLink}
-            variant={Button.VARIANT.PRIMARY}
-            href="https://forms.gle/Zkdub5e1x4MNqSKW9"
-          >
-            Nominate a Developer Champion
-            <FeatherIcon
-              className={styles.externalLinkIcon}
-              name="external-link"
-            />
-          </Button>
+        <section className={cx(styles.section, styles.stripedSection, styles.developerChampions)}>
+          <div>
+            <h1>New Relic developer champions</h1>
+            <p>
+              New Relic Champions are solving big problems using New Relic as
+              their linchpin and are recognized as experts and leaders in the New
+              Relic technical community.
+            </p>
+            <Button
+              as={ExternalLink}
+              variant={Button.VARIANT.PRIMARY}
+              href="https://forms.gle/Zkdub5e1x4MNqSKW9"
+            >
+              Nominate a Developer Champion
+              <FeatherIcon
+                className={styles.externalLinkIcon}
+                name="external-link"
+              />
+            </Button>
+          </div>
+          <img
+            className={styles.img}
+            src={devChampionBadge}
+            alt="developer champion badge"
+          />
         </section>
       </Layout>
     </PageContext.Provider>

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -106,3 +106,11 @@
     border-color: inherit;
   }
 }
+
+.developerChampions {
+  display: flex;
+
+  img {
+    height: 9rem;
+  }
+}


### PR DESCRIPTION
## Description

We can do a better job of incorporating the developer champion badge into its box on the landing page. This PR moves the badge to the right of the box and increases the size so it's more prominent.

## Screenshot(s)

### Before

<img width="878" alt="Screen Shot 2020-07-01 at 3 20 10 PM" src="https://user-images.githubusercontent.com/186715/86297011-14bfb380-bbaf-11ea-8223-5a761a942024.png">

### After

<img width="876" alt="Screen Shot 2020-07-01 at 3 19 56 PM" src="https://user-images.githubusercontent.com/186715/86297017-1d17ee80-bbaf-11ea-85b8-fbeb20c28eb3.png">

