### PR TITLE
Add responsive columns to developer champion and podcast pages

### DIFF
--- a/src/pages/developer-champion.module.scss
+++ b/src/pages/developer-champion.module.scss
@@ -8,6 +8,10 @@
   display: grid;
   grid-template-columns: repeat(2, calc(50% - 1rem));
   grid-gap: 2rem;
+
+  @media (max-width: 760px) {
+    grid-template-columns: 1fr
+  }
 }
 
 .img {
@@ -18,10 +22,21 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   grid-gap: 2rem;
+
+  @media (max-width: 760px) {
+    display: block;
+    text-align: center;
+  }
 }
 
 .point {
   text-align: center;
+  max-width: 400px;
+  margin: auto;
+
+  @media (max-width: 760px) {
+   margin-bottom: 40px;
+  }
 }
 
 .pointIcon {

--- a/src/pages/podcasts.js
+++ b/src/pages/podcasts.js
@@ -13,7 +13,7 @@ const PodcastsPage = () => {
         <PageLayout.Header title="New Relic Podcasts" />
         <PageLayout.Content>
           <section className={cx(styles.section, styles.twoColumn)}>
-            <div>
+            <div className={styles.bodyText}>
               <p>
                 Sometimes we talk on the internet about some things. You
                 probably listen to some things on the internet sometimes. We're

--- a/src/pages/podcasts.module.scss
+++ b/src/pages/podcasts.module.scss
@@ -6,12 +6,28 @@
 
 .twoColumn {
   display: grid;
-  grid-template-columns: repeat(2, calc(50% - 1rem));
   grid-gap: 2rem;
+  grid-template-columns: repeat(2, calc(50% - 1rem));
+
+  @media (max-width: 760px) {
+    grid-template-columns: 1fr
+  }
+}
+
+.bodyText {
+  @media (max-width: 760px) {
+    order: 1;
+  }
 }
 
 .img {
   width: 100%;
+  max-width: 350px;
+  margin: 0 auto;
+
+  @media (max-width: 760px) {
+    order: 0;
+  }
 }
 
 .player iframe {


### PR DESCRIPTION
## Description

On the **podcasts** and **developer champion** pages, the current style rules enforce a 2 and even 3 column layout on mobile devices.

This PR applies single column styles on those pages until the breakpoint used throughout the codebase `@media (max-width: 760px)`

## Reviewer Notes
1. Go to `/podcasts` or `/developer-champion` on a mobile device or in a viewport narrower than `760px`
2. Note that these layouts are single columned for the main body content, and only apply the 2 and 3 column rules from `760px` and wider

## Related Issue(s) / Ticket(s)
Addresses: [2- and 3-column grid layouts on mobile devices](https://github.com/newrelic/developer-website/issues/568)

## Screenshot(s)

### Current developer champion page

![Screenshot 2020-08-09 at 20 03 58](https://user-images.githubusercontent.com/20293876/89739829-cf2eba00-da7b-11ea-936c-30c53684a87c.jpg)

![IMG_2125](https://user-images.githubusercontent.com/20293876/89739295-73623200-da77-11ea-987e-20a9f2d62672.jpg)


### This PR's developer champion page

![Screenshot 2020-08-09 at 19 56 20](https://user-images.githubusercontent.com/20293876/89739774-4b74cd80-da7b-11ea-8d63-3d1d36c8ef0e.jpg)

![Screenshot 2020-08-09 at 19 56 31](https://user-images.githubusercontent.com/20293876/89739775-4ca5fa80-da7b-11ea-816c-21c1dbb25896.jpg)



### Current podcast page

![Screenshot 2020-08-09 at 19 58 06](https://user-images.githubusercontent.com/20293876/89739743-22543d00-da7b-11ea-800a-7818943752c8.jpg)

![IMG_2123](https://user-images.githubusercontent.com/20293876/89739292-71986e80-da77-11ea-9e27-25b1f5a51d07.jpg)

![Screenshot 2020-08-09 at 19 58 28](https://user-images.githubusercontent.com/20293876/89739739-1bc5c580-da7b-11ea-87c5-14ab9e923315.jpg)


### This PR's podcast page

![Screenshot 2020-08-09 at 19 57 18](https://user-images.githubusercontent.com/20293876/89739750-2c763b80-da7b-11ea-9465-5e5cf814fbd7.jpg)

![Screenshot 2020-08-09 at 19 57 28](https://user-images.githubusercontent.com/20293876/89739776-4d3e9100-da7b-11ea-821c-d2bfa1b426e0.jpg)

![Screenshot 2020-08-09 at 19 56 52](https://user-images.githubusercontent.com/20293876/89739759-35670d00-da7b-11ea-9b29-d780d3a18d31.jpg)


