### PR TITLE
Announcement Banner Fixes

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -11,7 +11,10 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
 
   const result = await graphql(`
     {
-      allMdx(limit: 1000) {
+      allMdx(
+        limit: 1000
+        filter: { fileAbsolutePath: { regex: "/src/markdown-pages/" } }
+      ) {
         edges {
           node {
             fileAbsolutePath

--- a/package-lock.json
+++ b/package-lock.json
@@ -4122,9 +4122,9 @@
       }
     },
     "@newrelic/gatsby-theme-newrelic": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.9.1.tgz",
-      "integrity": "sha512-s0MAIwFVJ9CSsJLT4/gVhUHcV1+40EmFg4FFZO2bMQgjew8ywGqXBXEz2VZ8EatjEq6s143tvAjykEt0p1Rxiw==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.9.2.tgz",
+      "integrity": "sha512-zKak+HYUFUih3x+JCXRc/SchLy3BAit73I1fNaTimjMMNXuzq/djtlpYLgUiR9p/sy9KWx0V3fwsdygCJ62t+g==",
       "requires": {
         "@elastic/react-search-ui": "^1.4.1",
         "@elastic/react-search-ui-views": "^1.4.1",
@@ -5023,20 +5023,20 @@
           }
         },
         "browserslist": {
-          "version": "4.14.1",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.1.tgz",
-          "integrity": "sha512-zyBTIHydW37pnb63c7fHFXUG6EcqWOqoMdDx6cdyaDFriZ20EoVxcE95S54N+heRqY8m8IUgB5zYta/gCwSaaA==",
+          "version": "4.14.2",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.2.tgz",
+          "integrity": "sha512-HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==",
           "requires": {
-            "caniuse-lite": "^1.0.30001124",
-            "electron-to-chromium": "^1.3.562",
+            "caniuse-lite": "^1.0.30001125",
+            "electron-to-chromium": "^1.3.564",
             "escalade": "^3.0.2",
-            "node-releases": "^1.1.60"
+            "node-releases": "^1.1.61"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001124",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz",
-          "integrity": "sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA=="
+          "version": "1.0.30001125",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001125.tgz",
+          "integrity": "sha512-9f+r7BW8Qli917mU3j0fUaTweT3f3vnX/Lcs+1C73V+RADmFme+Ih0Br8vONQi3X0lseOe6ZHfsZLCA8MSjxUA=="
         },
         "core-js": {
           "version": "3.6.5",
@@ -5081,9 +5081,9 @@
           }
         },
         "gatsby-plugin-mdx": {
-          "version": "1.2.38",
-          "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.2.38.tgz",
-          "integrity": "sha512-S8tGJ2tvAgkboUW2uGFoZjMyQ4X1XESMuKaTg/Q9n3uu06HWcYVEV/+PI0pB8QMrBBVkTDNLNMy9WlMZi+JDOA==",
+          "version": "1.2.39",
+          "resolved": "https://registry.npmjs.org/gatsby-plugin-mdx/-/gatsby-plugin-mdx-1.2.39.tgz",
+          "integrity": "sha512-drfUCPLBBpjZEKSRELexqsYden2r9goR7r5GMlAmbh9gBeqKWkjxWj6fiK9R0zHauw7CBw45DvZa9D8vaMH6gQ==",
           "requires": {
             "@babel/core": "^7.10.3",
             "@babel/generator": "^7.10.3",
@@ -5140,9 +5140,9 @@
           }
         },
         "node-releases": {
-          "version": "1.1.60",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
-          "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA=="
+          "version": "1.1.61",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
+          "integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g=="
         },
         "tmp": {
           "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^10.0.27",
     "@mdx-js/mdx": "^1.6.16",
     "@mdx-js/react": "^1.6.16",
-    "@newrelic/gatsby-theme-newrelic": "^1.9.1",
+    "@newrelic/gatsby-theme-newrelic": "^1.9.2",
     "@splitsoftware/splitio-react": "^1.2.0",
     "classnames": "^2.2.6",
     "date-fns": "^2.15.0",

--- a/src/hooks/useResizeObserver.js
+++ b/src/hooks/useResizeObserver.js
@@ -1,0 +1,20 @@
+import { useLayoutEffect, useState, useRef } from 'react';
+
+const useResizeObserver = () => {
+  const ref = useRef(null);
+  const [height, setHeight] = useState(0);
+
+  const resizeObserver = new ResizeObserver((entries) => {
+    entries.forEach((entry) => {
+      setHeight(entry.contentBoxSize.blockSize);
+    });
+  });
+
+  useLayoutEffect(() => {
+    resizeObserver.observe(ref.current);
+  }, []);
+
+  return [ref, height];
+};
+
+export default useResizeObserver;

--- a/src/hooks/useResizeObserver.js
+++ b/src/hooks/useResizeObserver.js
@@ -12,7 +12,7 @@ const useResizeObserver = () => {
 
   useLayoutEffect(() => {
     resizeObserver.observe(ref.current);
-  }, []);
+  }, [resizeObserver]);
 
   return [ref, height];
 };

--- a/src/hooks/useResizeObserver.js
+++ b/src/hooks/useResizeObserver.js
@@ -4,6 +4,9 @@ const useResizeObserver = () => {
   const ref = useRef(null);
   const [height, setHeight] = useState(0);
 
+  // ResizeObserver is not available at build time
+  const ResizeObserver = global.ResizeObserver || class ResizeObserver {};
+
   const resizeObserver = new ResizeObserver((entries) => {
     entries.forEach((entry) => {
       setHeight(entry.contentBoxSize.blockSize);

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -85,7 +85,14 @@ const MainLayout = ({ children }) => {
           </script>
         ) : null}
       </Helmet>
-      <div ref={headerRef}>
+      <div
+        ref={headerRef}
+        css={css`
+          position: sticky;
+          z-index: 99;
+          top: 0;
+        `}
+      >
         <GlobalHeader editUrl={editUrl} />
       </div>
       <MobileHeader

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 
@@ -36,6 +36,8 @@ const MainLayout = ({ children }) => {
 
   const location = useLocation();
   const { fileRelativePath } = usePageContext();
+  const headerRef = useRef(null);
+  const [headerHeight, setHeaderHeight] = useState(0);
   const [cookieConsent, setCookieConsent] = useState(false);
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
   const isComponentDoc = fileRelativePath.includes(
@@ -54,10 +56,14 @@ const MainLayout = ({ children }) => {
     setIsMobileNavOpen(false);
   }, [location.pathname]);
 
+  useLayoutEffect(() => {
+    setHeaderHeight(headerRef?.current?.clientHeight || 0);
+  });
+
   return (
     <div
       css={css`
-        --global-header-height: 30px;
+        --global-header-height: ${headerHeight}px;
         --sidebar-width: 300px;
 
         min-height: 100vh;
@@ -79,7 +85,9 @@ const MainLayout = ({ children }) => {
           </script>
         ) : null}
       </Helmet>
