### PR TITLE
Fix marketo content blocking issue.

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -42,9 +42,11 @@ const onInitialClientRender = () => {
   }
 
   // eslint-disable-next-line no-undef
-  MktoForms2.whenRendered(function (form) {
-    destyleMktoForm(form);
-  });
+  if (window.MktoForms2) {
+    MktoForms2.whenRendered(function (form) {
+      destyleMktoForm(form);
+    });
+  }
 };
 
 const onRouteUpdate = ({ location }) => {


### PR DESCRIPTION
## Description
With Content Blocking enabled in Firefox the page vanishes in prod, and looks like this locally:
<img width="712" alt="Pasted_Image_9_18_20__1_06_PM" src="https://user-images.githubusercontent.com/51608/93641131-9e15a380-f9b0-11ea-9e7b-9d8fc846f269.png">

## Reviewer Notes
Use Firefox, enabled content blocking. Very before and after.

## Related Issue(s) / Ticket(s)
This is a JIRA for this. Not sure what it is.

## Screenshot(s)
I can't see amplify's failure, this is what it looks like for me after the fix:
<img width="950" alt="image" src="https://user-images.githubusercontent.com/51608/93641340-f5b40f00-f9b0-11ea-90ed-77dfcde4275c.png">

