### PR TITLE
Move component overview page into component library side nav item

### DIFF
--- a/src/components/NavigationItems.js
+++ b/src/components/NavigationItems.js
@@ -116,6 +116,15 @@ const NavItem = ({ page, depthLevel, searchTerm, filteredPageNames }) => {
         >
           <span className={styles.navLinkText}>
             {headerIcon}
+            {page.displayName === 'Component library' && (
+              <FeatherIcon
+                className={cx(
+                  { [styles.isExpanded]: isExpanded },
+                  styles.nestedChevron
+                )}
+                name="chevron-right"
+              />
+            )}
             {display}
           </span>
           {isCurrentPage && (

--- a/src/data/sidenav.json
+++ b/src/data/sidenav.json
@@ -110,10 +110,6 @@
         "url": "/explore-docs/nerdpack-file-structure"
       },
       {
-        "displayName": "Intro to New Relic One API components",
-        "url": "/explore-docs/intro-to-sdk"
-      },
-      {
         "displayName": "Intro to Nerdstorage",
         "url": "/explore-docs/nerdstorage"
       },
@@ -123,6 +119,7 @@
       },
       {
         "displayName": "Component library",
+        "url": "/explore-docs/intro-to-sdk",
         "children": [
           {
             "displayName": "AccountPicker",


### PR DESCRIPTION
## Description
This PR moves our existing intro to the SDK page into the component library side nav item. Instead of remaining a toggle, the component library will now land on the intro page as well as expand the sub nav of components.

## Related Issue(s) / Ticket(s)
Closes #306 

## Screenshot(s)
<img width="1107" alt="Screen Shot 2020-07-07 at 2 35 53 PM" src="https://user-images.githubusercontent.com/39655074/86846234-75436a80-c05f-11ea-92d1-5d45df79853b.png">
<img width="1113" alt="Screen Shot 2020-07-07 at 2 36 08 PM" src="https://user-images.githubusercontent.com/39655074/86846239-770d2e00-c05f-11ea-8b86-3b7d8d504973.png">

