### PR TITLE
Upgrade Gatsby theme to get sign up button + other goodies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4124,9 +4124,9 @@
       }
     },
     "@newrelic/gatsby-theme-newrelic": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.6.0.tgz",
-      "integrity": "sha512-pT7fRAYhOgvKN40gZZQsvxEhnyOSzU7P1sVK/YnUUXMiHm7NqNxBDw32qU4YlARVoSnvaosXcMdIMKPCku59UQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.7.0.tgz",
+      "integrity": "sha512-1xNvJFLqUgOIyHvP96v8A1wpWF1rOYJis+oQ43hTUZ/Kl9dFti2JMDnSxnT6Q8pB+Sq1SOjj8+P8MD96nETxGg==",
       "requires": {
         "@elastic/react-search-ui": "^1.4.1",
         "@elastic/react-search-ui-views": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^10.0.27",
     "@mdx-js/mdx": "^1.6.10",
     "@mdx-js/react": "^1.6.14",
-    "@newrelic/gatsby-theme-newrelic": "^1.6.0",
+    "@newrelic/gatsby-theme-newrelic": "^1.7.0",
     "classnames": "^2.2.6",
     "date-fns": "^2.15.0",
     "eslint-plugin-react-hooks": "^4.0.8",

--- a/src/components/Logo.module.scss
+++ b/src/components/Logo.module.scss
@@ -7,12 +7,12 @@
 }
 
 .brackets {
-  stroke: var(--logo-bracket-color, var(--color-brand-800));
+  stroke: var(--logo-bracket-color, var(--color-brand-500));
   stroke-width: 2;
   stroke-linecap: round;
   stroke-linejoin: round;
 
   :global(.dark-mode) & {
-    stroke: var(--logo-bracket-color, var(--color-brand-400));
+    stroke: var(--logo-bracket-color, var(--color-brand-300));
   }
 }

--- a/src/components/RelatedContentModules/Contribute.js
+++ b/src/components/RelatedContentModules/Contribute.js
@@ -52,7 +52,7 @@ const Contribute = ({ pageContext }) => {
       <Button
         as={ExternalLink}
         href={`${repository}/tree/main/${fileRelativePath}`}
-        variant={Button.VARIANT.PLAIN}
+        variant={Button.VARIANT.NORMAL}
         size={Button.SIZE.SMALL}
       >
         <Icon

--- a/src/components/styles.scss
+++ b/src/components/styles.scss
@@ -1,5 +1,5 @@
 :root {
-  --height-global-header: 30px;
+  --height-global-header: 36px;
   --height-mobile-nav-bar: 60px;
   --ease-out-quad: cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -11,7 +11,6 @@ import MobileHeader from '../components/MobileHeader';
 import Sidebar from '../components/Sidebar';
 import CookieApprovalDialog from '../components/CookieApprovalDialog';
 import '../components/styles.scss';
-import usePageContext from '../hooks/usePageContext';
 import { useLocation } from '@reach/router';
 
 const gaTrackingId = 'UA-3047412-33';
@@ -19,7 +18,7 @@ const gdprConsentCookieName = 'newrelic-gdpr-consent';
 
 const MainLayout = ({ children }) => {
   const {
-    site: { layout, siteMetadata },
+    site: { layout },
   } = useStaticQuery(graphql`
     query {
       site {
@@ -27,23 +26,13 @@ const MainLayout = ({ children }) => {
           contentPadding
           maxWidth
         }
-        siteMetadata {
-          repository
-        }
       }
     }
   `);
 
   const location = useLocation();
-  const { fileRelativePath } = usePageContext();
   const [cookieConsent, setCookieConsent] = useState(false);
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
-  const isComponentDoc = fileRelativePath.includes(
-    'src/markdown-pages/components'
-  );
-  const editUrl = isComponentDoc
-    ? null
-    : `${siteMetadata.repository}/blob/main/${fileRelativePath}`;
 
   useEffect(() => {
     const consentValue = Cookies.get(gdprConsentCookieName) === 'true';
@@ -79,7 +68,7 @@ const MainLayout = ({ children }) => {
           </script>
         ) : null}
       </Helmet>
-      <GlobalHeader editUrl={editUrl} search />
+      <GlobalHeader search />
       <MobileHeader
         css={css`
           @media (min-width: 761px) {

--- a/src/pages/developer-champion.module.scss
+++ b/src/pages/developer-champion.module.scss
@@ -10,7 +10,7 @@
   grid-gap: 2rem;
 
   @media (max-width: 760px) {
-    grid-template-columns: 1fr
+    grid-template-columns: 1fr;
   }
 }
 
@@ -35,7 +35,7 @@
   margin: auto;
 
   @media (max-width: 760px) {
-   margin-bottom: 40px;
+    margin-bottom: 40px;
   }
 }
 
@@ -43,7 +43,7 @@
   --feather-icon-stroke-width: 1;
 
   margin-bottom: 2rem;
-  color: var(--color-brand-400);
+  color: var(--color-brand-500);
 }
 
 .nominateButton {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import { css } from '@emotion/core';
 import { graphql, Link } from 'gatsby';
 
 import SEO from '../components/Seo';
@@ -177,6 +178,9 @@ const IndexPage = ({ data, pageContext }) => {
                 as={ExternalLink}
                 variant={Button.VARIANT.PRIMARY}
                 href="https://forms.gle/Zkdub5e1x4MNqSKW9"
+                css={css`
+                  margin-right: 0.5rem;
+                `}
               >
                 Nominate a developer champion
                 <FeatherIcon
@@ -186,7 +190,7 @@ const IndexPage = ({ data, pageContext }) => {
               </Button>
               <Button
                 as={Link}
-                variant={Button.VARIANT.PLAIN}
+                variant={Button.VARIANT.LINK}
                 to="/developer-champion"
               >
                 Learn more about developer champions

--- a/src/pages/kubecon-europe-2020.module.scss
+++ b/src/pages/kubecon-europe-2020.module.scss
@@ -38,15 +38,6 @@
   }
 }
 
-.pointIcon {
-  --feather-icon-stroke-width: 1;
-
-  margin: auto;
-  margin-bottom: 10px;
-  display: block;
-  color: var(--color-brand-800);
-}
-
 .externalLinkIcon {
   margin-left: 0.5rem;
 }
@@ -57,9 +48,4 @@
 
 .highlightDiv {
   margin: auto;
-}
-
-.highlightText {
-  color: var(--color-brand-800);
-  text-align: center;
 }


### PR DESCRIPTION
Closes #536 

## Description

Upgrades `gatsby-theme-newrelic` to add the sign up button. Updates the brand colors to match the latest color palette. Update `PLAIN` buttons to use the proper button styles.

## Screenshot(s)

<img width="1920" alt="Screen Shot 2020-08-17 at 11 06 31 AM" src="https://user-images.githubusercontent.com/565661/90429001-ba54b680-e079-11ea-884a-c5201c8e79c3.png">

