### PR TITLE
copies to clipboard with `icon.TYPE.` prefix

### DIFF
--- a/src/components/IconReference.js
+++ b/src/components/IconReference.js
@@ -11,7 +11,7 @@ const IconReference = ({ type }) => {
       className={styles.button}
       type="button"
       key={type}
-      onClick={() => copyIcon(type)}
+      onClick={() => copyIcon(`Icon.TYPE.${type}`)}
     >
       <Icon className={styles.icon} type={Icon.TYPE[type]} />
       <span className={styles.iconName}>{copied ? 'Copied!' : type}</span>


### PR DESCRIPTION
## Description
Copies to clipboard with the `Icon.TYPE.` prefix

## Reviewer Notes
Go to the icon gallery and clip the copy to clipboard for one of the icons. 

## Related Issue(s) / Ticket(s)
Closes #395 

