### PR TITLE
Styles for `iframe`s within Guides

### DIFF
--- a/src/components/Iframe.js
+++ b/src/components/Iframe.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { css } from '@emotion/core';
+
+const Iframe = (props) => {
+  // strip out width and then render iframe
+  const { width, ...limitedProps } = props;
+
+  return (
+    <iframe
+      {...limitedProps}
+      css={css`
+        width: 100%;
+      `}
+    />
+  );
+};
+
+export default Iframe;

--- a/src/components/Iframe.js
+++ b/src/components/Iframe.js
@@ -1,18 +1,30 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 
 const Iframe = (props) => {
   // strip out width and then render iframe
-  const { width, ...limitedProps } = props;
+  // eslint-disable-next-line no-unused-vars
+  const { width, title, ...limitedProps } = props;
 
   return (
     <iframe
+      title={title}
       {...limitedProps}
       css={css`
         width: 100%;
       `}
     />
   );
+};
+
+Iframe.propTypes = {
+  width: PropTypes.string,
+  title: PropTypes.string,
+};
+
+Iframe.defaultProps = {
+  title: 'iFrame content',
 };
 
 export default Iframe;

--- a/src/components/MDXContainer.js
+++ b/src/components/MDXContainer.js
@@ -10,6 +10,7 @@ import Caution from './Caution';
 import Important from './Important';
 import Tip from './Tip';
 import Intro from './Intro';
+import Iframe from './Iframe';
 import { MDXCodeBlock, Video } from '@newrelic/gatsby-theme-newrelic';
 
 import styles from './MDXContainer.module.scss';
@@ -22,6 +23,7 @@ const components = {
   Important,
   Tip,
   Intro,
+  iframe: Iframe,
   code: MDXCodeBlock,
   pre: (props) => props.children,
 };

--- a/src/components/RelatedContentModules/PageUpdated.js
+++ b/src/components/RelatedContentModules/PageUpdated.js
@@ -9,6 +9,9 @@ const PageUpdated = ({ page }) => {
     fields: { gitAuthorTime },
   } = page;
 
+  // If there is no date available, do not render the component
+  if (gitAuthorTime === 'Invalid date') return null;
+
   return (
     <Section
       css={css`


### PR DESCRIPTION
## Description
Adds some minor adjustments to `iframe`s added to guides. At the moment, we are simply making them full-width and ensuring a `title` property is added (for accesability). In the future, we can use this component to provide additional styling, a mobile-fallback-message, or limit what gets built (for security).

This also fixes a small issue where the "Last updated" message shows "Invalid date". It's likely that we would never run into that condition, but just in case I added a check.

## Reviewer Notes
To test this, I made a test markdown page with an `iframe` in it. See the related PR (linked below) for an example of how this would be used and the screenshots section for how that page would be rendered.

## Related Issue(s) / PR(s)
* Closes #593 
* Relates to #596 

## Screenshot(s)
**Desktop**
![Screen Shot 2020-08-14 at 2 10 18 PM](https://user-images.githubusercontent.com/1946433/90293933-1630fc80-de3a-11ea-957f-d88182757ad9.png)

**Mobile**
![Screen Shot 2020-08-14 at 2 09 59 PM](https://user-images.githubusercontent.com/1946433/90293939-19c48380-de3a-11ea-8ef3-4f623600fc66.png)
