### PR TITLE
Fix Firefox crash (marketo forms)

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -41,10 +41,12 @@ const onInitialClientRender = () => {
     }
   }
 
-  // eslint-disable-next-line no-undef
-  MktoForms2.whenRendered(function (form) {
-    destyleMktoForm(form);
-  });
+  if (typeof window !== 'undefined' && window.MktoForms2) {
+    // eslint-disable-next-line no-undef
+    MktoForms2.whenRendered(function (form) {
+      destyleMktoForm(form);
+    });
+  }
 };
 
 const onRouteUpdate = ({ location }) => {

--- a/src/components/MarketoForm/MarketoForm.js
+++ b/src/components/MarketoForm/MarketoForm.js
@@ -11,9 +11,9 @@ const MarketoForm = ({
   publishableKey,
   redirectLink,
 }) => {
-  useMarketoForm(munchkinId, id, publishableKey, redirectLink);
+  const loaded = useMarketoForm(munchkinId, id, publishableKey, redirectLink);
 
-  return (
+  return loaded ? (
     <div
       css={css`
         position: relative;
@@ -40,7 +40,7 @@ const MarketoForm = ({
         <form id={`mktoForm_${id}`} />
       </div>
     </div>
-  );
+  ) : null;
 };
 
 MarketoForm.propTypes = {

--- a/src/hooks/useMarketoForm.js
+++ b/src/hooks/useMarketoForm.js
@@ -1,8 +1,15 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { navigate } from 'gatsby';
 
 const useMarketoForm = (munchkinId, id, publishableKey, redirectLink) => {
+  const [loaded, setLoaded] = useState(false);
+
   useEffect(() => {
+    if (!window.MktoForms2) {
+      return;
+    }
+    setLoaded(true);
+
     window.MktoForms2.loadForm(
       '//app-abj.marketo.com',
       munchkinId,
@@ -43,6 +50,8 @@ const useMarketoForm = (munchkinId, id, publishableKey, redirectLink) => {
     };
     document.body.append(script);
   }, [munchkinId, id, publishableKey, redirectLink]);
+
+  return loaded;
 };
 
 export default useMarketoForm;


### PR DESCRIPTION
## Description
When Firefox has "Strict" content blocked enabled, the developer site would crash because the browser removed `MktoForms2` from the `window` object. This PR checks to make sure it's available (and is loaded) before adding the form to the page.

## Reviewer Notes
I initially tried to create an _ErrorBoundary_ component, but the issue was coming from `gatsby-node` initially. At some point, we should consider building in some boundaries so the site can partially function in the event of errors.

## Related Issue(s) / Ticket(s)
* Closes #774 (issue)
* Closes #775 (first-pass attempt to solve the issue, thanks @curious-attempt-bunny !)
