### PR TITLE
Index tags for a guide

### DIFF
--- a/src/components/Seo.js
+++ b/src/components/Seo.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { useStaticQuery, graphql, withPrefix } from 'gatsby';
 
-function SEO({ description, lang, meta, title }) {
+function SEO({ description, lang, meta, title, tags }) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -67,6 +67,12 @@ function SEO({ description, lang, meta, title }) {
       'data-type': 'string',
       content: description,
     },
+    ...(tags ?? []).map((tag) => ({
+      name: 'tags',
+      class: 'swiftype',
+      'data-type': 'string',
+      content: tag,
+    })),
   ];
 
   // only add metadata if we have content
@@ -100,6 +106,7 @@ SEO.propTypes = {
   lang: PropTypes.string,
   meta: PropTypes.arrayOf(PropTypes.object),
   title: PropTypes.string,
+  tags: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default SEO;

--- a/src/markdown-pages/automate-workflows/get-started-new-relic-cli.mdx
+++ b/src/markdown-pages/automate-workflows/get-started-new-relic-cli.mdx
@@ -8,6 +8,12 @@ promote: true
 tileShorthand:
   title: 'Automate common tasks'
   description: 'Use the New Relic CLI to tag apps and create deployment markers'
+tags:
+  - api key
+  - New Relic CLI
+  - Tags
+  - Entity
+  - Deployment markers
 ---
 
 <Intro>

--- a/src/markdown-pages/automate-workflows/get-started-terraform.mdx
+++ b/src/markdown-pages/automate-workflows/get-started-terraform.mdx
@@ -7,6 +7,9 @@ description: 'Learn how to provision New Relic resources using [Terraform](https
 tileShorthand:
   title: 'Set up New Relic using Terraform'
   description: 'Learn how to provision New Relic resources using Terraform'
+tags:
+  - notification channel
+  - Synthetics monitors
 ---
 
 <Intro>

--- a/src/markdown-pages/build-apps/build-hello-world-app.mdx
+++ b/src/markdown-pages/build-apps/build-hello-world-app.mdx
@@ -4,7 +4,13 @@ duration: '15 min'
 title: 'Create a "Hello, World!" application'
 template: 'GuideTemplate'
 description: 'Build a "Hello, World!" app and publish it to New Relic One'
+tags:
+  - nr1 cli
+  - Nerdpack file structure
+  - NR One Catalog
+  - Subscribe applications
 ---
+
 <Intro>
 
 Here's how you can quickly build a "Hello, World!" application in New Relic One. In these steps, we'll show you how to create a local version of the New Relic One site where you can prototype your application. Then, when you're ready to share the application with others, you can publish it to New Relic One.

--- a/src/markdown-pages/collect-data/add-custom-attributes.mdx
+++ b/src/markdown-pages/collect-data/add-custom-attributes.mdx
@@ -14,6 +14,9 @@ resources:
 
   - title: Learn more about NRQL
     url: /technology/nrql
+tags:
+  - Custom Attributes
+  - NRQL
 ---
 
 <Intro>

--- a/src/markdown-pages/collect-data/collect-data-from-any-source.mdx
+++ b/src/markdown-pages/collect-data/collect-data-from-any-source.mdx
@@ -10,6 +10,10 @@ tileShorthand:
   description: 'APIs, agents, OS emitters - get any data'
 redirects:
   - /use-cases/collect-data-from-any-source
+tags:
+  - apm
+  - nrql
+  - api
 ---
 
 <Intro>

--- a/src/markdown-pages/collect-data/collect-data-from-any-source.mdx
+++ b/src/markdown-pages/collect-data/collect-data-from-any-source.mdx
@@ -11,9 +11,11 @@ tileShorthand:
 redirects:
   - /use-cases/collect-data-from-any-source
 tags:
-  - apm
-  - nrql
-  - api
+  - Agent API
+  - Telemetry SDK
+  - Trace API
+  - Metric API
+  - Event API
 ---
 
 <Intro>

--- a/src/markdown-pages/explore-docs/newrelic-CLI.mdx
+++ b/src/markdown-pages/explore-docs/newrelic-CLI.mdx
@@ -4,6 +4,8 @@ duration: ''
 title: 'New Relic CLI Reference'
 template: 'GuideTemplate'
 description: 'The command line tools for performing tasks against New Relic APIs'
+tags:
+  - new relic cli
 ---
 
 <Intro>

--- a/src/markdown-pages/explore-docs/nr1-cli.mdx
+++ b/src/markdown-pages/explore-docs/nr1-cli.mdx
@@ -11,6 +11,9 @@ redirects:
 resources:
   - title: Deploy an app
     url: /build-apps/publish-deploy
+tags:
+  - New Relic One app
+  - nerdpack commands
 ---
 
 <Intro>

--- a/src/templates/GuideTemplate.js
+++ b/src/templates/GuideTemplate.js
@@ -15,11 +15,11 @@ import SEO from '../components/Seo';
 const GuideTemplate = ({ data }) => {
   const { mdx } = data;
   const { frontmatter, body } = mdx;
-  const { title, description, duration } = frontmatter;
+  const { title, description, duration, tags } = frontmatter;
 
   return (
     <>
-      <SEO title={title} description={description} />
+      <SEO title={title} description={description} tags={tags} />
       <PageLayout type={PageLayout.TYPE.RELATED_CONTENT}>
         <PageLayout.Header title={title}>
           {duration && (
@@ -64,6 +64,7 @@ export const pageQuery = graphql`
         path
         title
         description
+        tags
       }
 
       ...Resources_page


### PR DESCRIPTION
Relates to #541 
Closes #539 

## Description
This PR sets up the tagging mechanism defined in frontmatter so that we can index the tags with Swiftype. Once we get the tags defined from #539 we can add tags in this PR on all of the guides we want to test with.