### PR TITLE
Bump @newrelic/gatsby-theme-newrelic version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4124,9 +4124,9 @@
       }
     },
     "@newrelic/gatsby-theme-newrelic": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.7.0.tgz",
-      "integrity": "sha512-1xNvJFLqUgOIyHvP96v8A1wpWF1rOYJis+oQ43hTUZ/Kl9dFti2JMDnSxnT6Q8pB+Sq1SOjj8+P8MD96nETxGg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.7.1.tgz",
+      "integrity": "sha512-Cc14nytI0BDUh6K7p9j324KxBJEm6SLbqw+hZgEh4ZUv2HEHczxpjJFa4wWaF8JrbqLt33kNqSr1zwtanQ0RLw==",
       "requires": {
         "@elastic/react-search-ui": "^1.4.1",
         "@elastic/react-search-ui-views": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^10.0.27",
     "@mdx-js/mdx": "^1.6.10",
     "@mdx-js/react": "^1.6.14",
-    "@newrelic/gatsby-theme-newrelic": "^1.7.0",
+    "@newrelic/gatsby-theme-newrelic": "^1.7.1",
     "classnames": "^2.2.6",
     "date-fns": "^2.15.0",
     "eslint-plugin-react-hooks": "^4.0.8",


### PR DESCRIPTION
Closes #629 

## Description

Bumps the `@newrelic/gatsby-theme-newrelic` version to get the latest changes.