### PR TITLE
Right-rail A/B test on buttons

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -26,6 +26,7 @@ module.exports = {
             development: {
               features: {
                 'developer-website_global-header-gh-buttons': 'on',
+                'developer-website_right-rail-buttons': 'outline',
               },
               core: {
                 authorizationKey: process.env.SPLITIO_AUTH_KEY || 'localhost',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4122,9 +4122,9 @@
       }
     },
     "@newrelic/gatsby-theme-newrelic": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.8.1.tgz",
-      "integrity": "sha512-FrJHO1XNOiQZeS3IxWWs43wsamFfbQGH65jjs5NspJN6MNm4rmICV0WF4WQXaRG1B3WSquLvImyo8RuKXYDhnQ==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.8.2.tgz",
+      "integrity": "sha512-7u7zw/P1BF/uXLt3Y+BSmevQnYn4rwicJDaxB3aB3t3NHP4UqEGrxvjvgrDpwuH1bHYog8QpGf2MoL2cq46K2Q==",
       "requires": {
         "@elastic/react-search-ui": "^1.4.1",
         "@elastic/react-search-ui-views": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^10.0.27",
     "@mdx-js/mdx": "^1.6.16",
     "@mdx-js/react": "^1.6.16",
-    "@newrelic/gatsby-theme-newrelic": "^1.8.1",
+    "@newrelic/gatsby-theme-newrelic": "^1.8.2",
     "@splitsoftware/splitio-react": "^1.2.0",
     "classnames": "^2.2.6",
     "date-fns": "^2.15.0",

--- a/src/components/PageLayout/PageLayout.js
+++ b/src/components/PageLayout/PageLayout.js
@@ -18,7 +18,7 @@ const LAYOUTS = {
     grid-template-areas:
       'page-header page-header'
       'content related-content';
-    grid-template-columns: minmax(0, 1fr) 315px;
+    grid-template-columns: minmax(0, 1fr) 320px;
     grid-gap: 2rem;
 
     @media (max-width: 1240px) {

--- a/src/components/RelatedContentModules/Contribute.js
+++ b/src/components/RelatedContentModules/Contribute.js
@@ -5,7 +5,7 @@ import { Button, ExternalLink, Icon } from '@newrelic/gatsby-theme-newrelic';
 import { graphql, useStaticQuery } from 'gatsby';
 import useTreatment from '../../hooks/useTreatment';
 import { useTrack } from '@splitsoftware/splitio-react';
-import { SPLITS } from '../../data/constants';
+import { SPLITS, SPLIT_TRACKING_EVENTS } from '../../data/constants';
 import Section from './Section';
 
 const Contribute = ({ pageContext }) => {
@@ -19,7 +19,7 @@ const Contribute = ({ pageContext }) => {
     }
   `);
 
-  const { treatment, config } = useTreatment(SPLITS.CONTRIBUTE_BUTTONS);
+  const { config } = useTreatment(SPLITS.CONTRIBUTE_BUTTONS);
   const track = useTrack();
 
   const { fileRelativePath } = pageContext;
@@ -44,7 +44,7 @@ const Contribute = ({ pageContext }) => {
         variant={config?.issues || Button.VARIANT.NORMAL}
         size={Button.SIZE.SMALL}
         onClick={() =>
-          track('related_content.contribute_action_clicked', null, {
+          track(SPLIT_TRACKING_EVENTS.RELATED_CONTENT_ACTION_CLICKED, null, {
             action: 'issues',
           })
         }
@@ -63,7 +63,7 @@ const Contribute = ({ pageContext }) => {
         variant={config?.edit || Button.VARIANT.NORMAL}
         size={Button.SIZE.SMALL}
         onClick={() =>
-          track('related_content.contribute_action_clicked', null, {
+          track(SPLIT_TRACKING_EVENTS.RELATED_CONTENT_ACTION_CLICKED, null, {
             action: 'edit',
           })
         }

--- a/src/components/RelatedContentModules/Contribute.js
+++ b/src/components/RelatedContentModules/Contribute.js
@@ -46,7 +46,7 @@ const Contribute = ({ pageContext }) => {
         size={Button.SIZE.SMALL}
         onClick={() =>
           track('related_content.contribute_action_clicked', null, {
-            button: 'issues',
+            action: 'issues',
           })
         }
       >
@@ -66,7 +66,7 @@ const Contribute = ({ pageContext }) => {
         size={Button.SIZE.SMALL}
         onClick={() =>
           track('related_content.contribute_action_clicked', null, {
-            button: 'edit',
+            action: 'edit',
           })
         }
       >

--- a/src/components/RelatedContentModules/Contribute.js
+++ b/src/components/RelatedContentModules/Contribute.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import { Button, ExternalLink, Icon } from '@newrelic/gatsby-theme-newrelic';
 import { graphql, useStaticQuery } from 'gatsby';
+import useTreatment from '../../hooks/useTreatment';
+import { useTrack } from '@splitsoftware/splitio-react';
+import { SPLITS } from '../../data/constants';
 import Section from './Section';
 
 const Contribute = ({ pageContext }) => {
@@ -15,6 +18,9 @@ const Contribute = ({ pageContext }) => {
       }
     }
   `);
+
+  const { treatment, config } = useTreatment(SPLITS.CONTRIBUTE_BUTTONS);
+  const track = useTrack();
 
   const { fileRelativePath } = pageContext;
 
@@ -35,8 +41,14 @@ const Contribute = ({ pageContext }) => {
         css={css`
           margin-right: 0.5rem;
         `}
-        variant={Button.VARIANT.PRIMARY}
+        disabled={treatment === 'control'}
+        variant={config?.issues || Button.VARIANT.NORMAL}
         size={Button.SIZE.SMALL}
+        onClick={() =>
+          track('related_content.contribute_action_clicked', null, {
+            button: 'issues',
+          })
+        }
       >
         <Icon
           name={Icon.TYPE.GITHUB}
@@ -49,8 +61,14 @@ const Contribute = ({ pageContext }) => {
       <Button
         as={ExternalLink}
         href={`${repository}/tree/main/${fileRelativePath}`}
-        variant={Button.VARIANT.NORMAL}
+        disabled={treatment === 'control'}
+        variant={config?.edit || Button.VARIANT.NORMAL}
         size={Button.SIZE.SMALL}
+        onClick={() =>
+          track('related_content.contribute_action_clicked', null, {
+            button: 'edit',
+          })
+        }
       >
         <Icon
           name={Icon.TYPE.EDIT}

--- a/src/components/RelatedContentModules/Contribute.js
+++ b/src/components/RelatedContentModules/Contribute.js
@@ -41,7 +41,6 @@ const Contribute = ({ pageContext }) => {
         css={css`
           margin-right: 0.5rem;
         `}
-        disabled={treatment === 'control'}
         variant={config?.issues || Button.VARIANT.NORMAL}
         size={Button.SIZE.SMALL}
         onClick={() =>
@@ -61,7 +60,6 @@ const Contribute = ({ pageContext }) => {
       <Button
         as={ExternalLink}
         href={`${repository}/tree/main/${fileRelativePath}`}
-        disabled={treatment === 'control'}
         variant={config?.edit || Button.VARIANT.NORMAL}
         size={Button.SIZE.SMALL}
         onClick={() =>

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -3,3 +3,7 @@ export const githubBaseUrl = 'https://github.com/newrelic/developer-website';
 export const SPLITS = {
   CONTRIBUTE_BUTTONS: 'developer-website_right-rail-buttons',
 };
+
+export const SPLIT_TRACKING_EVENTS = {
+  RELATED_CONTENT_ACTION_CLICKED: 'related_content.contribute_action_clicked',
+};

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -1,1 +1,5 @@
 export const githubBaseUrl = 'https://github.com/newrelic/developer-website';
+
+export const SPLITS = {
+  CONTRIBUTE_BUTTONS: 'developer-website_right-rail-buttons',
+};

--- a/src/hooks/useTreatment.js
+++ b/src/hooks/useTreatment.js
@@ -1,0 +1,20 @@
+import { useMemo } from 'react';
+import { useTreatments } from '@splitsoftware/splitio-react';
+
+const useTreatment = (name) => {
+  const treatments = useTreatments([name]);
+  const { treatment, config } = treatments[name];
+
+  return {
+    treatment,
+    config: useMemo(() => {
+      try {
+        return JSON.parse(config);
+      } catch (e) {
+        return {};
+      }
+    }, [config]),
+  };
+};
+
+export default useTreatment;

--- a/src/hooks/useTreatment.js
+++ b/src/hooks/useTreatment.js
@@ -11,7 +11,7 @@ const useTreatment = (name) => {
       try {
         return JSON.parse(config);
       } catch (e) {
-        return {};
+        return config;
       }
     }, [config]),
   };


### PR DESCRIPTION
Closes #643 

## Description
Adds an A/B test for the right rail button treatment. One treatment will keep the buttons like they are and the other treatment will show the outline button variant. The buttons are tracked via the `related_content.contribute_action_clicked` event.

## Screenshot(s)

<img width="385" alt="Screen Shot 2020-09-03 at 4 07 34 PM" src="https://user-images.githubusercontent.com/565661/92182068-a2ae5980-edff-11ea-8327-9b356215568d.png">

