### PR TITLE
Update countdown timer after CFP closes

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -76,24 +76,12 @@ const IndexPage = ({ data, pageContext }) => {
                 getting your hands on the software to solve problems
                 efficiently.
               </p>
-              <p>
-                Got a cool project you want to share with fellow engineers?
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href="https://docs.google.com/forms/d/e/1FAIpQLSe8LOilCrD_TCUPyHFHG_QzVW2UdUR0UKZ8H8WNylz0flB7OQ/viewform"
-                >
-                  {' '}
-                  Submit your proposal!
-                </a>{' '}
-                Submissions are due September 1, 2020 at 11:59 PM PT.
-              </p>
               <Countdown
-                targetDate="September 1 2020 23:59:59 PDT"
-                inactiveMessage="Submissions are closed"
+                targetDate="October 13 2020 9:00:00 PDT"
+                inactiveMessage="Countdown to Nerd Days"
               />
               <p>
-                <Link to="/nerd-days">Learn more</Link>
+                <Link to="/nerd-days">Register</Link>
               </p>
             </div>
             <div


### PR DESCRIPTION
## Description
Updating countdown to reflect countdown to Nerd Days and removing CFP messaging.

## Reviewer Notes
Do not merge this until Sept. 2 after call for proposals are closed. 

## Related Issue(s) / Ticket(s)
https://github.com/newrelic/developer-website/issues/704

## Screenshot(s)
If relevant, add screenshots here.
![image](https://user-images.githubusercontent.com/6426523/91909359-e3706c00-ec61-11ea-8ca8-d7c065ba7830.png)
