### PR TITLE
Add link to dev champions page from landing page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -200,11 +200,18 @@ const IndexPage = ({ data, pageContext }) => {
             variant={Button.VARIANT.PRIMARY}
             href="https://forms.gle/Zkdub5e1x4MNqSKW9"
           >
-            Nominate a Developer Champion
+            Nominate a developer champion
             <FeatherIcon
               className={styles.externalLinkIcon}
               name="external-link"
             />
+          </Button>
+          <Button
+            as={Link}
+            variant={Button.VARIANT.PLAIN}
+            to="/developer-champion"
+          >
+            Learn more about developer champions
           </Button>
         </section>
       </Layout>


### PR DESCRIPTION
## Description
The developer champions banner on the landing page should really link to the developer champions page! This PR adds a link to do just that.

I also update the casing of both buttons to be sentence case to match the title of the banner.

## Screenshot(s)

<img width="838" alt="Screen Shot 2020-07-01 at 3 43 25 PM" src="https://user-images.githubusercontent.com/186715/86298084-bc3de580-bbb1-11ea-8712-8c971a013fd9.png">
