### PR TITLE
Remove quotes in the local build URL

### DIFF
--- a/src/markdown-pages/build-apps/build-hello-world-app.mdx
+++ b/src/markdown-pages/build-apps/build-hello-world-app.mdx
@@ -113,7 +113,7 @@ If you followed all the steps in the CLI wizard, you now have files under a new 
 
   <Step>
 
-  Open a browser and go to [https://one.newrelic.com/?nerdpacks='local'](https://one.newrelic.com/?nerdpacks='local') (this url is also shown in the terminal).
+  Open a browser and go to [https://one.newrelic.com/?nerdpacks=local](https://one.newrelic.com/?nerdpacks=local) (this url is also shown in the terminal).
 
   </Step>
 


### PR DESCRIPTION
Partially addresses #401 

## Description
Removes the quotes from the URL that describes where to visit when running local nerdpacks. This was a typo.
