### PR TITLE
Persist bold style in Link nav items

### DIFF
--- a/src/components/NavigationItems.js
+++ b/src/components/NavigationItems.js
@@ -125,6 +125,8 @@ const NavItem = ({ page, depthLevel, searchTerm, filteredPageNames }) => {
     >
       {page.url ? (
         <Link
+          activeStyle={{ fontWeight: 'bold' }}
+          partiallyActive
           onClick={
             isToggleable && (() => setToggleIsExpanded(!toggleIsExpanded))
           }

--- a/src/components/NavigationItems.module.scss
+++ b/src/components/NavigationItems.module.scss
@@ -80,7 +80,6 @@ button.navLink {
   }
 }
 
-.isCurrentPage,
 .isBreadCrumb {
   font-weight: bold !important;
 }


### PR DESCRIPTION
## Description
While we still don't have a full fix for #456, this PR at least maintains the bold styling on non toggle-able nav items (collect data, automate workflows, build apps) after refresh

## Reviewer Notes
Try navigating to a page within collect data, automate workflows, or build apps. Refresh the page to see the bold styling preserved

## Related Issue(s) / Ticket(s)
Partial fix for #456
