### PR TITLE
Fix build by resolving issue with Frontmatter

### DIFF
--- a/src/markdown-pages/explore-docs/nr1-catalog.mdx
+++ b/src/markdown-pages/explore-docs/nr1-catalog.mdx
@@ -6,7 +6,6 @@ description: 'An overview of the CLI commands you can use to manage your New Rel
 tileShorthand:
   title: 'Catalog CLI commands'
   description: 'Manage your New Relic One Catalog with our CLI.'
-redirects:
 ---
 
 <Intro>

--- a/src/markdown-pages/explore-docs/nr1-common.mdx
+++ b/src/markdown-pages/explore-docs/nr1-common.mdx
@@ -6,7 +6,7 @@ description: 'An overview of common commands you can use with the New Relic One 
 tileShorthand:
   title: 'New Relic One general commands'
   description: 'Common commands to get you started with the New Relic One CLI.'
-redirects:
+redirects: ''
 ---
 
 <Intro>

--- a/src/markdown-pages/explore-docs/nr1-common.mdx
+++ b/src/markdown-pages/explore-docs/nr1-common.mdx
@@ -6,7 +6,6 @@ description: 'An overview of common commands you can use with the New Relic One 
 tileShorthand:
   title: 'New Relic One general commands'
   description: 'Common commands to get you started with the New Relic One CLI.'
-redirects: ''
 ---
 
 <Intro>

--- a/src/markdown-pages/explore-docs/nr1-common.mdx
+++ b/src/markdown-pages/explore-docs/nr1-common.mdx
@@ -10,156 +10,183 @@ tileShorthand:
 
 <Intro>
 
-Here is a list of common commands to get you started with the New Relic One CLI. You can click any command to see its usage options and additional details about the command. 
+Here is a list of common commands to get you started with the New Relic One CLI. You can click any command to see its usage options and additional details about the command.
 
 </Intro>
 
-<br/> 
+<br />
 
