### PR TITLE
chore: Check string value instead of boolean

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -22,7 +22,7 @@ const Layout = ({ children }) => {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
 
   useEffect(() => {
-    const consentValue = Cookies.get(gdprConsentCookieName);
+    const consentValue = Cookies.get(gdprConsentCookieName) === 'true';
     consentValue && setCookieConsent(true);
   }, []);
 


### PR DESCRIPTION
## Description
Fixes a bug in which the value of a cookie was expected to be a boolean but was a string

