### PR TITLE
Remove empty related info section on a guide

### DIFF
--- a/src/markdown-pages/build-apps/howto-use-nrone-table-components.mdx
+++ b/src/markdown-pages/build-apps/howto-use-nrone-table-components.mdx
@@ -285,5 +285,3 @@ Go back to your application and try hovering over any of the rows: Notice how th
 You've built a table into a New Relic One application, using components to format data automatically and provide contextual actions. Well done!
 
 Keep exploring the `Table` components, their properties, and how to use them, in our [SDK documentation](https://developer.newrelic.com/client-side-sdk/index.html#components/Table).
-
-### Related info


### PR DESCRIPTION
## Description
Removes the empty "Related info" section at the bottom of the table guide.