-| Command | Description |
-|---|---|
-| [`nr1 help`](#nr1-help)                 | Shows all `nr1` commands or details about each command. |
-| [`nr1 update`](#nr1-update)             | Updates to the latest version of the CLI. |
-| [`nr1 create`](#nr1-create)             | Creates a new component from a template (Nerdpack, Nerdlet, launcher, or catalog). |
-| [`nr1 profiles`](#nr1-profiles)         | Manages the profiles you use to run CLI commands. |
-| [`nr1 autocomplete`](#nr1-autocomplete) | Displays autocomplete installation instructions. |
-| [`nr1 nrql`](#nr1-nrql)                 | Fetches data from New Relic using [NRQL](https://newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql) (New Relic query language). |                                                                                                                                                                                                                                                                                                 |
+| Command                                 | Description                                                                                                                                                                |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`nr1 help`](#nr1-help)                 | Shows all `nr1` commands or details about each command.                                                                                                                    |
+| [`nr1 update`](#nr1-update)             | Updates to the latest version of the CLI.                                                                                                                                  |
+| [`nr1 create`](#nr1-create)             | Creates a new component from a template (Nerdpack, Nerdlet, launcher, or catalog).                                                                                         |
+| [`nr1 profiles`](#nr1-profiles)         | Manages the profiles you use to run CLI commands.                                                                                                                          |
+| [`nr1 autocomplete`](#nr1-autocomplete) | Displays autocomplete installation instructions.                                                                                                                           |
+| [`nr1 nrql`](#nr1-nrql)                 | Fetches data from New Relic using [NRQL](https://newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql) (New Relic query language). |  |
 
 See our other New Relic One CLI docs for commands specific to [Nerdpack set-up](/explore-docs/nr1-nerdpack), [Nerdpack subscriptions](explore-docs/nr1-subscription), [CLI configuration](/explore-docs/nr1-config), [plugins](/explore-docs/nr1-plugins), or [catalogs](/explore-docs/nr1-catalog).
 
 # Command details
 
-***
+---
 
 ## `nr1 help`
+
 ### See commands and get details
+
 Shows all nr1 commands by default. To get details about a specific command, run `nr1 help COMMAND_NAME`.
 
 ### Usage
-`$ nr1 help` 
+
+`$ nr1 help`
 
 ### Arguments
-| | |
-|---|---|
-| `COMMAND_NAME` | The name of a particular command.|
+
+|                |                                   |
+| -------------- | --------------------------------- |
+| `COMMAND_NAME` | The name of a particular command. |
 
 ### Examples
-* `$ nr1 help` 
-* `$ nr1 help nerdpack` 
-* `$ nr1 help nerdpack:deploy` 
 
-<br>
+- `$ nr1 help`
+- `$ nr1 help nerdpack`
+- `$ nr1 help nerdpack:deploy`
 
-*** 
+<br />
+
+---
 
 ## `nr1 update`
+
 ### Update your CLI
+
 Updates to latest version of the CLI. You can specify which channel to update if you'd like.
 
 ### Usage
-`$ nr1 update` 
+
+`$ nr1 update`
 
 ### Arguments
-| | |
-|---|---|
+
+|           |                                   |
+| --------- | --------------------------------- |
 | `CHANNEL` | The name of a particular channel. |
 
 ### Examples
-* `$ nr1 update`
-* `$ nr1 update somechannel`
 
-<br>
+- `$ nr1 update`
+- `$ nr1 update somechannel`
 
-***
+<br />
+
+---
 
 ## `nr1 create`
+
 ### Create a new component
+
 Creates a new component from our template (either a Nerdpack, Nerdlet, launcher, or catalog). The CLI will walk you through this process.
 
 To learn more about Nerdpacks and their file structure, see [Nerdpack file structure](/explore-docs/nerdpack-file-structure). For more on how to set up your Nerdpacks, see our [Nerdpack CLI commands](/explore-docs/nr1-nerdpack).
 
 ### Usage
-`$ nr1 create` 
+
+`$ nr1 create`
 
 ### Options
-| | |
-|---|---|
-|  `-f, --force`       |  If present, overrides existing files without asking. |
-|  `-n, --name=NAME`   | Names the component. |
-|  `-t, --type=TYPE`   | Specifies the component type. |
-|  `--path=PATH`       | The route to the component. |
-| `--profile=PROFILE`  | The authentication profile you want to use. |
-| `--verbose`          | Adds extra information to the output. |
 
-<br>
+|                     |                                                      |
+| ------------------- | ---------------------------------------------------- |
+| `-f, --force`       | If present, overrides existing files without asking. |
+| `-n, --name=NAME`   | Names the component.                                 |
+| `-t, --type=TYPE`   | Specifies the component type.                        |
+| `--path=PATH`       | The route to the component.                          |
+| `--profile=PROFILE` | The authentication profile you want to use.          |
+| `--verbose`         | Adds extra information to the output.                |
 
-*** 
+<br />
+
+---
 
 ## `nr1 profiles`
+
 ### Manage your profiles keychain
-Displays a list of commands you can use to manage your profiles. Run `nr1 help profiles:COMMAND` for more on their specific usages. You can have more than one profile, which is helpful for executing commands on multiple New Relic accounts. 
+
+Displays a list of commands you can use to manage your profiles. Run `nr1 help profiles:COMMAND` for more on their specific usages. You can have more than one profile, which is helpful for executing commands on multiple New Relic accounts.
 
 To learn more about setting up profiles, see [our Github workshop](https://github.com/newrelic/nr1-workshop/blob/master/lab-cli/INSTRUCTIONS.md).
 
 ### Usage
+
 `$ nr1 profiles:COMMAND`
 
 ### Commands
 
-|   |   |
-|---|---|
+|                    |                                               |
+| ------------------ | --------------------------------------------- |
 | `profiles:add`     | Adds a new profile to your profiles keychain. |
-| `profiles:default` | Chooses which profile should be default. |
-| `profiles:list`    | Lists the profiles on your keychain. |
-| `profiles:remove`   | Removes a profile from your keychain. |
+| `profiles:default` | Chooses which profile should be default.      |
+| `profiles:list`    | Lists the profiles on your keychain.          |
+| `profiles:remove`  | Removes a profile from your keychain.         |
 
-<br>
+<br />
 
-*** 
+---
 
 ## `nr1 autocomplete`
+
 ### See autocomplete installation instructions
+
 Displays the autocomplete installation instructions.
 
 By default, the command displays the autocomplete instructions for zsh. If you want instructions for bash, run `nr1 autocomplete bash`.
 
 ### Usage
+
 `$ nr1 autocomplete`
 
 ### Arguments
-| | |
-|---|---|
+
+|         |                                           |
+| ------- | ----------------------------------------- |
 | `SHELL` | The shell type you want instructions for. |
 
 ### Options
-| | |
-|---|---|
-|  `-r, --refresh-cache` | Refreshes cache (ignores displaying instructions). |
+
+|                       |                                                    |
+| --------------------- | -------------------------------------------------- |
+| `-r, --refresh-cache` | Refreshes cache (ignores displaying instructions). |
 
 ### Examples
-*  `$ nr1 autocomplete`
-*  `$ nr1 autocomplete zsh`
-*  `$ nr1 autocomplete bash`
-*  `$ nr1 autocomplete --refresh-cache`
 
-<br>
+- `$ nr1 autocomplete`
+- `$ nr1 autocomplete zsh`
+- `$ nr1 autocomplete bash`
+- `$ nr1 autocomplete --refresh-cache`
 
-*** 
+<br />
+
+---
 
 ## `nr1 nrql`
+
 ### Query using NRQL
+
 Fetches data from New Relic databases using a NRQL (New Relic query language) query.
 
 To learn more about NRQL and how to use it, see our [NRQL docs](https://newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql).
 
 ### Usage
+
 `$ nr1 nrql OPTION ...`
 
 ### Options
-| | |
-|---|---|
-| `-a, --account=ACCOUNT` | The user account ID. **required** |
-|  `-q, --query=QUERY`    | The NRQL query to run. **required** |
-|  `-u, --ugly`           | Displays the content without tabs or spaces. |
-|  `--profile=PROFILE`    | The authentication profile you want to use. |
-|  `--verbose`            | Adds extra information to the output. |
+
+|                         |                                              |
+| ----------------------- | -------------------------------------------- |
+| `-a, --account=ACCOUNT` | The user account ID. **required**            |
+| `-q, --query=QUERY`     | The NRQL query to run. **required**          |
+| `-u, --ugly`            | Displays the content without tabs or spaces. |
+| `--profile=PROFILE`     | The authentication profile you want to use.  |
+| `--verbose`             | Adds extra information to the output.        |

--- a/src/markdown-pages/explore-docs/nr1-config.mdx
+++ b/src/markdown-pages/explore-docs/nr1-config.mdx
@@ -6,7 +6,6 @@ description: 'An overview of the commands you can use to configure your New Reli
 tileShorthand:
   title: 'Config CLI commands'
   description: 'Configure your New Relic One CLI preferences.'
-redirects:
 ---
 
 <Intro>

--- a/src/markdown-pages/explore-docs/nr1-config.mdx
+++ b/src/markdown-pages/explore-docs/nr1-config.mdx
@@ -16,100 +16,119 @@ Run `nr1 config:list` to see all your existing configurations and their keys.
 
 </Intro>
 
-<br/> 
+<br />
 
-| Command | Description |
-|---|---|
-| [`nr1 config:set`](#nr1-configset) | Sets a specific configuration value. |
-| [`nr1 config:get`](#nr1-configget) | Shows a specific configuration. |
-| [`nr1 config:list`](#nr1-configlist) | Lists your configuration choices. |
+| Command                                  | Description                                    |
+| ---------------------------------------- | ---------------------------------------------- |
+| [`nr1 config:set`](#nr1-configset)       | Sets a specific configuration value.           |
+| [`nr1 config:get`](#nr1-configget)       | Shows a specific configuration.                |
+| [`nr1 config:list`](#nr1-configlist)     | Lists your configuration choices.              |
 | [`nr1 config:delete`](#nr1-configdelete) | Removes the value of a specific configuration. |
 
 # Command details
 
-***
+---
 
 ## `nr1 config:set`
+
 ### Set a configuration
-Sets a specific configuration value given a configuration key. By default, the command will prompt you for a new value after providing a key, but you can also use the `--k, --key=KEY` option to skip this step.  
+
+Sets a specific configuration value given a configuration key. By default, the command will prompt you for a new value after providing a key, but you can also use the `--k, --key=KEY` option to skip this step.
 
 ### Usage
-`$ nr1 config:set OPTION` 
+
+`$ nr1 config:set OPTION`
 
 ### Options
-| | |
-|---|---|
-| `-k, --key=KEY` | The key of the config. **(required)** |
-| `-V, --value=VALUE` | The value of the config. |
-| `--profile=PROFILE` | The authentication profile you want to use. |
-|` -t, --this-profile-only` | If present, this configuration will only apply while running with the specified profile.|
-| `--verbose` | Adds extra information to the output. |
+
+|                           |                                                                                          |
+| ------------------------- | ---------------------------------------------------------------------------------------- |
+| `-k, --key=KEY`           | The key of the config. **(required)**                                                    |
+| `-V, --value=VALUE`       | The value of the config.                                                                 |
+| `--profile=PROFILE`       | The authentication profile you want to use.                                              |
+| `-t, --this-profile-only` | If present, this configuration will only apply while running with the specified profile. |
+| `--verbose`               | Adds extra information to the output.                                                    |
 
 ### Examples
-* `$ nr1 config:set --key=proxyEnabled`   
-* `$ nr1 config:set --key=proxyEnabled --value=ENABLED`   
 
-<br>
+- `$ nr1 config:set --key=proxyEnabled`
+- `$ nr1 config:set --key=proxyEnabled --value=ENABLED`
 
-*** 
+<br />
+
+---
 
 ## `nr1 config:get`
+
 ### See your configuration
+
 Shows the value for a specific configuration.
 
 ### Usage
+
 `$ nr1 config:get OPTION`
 
 ### Options
-| | |
-|---|---|
-| `-k, --key=KEY` | The key of the config. **(required)** |
+
+|                     |                                             |
+| ------------------- | ------------------------------------------- |
+| `-k, --key=KEY`     | The key of the config. **(required)**       |
 | `--profile=PROFILE` | The authentication profile you want to use. |
-| `--verbose` | Adds extra information to the output. |
+| `--verbose`         | Adds extra information to the output.       |
 
-<br>
+<br />
 
-*** 
+---
 
 ## `nr1 config:list`
+
 ### See all your configurations
+
 Shows a list of all your configuration choices, including the configuration key, value, and origin.
 
 ### Usage
+
 `$ nr1 config:list`
 
 ### Options
-| | |
-|---|---|
+
+|                     |                                             |
+| ------------------- | ------------------------------------------- |
 | `--profile=PROFILE` | The authentication profile you want to use. |
-| `--verbose` | Adds extra information to the output. |
+| `--verbose`         | Adds extra information to the output.       |
 
 ### Aliases
-* `$ nr1 config:ls`
 
-<br>
+- `$ nr1 config:ls`
 
-*** 
+<br />
+
+---
 
 ## `nr1 config:delete`
+
 ### Remove a configuration
+
 Removes the value of a specific configuration.
 
 ### Usage
+
 `$ nr1 config:delete OPTION`
 
 ### Options
-| | |
-|---|---|
-| `-k, --key=KEY` | The key of the config. **(required)**|
-| `--profile=PROFILE` | The authentication profile you want to use. |
-|` -t, --this-profile-only` | If present, this configuration will only apply while running with the specified profile.|
-| `--verbose` | Adds extra information to the output. |
+
+|                           |                                                                                          |
+| ------------------------- | ---------------------------------------------------------------------------------------- |
+| `-k, --key=KEY`           | The key of the config. **(required)**                                                    |
+| `--profile=PROFILE`       | The authentication profile you want to use.                                              |
+| `-t, --this-profile-only` | If present, this configuration will only apply while running with the specified profile. |
+| `--verbose`               | Adds extra information to the output.                                                    |
 
 ### Aliases
-* `nr1 config:remove`
-* `nr1 config:rm`
+
+- `nr1 config:remove`
+- `nr1 config:rm`
 
 ### Examples:
-* `$ nr1 config:delete --key=proxyHttp`   
 
+- `$ nr1 config:delete --key=proxyHttp`

--- a/src/markdown-pages/explore-docs/nr1-nerdpack.mdx
+++ b/src/markdown-pages/explore-docs/nr1-nerdpack.mdx
@@ -6,7 +6,6 @@ description: 'An overview of the CLI commands you can use to set up your New Rel
 tileShorthand:
   title: 'Nerdpack CLI commands'
   description: 'Set up your Nerdpacks with the New Relic One CLI.'
-redirects:
 ---
 
 <Intro>

--- a/src/markdown-pages/explore-docs/nr1-plugins.mdx
+++ b/src/markdown-pages/explore-docs/nr1-plugins.mdx
@@ -6,7 +6,6 @@ description: 'An overview of the CLI commands you can use to install and manage 
 tileShorthand:
   title: 'Plugin CLI commands'
   description: 'Install and manage plugins with the New Relic One CLI.'
-redirects:
 ---
 
 <Intro>

--- a/src/markdown-pages/explore-docs/nr1-subscription.mdx
+++ b/src/markdown-pages/explore-docs/nr1-subscription.mdx
@@ -6,7 +6,6 @@ description: 'An overview of the CLI commands you can use to manage your Nerdpac
 tileShorthand:
   title: 'Subscription CLI commands'
   description: 'Manage your Nerdpack subscriptions with the New Relic One CLI.'
-redirects:
 ---
 
 <Intro>


### PR DESCRIPTION
## Description
One of our recently merged markdown files had empty frontmatter which was causing Gatsby to fail when building. Adding `''` as the value resolves this.