### PR TITLE
Swap out URL

### DIFF
--- a/src/announcements/dev-portal-vote.mdx
+++ b/src/announcements/dev-portal-vote.mdx
@@ -5,4 +5,4 @@ endDate: 2020-10-02
 
 ## We are nominated for the DevPortal awards!
 
-Cast your vote [here](https://devportalawards.org/contact/voting_form)!
+Cast your vote [here](https://devportalawards.org/nominees/2020/new-relic)!


### PR DESCRIPTION
I'd prefer for us to put the nominee page, so we can show all the categories we've been nominated for. https://devportalawards.org/nominees/2020/new-relic
![image](https://user-images.githubusercontent.com/6426523/93507640-cdee7980-f8d2-11ea-9fbc-d853f96b10d0.png)
