### PR TITLE
added events to side nav

### DIFF
--- a/src/components/FeatherIcon.js
+++ b/src/components/FeatherIcon.js
@@ -147,6 +147,14 @@ const ICONS = {
       <path d="M16 3.13a4 4 0 0 1 0 7.75" />
     </>
   ),
+  event: (
+    <>
+      <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+      <line x1="16" y1="2" x2="16" y2="6"></line>
+      <line x1="8" y1="2" x2="8" y2="6"></line>
+      <line x1="3" y1="10" x2="21" y2="10"></line>
+    </>
+  ),
 };
 
 FeatherIcon.propTypes = {

--- a/src/components/FeatherIcon.js
+++ b/src/components/FeatherIcon.js
@@ -149,10 +149,10 @@ const ICONS = {
   ),
   event: (
     <>
-      <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
-      <line x1="16" y1="2" x2="16" y2="6"></line>
-      <line x1="8" y1="2" x2="8" y2="6"></line>
-      <line x1="3" y1="10" x2="21" y2="10"></line>
+      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="3" y1="10" x2="21" y2="10" />
     </>
   ),
 };

--- a/src/data/sidenav.json
+++ b/src/data/sidenav.json
@@ -509,13 +509,19 @@
     ]
   },
   {
+    "displayName": "Attend events",
+    "children": [
+      {
+        "displayName": "Kubecon & CloudNativeCon",
+        "url": "/kubecon-europe-2020"
+      }
+    ]
+  },
+  {
     "displayName": "Developer champions",
     "url": "/developer-champion"
   },
-  {
-    "displayName": "Kubecon & CloudNativeCon",
-    "url": "/kubecon-europe-2020"
-  },
+
   {
     "displayName": "Podcasts",
     "url": "/podcasts"


### PR DESCRIPTION
## Description

Adds a side bar nav item called Attend events.
Moves the kubecon event page under that nav item

![Screen Shot 2020-08-14 at 5 07 46 PM](https://user-images.githubusercontent.com/1395158/90299261-a844ff00-de52-11ea-98ca-297ef68ef8f6.png)
