### PR TITLE
Fix for banners not staying dismissed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4122,9 +4122,9 @@
       }
     },
     "@newrelic/gatsby-theme-newrelic": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.9.4.tgz",
-      "integrity": "sha512-cX4VdYFZYdD7pn/MUcSbBiVpe4MPmZ7qfQaIvxrv4gkG+XcLPW92qa2Gwr9OZg9TyTtvoHkcxEKZo3TvVjqHcg==",
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.9.5.tgz",
+      "integrity": "sha512-r6KcpJav0sZ3UxJrhUDiixtjJZg4j3Heg2O7IR7YXaNajGb0lHfZe8lo8JfjyPd+s8xryD63lipqqic9PEIGZA==",
       "requires": {
         "@elastic/react-search-ui": "^1.4.1",
         "@elastic/react-search-ui-views": "^1.4.1",
@@ -5023,43 +5023,38 @@
           }
         },
         "browserslist": {
-          "version": "4.14.2",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.2.tgz",
-          "integrity": "sha512-HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==",
+          "version": "4.14.4",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.4.tgz",
+          "integrity": "sha512-7FOuawafVdEwa5Jv4nzeik/PepAjVte6HmVGHsjt2bC237jeL9QlcTBDF3PnHEvcC6uHwLGYPwZHNZMB7wWAnw==",
           "requires": {
-            "caniuse-lite": "^1.0.30001125",
-            "electron-to-chromium": "^1.3.564",
-            "escalade": "^3.0.2",
+            "caniuse-lite": "^1.0.30001135",
+            "electron-to-chromium": "^1.3.570",
+            "escalade": "^3.1.0",
             "node-releases": "^1.1.61"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001131",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001131.tgz",
-          "integrity": "sha512-4QYi6Mal4MMfQMSqGIRPGbKIbZygeN83QsWq1ixpUwvtfgAZot5BrCKzGygvZaV+CnELdTwD0S4cqUNozq7/Cw=="
+          "version": "1.0.30001135",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001135.tgz",
+          "integrity": "sha512-ziNcheTGTHlu9g34EVoHQdIu5g4foc8EsxMGC7Xkokmvw0dqNtX8BS8RgCgFBaAiSp2IdjvBxNdh0ssib28eVQ=="
         },
         "core-js": {
           "version": "3.6.5",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
           "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
         },
-        "date-fns": {
-          "version": "2.16.1",
-          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
-          "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
-        },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "electron-to-chromium": {
-          "version": "1.3.570",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.570.tgz",
-          "integrity": "sha512-Y6OCoVQgFQBP5py6A/06+yWxUZHDlNr/gNDGatjH8AZqXl8X0tE4LfjLJsXGz/JmWJz8a6K7bR1k+QzZ+k//fg=="
+          "version": "1.3.571",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.571.tgz",
+          "integrity": "sha512-UYEQ2Gtc50kqmyOmOVtj6Oqi38lm5yRJY3pLuWt6UIot0No1L09uu6Ja6/1XKwmz/p0eJFZTUZi+khd1PV1hHA=="
         },
         "escalade": {
           "version": "3.1.0",
@@ -5121,14 +5116,6 @@
             "unist-util-map": "^1.0.5",
             "unist-util-remove": "^1.0.3",
             "unist-util-visit": "^1.4.1"
-          }
-        },
-        "gatsby-plugin-newrelic": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/gatsby-plugin-newrelic/-/gatsby-plugin-newrelic-1.0.3.tgz",
-          "integrity": "sha512-2wxJ+K+DJ4Kx9wKMKq1JmA6lznG32BvReNRWfqTP5A51/OAZFmaloFggqVa5SLWzNLFiQKn28JKF4w/+YVhI4A==",
-          "requires": {
-            "@babel/runtime": "^7.0.0"
           }
         },
         "lodash": {
@@ -25666,9 +25653,9 @@
       }
     },
     "polished": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-3.6.6.tgz",
-      "integrity": "sha512-yiB2ims2DZPem0kCD6V0wnhcVGFEhNh0Iw0axNpKU+oSAgFt6yx6HxIT23Qg0WWvgS379cS35zT4AOyZZRzpQQ==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-3.6.7.tgz",
+      "integrity": "sha512-b4OViUOihwV0icb9PHmWbR+vPqaSzSAEbgLskvb7ANPATVXGiYv/TQFHQo65S53WU9i5EQ1I03YDOJW7K0bmYg==",
       "requires": {
         "@babel/runtime": "^7.9.2"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^10.0.27",
     "@mdx-js/mdx": "^1.6.16",
     "@mdx-js/react": "^1.6.16",
-    "@newrelic/gatsby-theme-newrelic": "^1.9.4",
+    "@newrelic/gatsby-theme-newrelic": "^1.9.5",
     "@splitsoftware/splitio-react": "^1.2.0",
     "classnames": "^2.2.6",
     "date-fns": "^2.16.1",


### PR DESCRIPTION
## Description
Bumps the theme to the latest version to implement a [fix](https://github.com/newrelic/gatsby-theme-newrelic/pull/111) to _AnnouncementBanner_ to help resolve an issue where banners weren't staying dismissed.

## Related Issue(s) / PR(s)
* Closes #779
* [https://github.com/newrelic/gatsby-theme-newrelic/pull/111](https://github.com/newrelic/gatsby-theme-newrelic/pull/111)
