### PR TITLE
Style adjustments on kubecon page

### DIFF
--- a/src/pages/kubecon-europe-2020.module.scss
+++ b/src/pages/kubecon-europe-2020.module.scss
@@ -10,7 +10,7 @@
   grid-gap: 2rem;
 
   @media (max-width: 760px) {
-    grid-template-columns: 1fr
+    grid-template-columns: 1fr;
   }
 }
 
@@ -31,11 +31,10 @@
 
 .point {
   text-align: center;
-  max-width: 400px;
-  margin: auto;
+  width: 100%;
 
   @media (max-width: 760px) {
-   margin-bottom: 40px;
+    margin-bottom: 40px;
   }
 }
 
@@ -52,12 +51,12 @@
   margin-left: 0.5rem;
 }
 
-.videoGrid {
-  width: 400px;
+.point h4 {
+  min-height: 3rem;
 }
 
 .highlightDiv {
-  margin: auto
+  margin: auto;
 }
 
 .highlightText {


### PR DESCRIPTION
## Description
The recently-added kubecon landing page had some issues with responsiveness (specifically around the tablet breakpoint). This makes a few adjustments to resolve this (as well as updates the scss file for scss).

## Reviewer Notes
This is a quick fix for Kubecon. At some point, we should update this to use emotion.

## Related Issue(s) / Ticket(s)
N/A

## Screenshot(s)
**Before**
![Screen Shot 2020-08-14 at 4 40 35 PM](https://user-images.githubusercontent.com/1946433/90299989-361deb80-de4d-11ea-8360-d18c328553ca.png)

**After**
![Screen Shot 2020-08-14 at 4 40 46 PM](https://user-images.githubusercontent.com/1946433/90299991-38804580-de4d-11ea-960b-cf40767d8ea7.png)
