### PR TITLE
remove custom css font properties to allow dark mode toggle to work on text

### DIFF
--- a/src/pages/nerd-days.js
+++ b/src/pages/nerd-days.js
@@ -613,9 +613,7 @@ const CtaItem = ({ date, to, children }) => (
     <span
       css={css`
         margin-top: 0.25rem;
-        font-size: 0.625rem;
-        opacity: 0.75;
-        color: #464e4e;
+        font-size: 0.9rem;
         text-transform: uppercase;
         letter-spacing: 0.5px;
       `}

--- a/src/pages/nerd-days.module.scss
+++ b/src/pages/nerd-days.module.scss
@@ -88,7 +88,6 @@
 // Responsive styles
 // ==============================================================
 @media screen and (max-width: 1200px) {
-
   .twoColumnAlt {
     display: grid;
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Description
removed custom css font properties on CtaItem to allow dark mode toggle to work correctly.
increased date font size for readability 
removed extra line from css file

## Screenshot(s)

![Screen Shot 2020-09-17 at 2 36 20 PM](https://user-images.githubusercontent.com/1395158/93525431-436a4200-f8f3-11ea-8279-884b02c9a30b.png)
