### PR TITLE
Change resources title and uppercase tag text

### DIFF
--- a/src/components/RelatedContentModules/Resources.js
+++ b/src/components/RelatedContentModules/Resources.js
@@ -34,7 +34,7 @@ const Resources = ({ page }) => {
 
   return resources?.length > 0 ? (
     <Section>
-      <Title>Resources</Title>
+      <Title>Related resources</Title>
       <nav>
         <ul
           css={css`
@@ -85,7 +85,13 @@ const Resources = ({ page }) => {
                   )}
                 </LinkElement>
 
-                <Tag>{tag}</Tag>
+                <Tag
+                  css={css`
+                    text-transform: uppercase;
+                  `}
+                >
+                  {tag}
+                </Tag>
               </li>
             );
           })}


### PR DESCRIPTION
## Description
This PR changes the right rail's `Resources` text to `Related resources`
It also applies uppercase to the tags' text

## Related Issue(s) / Ticket(s)
Closes #581 Partially addresses #561 

## Screenshot(s)
<img width="304" alt="Screen Shot 2020-08-12 at 12 01 26 PM" src="https://user-images.githubusercontent.com/39655074/90056335-8ea98900-dc93-11ea-8d86-b345efc2896e.png">
