### PR TITLE
Reduce font size on resources links

### DIFF
--- a/src/components/RelatedContentModules/Resources.js
+++ b/src/components/RelatedContentModules/Resources.js
@@ -56,6 +56,7 @@ const Resources = ({ page }) => {
                 key={resource.url}
                 css={css`
                   margin-bottom: 1rem;
+                  font-size: 0.875rem;
                 `}
               >
                 <LinkElement


### PR DESCRIPTION
## Description

Reduces font size on the resources links to try and save some vertical space
when possible.

## Screenshot(s)
**Before**
<img width="324" alt="Screen Shot 2020-08-10 at 11 21 26 PM" src="https://user-images.githubusercontent.com/565661/89864131-43428e00-db60-11ea-88db-ceec3adf5127.png">


**After**
<img width="331" alt="Screen Shot 2020-08-10 at 11 21 10 PM" src="https://user-images.githubusercontent.com/565661/89864137-48074200-db60-11ea-9db7-89ae4fcad544.png">
