### PR TITLE
GitHub Action to Generate Changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,52 @@
+name: Changelog
+
+on:
+  push:
+    branches:
+      # todo: change this branch name
+      - master
+    repository_dispatch:
+      types: [semantic-release]
+
+env:
+  THIRD_PARTY_GIT_AUTHOR_EMAIL: opensource+bot@newrelic.com
+  THIRD_PARTY_GIT_AUTHOR_NAME: nr-opensource-bot
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          # semantic-release requiers >= 10.18
+          node-version: 12
+
+      # todo: do we need this?
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        env:
+          cache-name: node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-
+
+      # todo: update / add this
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Semantic Release
+        env:
+          # Use nr-opensource-bot for authoring commits done by
+          # semantic-release (rather than using @semantic-release-bot)
+          GIT_AUTHOR_NAME: "nr-opensource-bot"
+          GIT_AUTHOR_EMAIL: "opensource+bot@newrelic.com"
+          GIT_COMMITTER_NAME: "nr-opensource-bot"
+          GIT_COMMITTER_EMAIL: "opensource+bot@newrelic.com"
+        run: npx semantic-release

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,8 +5,6 @@ on:
     branches:
       # todo: change this branch name
       - master
-    repository_dispatch:
-      types: [semantic-release]
 
 jobs:
   generate:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,7 +25,6 @@ jobs:
           # semantic-release requiers >= 10.18
           node-version: 12
 
-      # todo: do we need this?
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@v2
@@ -37,7 +36,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
 
-      # todo: update / add this
+      # deletes node_modules, install dependencies, does NOT update lockfile
       - name: Install Dependencies
         run: npm ci
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,10 +8,6 @@ on:
     repository_dispatch:
       types: [semantic-release]
 
-env:
-  THIRD_PARTY_GIT_AUTHOR_EMAIL: opensource+bot@newrelic.com
-  THIRD_PARTY_GIT_AUTHOR_NAME: nr-opensource-bot
-
 jobs:
   generate:
     runs-on: ubuntu-latest
@@ -22,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          # semantic-release requiers >= 10.18
+          # semantic-release requires >= 10.18
           node-version: 12
 
       - name: Cache node_modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Changelog
+name: Release
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
       - master
 
 jobs:
-  generate:
+  generate-changelog:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,4 +42,5 @@ jobs:
           GIT_AUTHOR_EMAIL: "opensource+bot@newrelic.com"
           GIT_COMMITTER_NAME: "nr-opensource-bot"
           GIT_COMMITTER_EMAIL: "opensource+bot@newrelic.com"
+          GITHUB_TOKEN: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
         run: npx semantic-release

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,5 @@
 {
-  "branches": ["develop"],
+  "branches": ["master"],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,21 @@
+{
+	"branches": ["develop"],
+	"plugins": [
+		"@semantic-release/commit-analyzer",
+		"@semantic-release/release-notes-generator",
+		["@semantic-release/changelog", {
+			"changelogFile": "CHANGELOG.md"
+		}],
+		"@semantic-release/github",
+		["@semantic-release/npm", {
+			"npmPublish": false
+		}],
+		["@semantic-release/git", {
+			"assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
+			"message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+		}]
+	],
+	"dryRun": false,
+	"debug": true
+}
+

--- a/.releaserc
+++ b/.releaserc
@@ -1,21 +1,21 @@
 {
-	"branches": ["develop"],
-	"plugins": [
-		"@semantic-release/commit-analyzer",
-		"@semantic-release/release-notes-generator",
-		["@semantic-release/changelog", {
-			"changelogFile": "CHANGELOG.md"
-		}],
-		"@semantic-release/github",
-		["@semantic-release/npm", {
-			"npmPublish": false
-		}],
-		["@semantic-release/git", {
-			"assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
-			"message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
-		}]
-	],
-	"dryRun": false,
-	"debug": true
+  "branches": ["develop"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md"
+    }],
+    "@semantic-release/github",
+    ["@semantic-release/npm", {
+      "npmPublish": false
+    }],
+    ["@semantic-release/git", {
+      "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
+      "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+    }]
+  ],
+  "dryRun": false,
+  "debug": true
 }
 


### PR DESCRIPTION
## Description
Adds a GitHub Action to generate a [semantic release](https://github.com/semantic-release/semantic-release) (and generate a changelog) whenever we merge into `master`. Much of this was taken from [what the OSS had set up](https://github.com/newrelic/opensource-website/blob/develop/.github/workflows/release.yml#L114-L153).

## Reviewer Notes
This will get kicked off when it gets merged into master. The only thing I was unsure about was the `Cache node_modules` step.

## Related Issue(s) / Ticket(s)
Closes #301
