### PR TITLE
Hide related resources for pages that are not yet indexed

### DIFF
--- a/src/components/RelatedContentModules/Resources.js
+++ b/src/components/RelatedContentModules/Resources.js
@@ -30,12 +30,10 @@ const normalizeDeveloperUrl = (url) =>
   url.replace('https://developer.newrelic.com', '');
 
 const Resources = ({ page }) => {
-  const {
-    relatedResources,
-    frontmatter: { resources },
-  } = page;
+  const { relatedResources, frontmatter } = page;
+  const resources = (frontmatter.resources || []).concat(relatedResources);
 
-  return (
+  return resources.length > 0 ? (
     <Section>
       <Title>Related resources</Title>
       <nav>
@@ -46,7 +44,7 @@ const Resources = ({ page }) => {
             padding: 0;
           `}
         >
-          {(resources || []).concat(relatedResources).map((resource) => {
+          {resources.map((resource) => {
             const tag = findTag(resource);
             const isDeveloperSite = tag === 'developer';
             const LinkElement = isDeveloperSite ? Link : ExternalLink;
@@ -101,7 +99,7 @@ const Resources = ({ page }) => {
         </ul>
       </nav>
     </Section>
-  );
+  ) : null;
 };
 
 Resources.propTypes = {

--- a/src/components/RelatedContentModules/Resources.js
+++ b/src/components/RelatedContentModules/Resources.js
@@ -89,6 +89,8 @@ const Resources = ({ page }) => {
                 <Tag
                   css={css`
                     text-transform: uppercase;
+                    font-size: 0.5625rem;
+                    letter-spacing: 0.5px;
                   `}
                 >
                   {tag}


### PR DESCRIPTION
## Description

Hides the "Related resources" section for pages that have not been indexed. Also
reduces the font-size a tad on the related resources section.

## Screenshots

**Before**
<img width="293" alt="Screen Shot 2020-08-13 at 4 42 24 PM" src="https://user-images.githubusercontent.com/565661/90197616-ffc86980-dd83-11ea-8edb-53830cacace4.png">

**After**
<img width="299" alt="Screen Shot 2020-08-13 at 4 41 23 PM" src="https://user-images.githubusercontent.com/565661/90197618-01922d00-dd84-11ea-9ce4-6a91e2823291.png">