### PR TITLE
Update collect data icon on main page

### DIFF
--- a/src/components/GuideTile/GuideTile.js
+++ b/src/components/GuideTile/GuideTile.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { Surface } from '@newrelic/gatsby-theme-newrelic';
 import FeatherIcon from '../FeatherIcon';
-import NewRelicIcon from '../NewRelicIcon';
 import Button from './Button';
 
 const GuideTile = ({

--- a/src/components/GuideTile/GuideTile.js
+++ b/src/components/GuideTile/GuideTile.js
@@ -1,5 +1,5 @@
+import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
-import React from 'react';
 import { css } from '@emotion/core';
 import { Surface } from '@newrelic/gatsby-theme-newrelic';
 import FeatherIcon from '../FeatherIcon';
@@ -55,7 +55,7 @@ const GuideTile = ({
           }
         `}
       >
-        <NewRelicIcon name={icon} size="2.5rem" />
+        {cloneElement(icon, { size: '2.5rem' })}
       </div>
     )}
     <div

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,6 +11,7 @@ import GuideTile from '../components/GuideTile/GuideTile';
 import PageLayout from '../components/PageLayout';
 import FeatherIcon from '../components/FeatherIcon';
 import ExternalLink from '../components/ExternalLink';
+import NewRelicIcon from '../components/NewRelicIcon';
 import { PageContext } from '../components/PageContext';
 import { pageContext } from '../types';
 import styles from './index.module.scss';
@@ -25,21 +26,21 @@ const getStartedGuides = [
     description:
       'Define, visualize, and get alerts on the data you want using custom events',
     path: '/collect-data/custom-events',
-    icon: 'collectData',
+    icon: <NewRelicIcon name="collectData" />,
   },
   {
     duration: '7 min',
     title: 'Add tags to apps',
     description: `Add tags to applications you instrument for easier filtering and organization`,
     path: '/automate-workflows/5-mins-tag-resources',
-    icon: 'automation',
+    icon: <NewRelicIcon name="automation" />,
   },
   {
     duration: '12 min',
     title: 'Build a Hello, World! app',
     description: `Build a Hello, World! app and publish it to your local New Relic One Catalog`,
     path: '/build-apps/build-hello-world-app',
-    icon: 'buildApps',
+    icon: <NewRelicIcon name="buildApps" />,
   },
 ];
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -34,7 +34,14 @@ const getStartedGuides = [
     title: 'Add tags to apps',
     description: `Add tags to applications you instrument for easier filtering and organization`,
     path: '/automate-workflows/5-mins-tag-resources',
-    icon: <NewRelicIcon name="automation" />,
+    icon: (
+      <NewRelicIcon
+        name="automation"
+        css={css`
+          stroke-width: 1;
+        `}
+      />
+    ),
   },
   {
     duration: '12 min',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -34,14 +34,7 @@ const getStartedGuides = [
     title: 'Add tags to apps',
     description: `Add tags to applications you instrument for easier filtering and organization`,
     path: '/automate-workflows/5-mins-tag-resources',
-    icon: (
-      <NewRelicIcon
-        name="automation"
-        css={css`
-          stroke-width: 1;
-        `}
-      />
-    ),
+    icon: <NewRelicIcon name="automation" />,
   },
   {
     duration: '12 min',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,6 +11,7 @@ import GuideTile from '../components/GuideTile/GuideTile';
 import PageLayout from '../components/PageLayout';
 import FeatherIcon from '../components/FeatherIcon';
 import ExternalLink from '../components/ExternalLink';
+import CollectDataIcon from '../components/CollectDataIcon';
 import NewRelicIcon from '../components/NewRelicIcon';
 import { PageContext } from '../components/PageContext';
 import { pageContext } from '../types';
@@ -26,7 +27,7 @@ const getStartedGuides = [
     description:
       'Define, visualize, and get alerts on the data you want using custom events',
     path: '/collect-data/custom-events',
-    icon: <NewRelicIcon name="collectData" />,
+    icon: <CollectDataIcon />,
   },
   {
     duration: '7 min',


### PR DESCRIPTION
Closes #642 

## Description
Updates the collect data icon on the main page to use the new icon

## Screenshot(s)

<img width="1359" alt="Screen Shot 2020-08-24 at 10 50 01 PM" src="https://user-images.githubusercontent.com/565661/91128105-6854f780-e65c-11ea-9c25-e029b5a2f274.png">
