### PR TITLE
added second level to events nav

### DIFF
--- a/src/components/NavigationItems.js
+++ b/src/components/NavigationItems.js
@@ -17,7 +17,7 @@ const iconLibrary = {
   'Build apps': 'buildApps',
   'Automate workflows': 'automation',
   'Explore docs': 'developerDocs',
-  'Attend events': 'event',
+  'Developer events': 'event',
   'Developer champions': 'developerChampions',
   Podcasts: 'podcasts',
   'Try our APIs': 'tryOurAPIs',

--- a/src/data/sidenav.json
+++ b/src/data/sidenav.json
@@ -524,7 +524,7 @@
         "url": "/nerd-days"
       },
       {
-        "displayName": "Past Events",
+        "displayName": "Past events",
         "children": [
           {
             "displayName": "Kubecon & CloudNativeCon",

--- a/src/data/sidenav.json
+++ b/src/data/sidenav.json
@@ -517,11 +517,20 @@
     ]
   },
   {
-    "displayName": "Attend events",
+    "displayName": "Developer events",
     "children": [
       {
-        "displayName": "Kubecon & CloudNativeCon",
-        "url": "/kubecon-europe-2020"
+        "displayName": "Nerd days 1.0",
+        "url": "/nerd-days"
+      },
+      {
+        "displayName": "Past Events",
+        "children": [
+          {
+            "displayName": "Kubecon & CloudNativeCon",
+            "url": "/kubecon-europe-2020"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Description
- Added a past events section to the Attend Events nav
- Changed the attend events nav item to Developer Events
- Added nerd days 1.0 to event nav section

## Reviewer Notes
If there are links or steps needed to test this work, add them here.

## Related Issue(s) / Ticket(s)

#672 

## Screenshot(s)

![Screen Shot 2020-08-24 at 7 14 52 PM](https://user-images.githubusercontent.com/1395158/91111841-c4108800-e63e-11ea-9462-70d14227343d.png)

