### PR TITLE
Add back missing styles removed from nerd days redesign

### DIFF
--- a/src/pages/nerd-days.module.scss
+++ b/src/pages/nerd-days.module.scss
@@ -1,3 +1,14 @@
+.twoColumnAlt {
+  display: grid;
+  grid-template-columns: 60% 35%;
+  grid-gap: 2rem;
+}
+
+.img {
+  width: 100%;
+  margin: 0.25rem auto;
+}
+
 .engagementOptions {
   display: inline-flex;
   list-style-type: none;


### PR DESCRIPTION
## Description

Add back missing styles preventing the 2-column layout on the nerd days pages from showing up correctly.

## Screenshots

**Before**
<img width="1391" alt="Screen Shot 2020-09-09 at 2 29 06 PM" src="https://user-images.githubusercontent.com/565661/92656992-dcbca700-f2a8-11ea-939e-86bdca031da1.png">


**After**
<img width="1441" alt="Screen Shot 2020-09-09 at 2 29 12 PM" src="https://user-images.githubusercontent.com/565661/92657035-e940ff80-f2a8-11ea-9710-6e7eff487bfa.png">
