### PR TITLE
Add the ability to provide supplemental API documentation

### DIFF
--- a/src/data/additionalDocs.js
+++ b/src/data/additionalDocs.js
@@ -5,7 +5,7 @@ const additionalDocs = {
         name: 'nerdlet.setUrlState',
         description: `
 Updates the current nerdlet's URL state that can be read from
-\`NerdletStateContext.Consumer\`.
+[\`NerdletStateContext.Consumer\`](/components/nerdlet-state-context).
 
 If you wish to update nerdlet's state without persisting its value in the
 url, use React's built-in \`setState()\`.

--- a/src/data/additionalDocs.js
+++ b/src/data/additionalDocs.js
@@ -1,0 +1,51 @@
+const additionalDocs = {
+  nerdlet: {
+    methods: [
+      {
+        name: 'nerdlet.setUrlState',
+        description: `
+Updates the current nerdlet's URL state that can be read from
+\`NerdletStateContext.Consumer\`.
+
+If you wish to update nerdlet's state without persisting its value in the
+url, use React's built-in \`setState()\`.
+
+This method behaves like React's \`setState()\`, meaning that it performs a
+shallow merge between the current URL state and the provided state in the
+\`urlState\` parameter.
+
+If you wish to navigate without adding an entry to the browser history, set
+\`urlStateOptions.replaceHistory\` to \`true\`.
+        `.trim(),
+        returnValue: { type: 'void' },
+        params: [
+          {
+            name: 'urlState',
+            type: 'Object',
+            description: 'New nerdlet URL state.',
+          },
+          {
+            name: 'urlStateOptions',
+            type: 'UrlStateOptions',
+            description: 'Options for the URL state.',
+          },
+        ],
+        examples: [
+          {
+            label: 'Example 1',
+            sourceCode: `
+nerlet.setUrlState({
+  foo: 'bar',
+});
+            `.trim(),
+            options: {
+              live: false,
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export default additionalDocs;


### PR DESCRIPTION
## Description
The bundle that we use to generate documentation for components and APIs is missing information. One example is the `nerdlet.setUrlState` method. In order to help provide more complete documentation, I created a system for us to add additional documentation that we define. This (temporary) solution should allow us to add in any missing methods, typeDefs, or constants.

## Reviewer Notes
At the moment, I have just added the `nerdlet.setUrlState` method documentation (as the linked ticket suggests). Please let me know what you think of this setup / naming convention.

## Related Issue(s) / Ticket(s)
* Closes #450 

## Screenshot(s)
The first method in this screenshot is defined by us, the rest come from the bundle:
![Screen Shot 2020-08-17 at 3 05 37 PM](https://user-images.githubusercontent.com/1946433/90449147-afab1900-e09b-11ea-9f92-f2311b3f7d1f.png)
