### PR TITLE
Fix broken links on subscription commands

### DIFF
--- a/src/markdown-pages/explore-docs/nr1-cli.mdx
+++ b/src/markdown-pages/explore-docs/nr1-cli.mdx
@@ -76,9 +76,9 @@ For more on how to serve and publish your application, see our guide on [Deploy
 ### [Manage your Nerdpack subscriptions](/explore-docs/nr1-subscriptions)
 |                                                                                    |                                                        |
 |------------------------------------------------------------------------------------|--------------------------------------------------------|
-| [`nr1 subscription:set`](/explore-docs/nr1-subscriptions/#nr1-subscriptionset)     | Subscribes your account to a Nerdpack and channel.     |
-| [`nr1 subscription:list`](/explore-docs/nr1-subscriptions/#nr1-subscriptionlist)   | Lists all the Nerdpacks your account is subscribed to. |
-| [`nr1 subscription:unset`](/explore-docs/nr1-subscriptions/#nr1-subscriptionunset) | Unsubscribes your account from a Nerdpack.             |
+| [`nr1 subscription:set`](/explore-docs/nr1-subscription/#nr1-subscriptionset)     | Subscribes your account to a Nerdpack and channel.     |
+| [`nr1 subscription:list`](/explore-docs/nr1-subscription/#nr1-subscriptionlist)   | Lists all the Nerdpacks your account is subscribed to. |
+| [`nr1 subscription:unset`](/explore-docs/nr1-subscription/#nr1-subscriptionunset) | Unsubscribes your account from a Nerdpack.             |
 
 ### [Install and manage plugins](/explore-docs/nr1-plugins)
 |                                                                                |                                              |


### PR DESCRIPTION
## Description
This PR fixes broken links in the New Relic One CLI docs for subscription commands.
