### PR TITLE
Commit changes to related content on the main branch

### DIFF
--- a/.github/workflows/fetch-related-content.yml
+++ b/.github/workflows/fetch-related-content.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          ref: main
 
       - name: Setup node.js
         uses: actions/setup-node@v1
@@ -47,50 +49,12 @@ jobs:
           git commit -m 'chore(related-content): updated related content data'
           echo "::set-output name=commit::true"
 
-      - name: Temporarily disable "required_pull_request_reviews" branch protection
-        id: disable-branch-protection
-        if: always()
-        uses: actions/github-script@v1
-        with:
-          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
-          previews: luke-cage-preview
-          script: |
-            const result = await github.repos.updateBranchProtection({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              branch: 'develop',
-              required_status_checks: null,
-              restrictions: null,
-              enforce_admins: null,
-              required_pull_request_reviews: null
-            })
-            console.log("Result:", result)
-
+      # Push directly to `main` branch because we want updates to the related
+      # content to trigger a deploy. If we commit directly to the `develop`
+      # branch, it would require a PR from the team to deploy the changes.
       - name: Push Commit
         if: steps.commit-changes.outputs.commit == 'true'
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
-          branch: develop
-
-      - name: Re-enable "required_pull_request_reviews" branch protection
-        id: enable-branch-protection
-        if: always()
-        uses: actions/github-script@v1
-        with:
-          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
-          previews: luke-cage-preview
-          script: |
-            const result = await github.repos.updateBranchProtection({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              branch: 'develop',
-              required_status_checks: null,
-              restrictions: null,
-              enforce_admins: true,
-              required_pull_request_reviews: {
-                dismiss_stale_reviews: true,
-                required_approving_review_count: 1
-              }
-            })
-            console.log("Result:", result)
+          branch: main


### PR DESCRIPTION
## Description

Updates the GitHub action, that triggers the updates to related content, to 
commit to `main` instead of `develop`. This ensures the site is redeployed when 
these changes occur without needing a team member to open a PR from `develop` to
`main`