-      <GlobalHeader editUrl={editUrl} />
+      <div ref={headerRef}>
+        <GlobalHeader editUrl={editUrl} />
+      </div>
       <MobileHeader
         css={css`
           @media (min-width: 761px) {

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -58,7 +58,7 @@ const MainLayout = ({ children }) => {
 
   useLayoutEffect(() => {
     setHeaderHeight(headerRef?.current?.clientHeight || 0);
-  });
+  }, [setHeaderHeight]);
 
   return (
     <div

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -47,6 +47,12 @@ const MainLayout = ({ children }) => {
     ? null
     : `${siteMetadata.repository}/blob/main/${fileRelativePath}`;
 
+  const resizeObserver = new ResizeObserver((entries) => {
+    entries.forEach((entry) => {
+      setHeaderHeight(entry.contentBoxSize.blockSize);
+    });
+  });
+
   useEffect(() => {
     const consentValue = Cookies.get(gdprConsentCookieName) === 'true';
     consentValue && setCookieConsent(true);

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -12,6 +12,7 @@ import Sidebar from '../components/Sidebar';
 import CookieApprovalDialog from '../components/CookieApprovalDialog';
 import '../components/styles.scss';
 import usePageContext from '../hooks/usePageContext';
+import useResizeObserver from '../hooks/useResizeObserver';
 import { useLocation } from '@reach/router';
 
 const gaTrackingId = 'UA-3047412-33';
@@ -36,8 +37,7 @@ const MainLayout = ({ children }) => {
 
   const location = useLocation();
   const { fileRelativePath } = usePageContext();
-  const headerRef = useRef(null);
-  const [headerHeight, setHeaderHeight] = useState(0);
+  const [headerRef, headerHeight] = useResizeObserver();
   const [cookieConsent, setCookieConsent] = useState(false);
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
   const isComponentDoc = fileRelativePath.includes(
@@ -47,12 +47,6 @@ const MainLayout = ({ children }) => {
     ? null
     : `${siteMetadata.repository}/blob/main/${fileRelativePath}`;
 
-  const resizeObserver = new ResizeObserver((entries) => {
-    entries.forEach((entry) => {
-      setHeaderHeight(entry.contentBoxSize.blockSize);
-    });
-  });
-
   useEffect(() => {
     const consentValue = Cookies.get(gdprConsentCookieName) === 'true';
     consentValue && setCookieConsent(true);
@@ -61,10 +55,6 @@ const MainLayout = ({ children }) => {
   useEffect(() => {
     setIsMobileNavOpen(false);
   }, [location.pathname]);
-
-  useLayoutEffect(() => {
-    setHeaderHeight(headerRef?.current?.clientHeight || 0);
-  }, [setHeaderHeight]);
 
   return (
     <div


### PR DESCRIPTION
## Description
This addresses a few issues that are specific to the developer site when it comes to using the _Announcement Banner_:
* Fixes an issue where Gatsby would try to create a new page for an announcement MDX file
* Fixes an issue where the sidebar was appearing _under_ the header when a banner was present

## Reviewer Notes
I added a hook called `useResizeObserver` that uses [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) under the hood. This may be helpful in other locations. At the moment, it's just set up to work with height, but we can make it more generalized if we want.

## Related Issue(s) / Ticket(s)
N/A

## Screenshot(s)
**With a Banner:**
![Screen Shot 2020-09-08 at 2 57 05 PM](https://user-images.githubusercontent.com/1946433/92532157-87b75d00-f1e4-11ea-9c09-e59b20e3a43d.png)

**Without a Banner:**
![Screen Shot 2020-09-08 at 2 57 15 PM](https://user-images.githubusercontent.com/1946433/92532180-969e0f80-f1e4-11ea-956a-78fcd5af702d.png)
