### PR TITLE
Fix indentation for a code sample in the add time picker guide

### DIFF
--- a/src/markdown-pages/build-apps/add-time-picker-guide.mdx
+++ b/src/markdown-pages/build-apps/add-time-picker-guide.mdx
@@ -161,15 +161,15 @@ Add the `PlatformStateContext` component to the end of the import statement so i
 
 Just below the current `return` insert this code for the `PlatformStateContext` component:
 
-  ```js
-  <PlatformStateContext.Consumer>
-      {(platformState) => {
-  return (
-  // ADD THE CURRENT RETURN CODE HERE
-  )
+```js
+<PlatformStateContext.Consumer>
+  {(platformState) => {
+    return (
+      // ADD THE CURRENT RETURN CODE HERE
+    )
   }}
-  </PlatformStateContext.Consumer>
-  ```
+</PlatformStateContext.Consumer>
+```
 
   </Step>
 


### PR DESCRIPTION
Partially addresses #401 

## Description
Fixes indentation on one of the code samples for the time picker guide. The code sample is not syntactically valid, so the automatic code formatting does not kick in properly. This PR manually adds the proper indentation so that the code sample shows up in a cleaner format. 

## Reviewer Notes
This updates step 3/5 under the `Import the PlatformStateContext component` section on the [add time picker guide](https://developer.newrelic.com/build-apps/add-time-picker-guide)
