### PR TITLE
added nrql lessons to page frontmatter resources

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -314,7 +314,7 @@ redirects:
   - /build-tools/new-relic-one-applications/intro-to-sdk
   - /client-side-sdk/index.html
 resources:
-  - title: Introduction to New Relic NerdGraph
+  - title: 'Introduction to New Relic NerdGraph'
     url: https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph
   - title: Deploy an app
     url: /build-apps/publish-deploy

--- a/src/markdown-pages/collect-data/get-started-nerdgraph-api-explorer.mdx
+++ b/src/markdown-pages/collect-data/get-started-nerdgraph-api-explorer.mdx
@@ -10,15 +10,14 @@ tileShorthand:
 redirects:
   - /technology/graphql
 resources:
-  - title: Introduction to New Relic NerdGraph
+  - title: 'Introduction to New Relic NerdGraph'
     url: https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph
-
-  - title: NerdGraph tutorials
+  - title: 'NerdGraph tutorials'
     url: https://docs.newrelic.com/docs/apis/nerdgraph/tutorials
 tags:
   - nerdgraph
   - mutations
-  - nerdgraph query terminal 
+  - nerdgraph query terminal
 ---
 
 <Intro>
@@ -27,7 +26,7 @@ NerdGraph is New Relic's [GraphQL](https://graphql.org/) API. It allows you to g
 
 With NerdGraph API Explorer you don't need to know the query format: using the Query Builder you can browse our entire graph and compose queries just by selecting the items you want and filling out their required values.
 
-<Video id='oo1lbw991a' type='wistia' />
+<Video id="oo1lbw991a" type="wistia" />
 
 </Intro>
 
@@ -60,6 +59,7 @@ This GraphQL snippet appears in the editor.
   }
 }
 ```
+
 </Step>
 <Step>
 
@@ -68,7 +68,6 @@ This GraphQL snippet appears in the editor.
 With this query, you're telling NerdGraph to retrieve your name. You're asking for the `name` field, which is nested within the `user` field. This refers to the user who owns the API key, which in turn is nested within `actor`.
 
 Click the **play** button to see the result: It has almost the same shape as the request. All the fields in the Query Builder make up what's called the GraphQL schema, which describes all the available data types and their attributes. To learn more about each field, click the **Docs** button, or hover over a field in the editor.
-
 
 ![NerdGraph documentation and tooltips](../../images/graphql-guide/graphql-documentation.png)
 
@@ -144,6 +143,7 @@ newrelic nerdgraph query '{
 }
 '
 ```
+
 </Step>
 </Steps>
 

--- a/src/markdown-pages/collect-data/get-started-nerdgraph-api-explorer.mdx
+++ b/src/markdown-pages/collect-data/get-started-nerdgraph-api-explorer.mdx
@@ -10,7 +10,7 @@ tileShorthand:
 redirects:
   - /technology/graphql
 resources:
-  - title: 'Introduction to New Relic NerdGraph'
+  - title: 'Introduction to NerdGraph'
     url: https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph
   - title: 'NerdGraph tutorials'
     url: https://docs.newrelic.com/docs/apis/nerdgraph/tutorials

--- a/src/markdown-pages/collect-data/query-data-nrql.mdx
+++ b/src/markdown-pages/collect-data/query-data-nrql.mdx
@@ -10,7 +10,7 @@ tileShorthand:
 redirects:
   - /technology/nrql
 resources:
-  - title: 'New Relic One NRQL Lessons'
+  - title: 'NRQL lessons'
     url: https://opensource.newrelic.com/projects/newrelic/nr1-learn-nrql
 tags:
   - NRQL

--- a/src/markdown-pages/collect-data/query-data-nrql.mdx
+++ b/src/markdown-pages/collect-data/query-data-nrql.mdx
@@ -9,10 +9,13 @@ tileShorthand:
   description: 'Query default event data, custom events, and attributes'
 redirects:
   - /technology/nrql
+resources:
+  - title: 'New Relic One NRQL Lessons'
+    url: https://opensource.newrelic.com/projects/newrelic/nr1-learn-nrql
 tags:
- - NRQL
- - NRQL syntax
- - calculate data NRQL 
+  - NRQL
+  - NRQL syntax
+  - calculate data NRQL
 ---
 
 <Intro>


### PR DESCRIPTION
## Description

- added nrql lessons to resources
- fixed a missing ' ' on the resource titles on the get-started-nerdgraph-api-explorer page 
- updated style guide to specify you need single quotes around resource titles.
