### PR TITLE
Fix logo rendering issue in Safari

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -36,7 +36,6 @@ const Sidebar = ({ className }) => {
         <Link
           css={css`
             display: block;
-            display: flex;
             margin-bottom: 1rem;
           `}
           to="/"


### PR DESCRIPTION
## Description
Fixes the logo height rendering issue in Safari

## Screenshots

**Before**
<img width="1018" alt="Screen Shot 2020-08-16 at 12 32 52 AM" src="https://user-images.githubusercontent.com/565661/90329269-0c052000-df58-11ea-87bb-1cd85a39d8d1.png">

**After**
<img width="1307" alt="Screen Shot 2020-08-16 at 12 31 16 AM" src="https://user-images.githubusercontent.com/565661/90329264-ed068e00-df57-11ea-85c5-1a883b99eb46.png">
