### PR TITLE
Update attribute name for toggling copy button

### DIFF
--- a/COMPONENT_GUIDE.md
+++ b/COMPONENT_GUIDE.md
@@ -229,9 +229,9 @@ There are four props that can be supplied to a code snippet.
   ```
   ````
 
-- `copy`: `true` or `false`. Will display or not display the copy button, defaults to `true`
+- `copyable`: `true` or `false`. Will display or not display the copy button, defaults to `true`
   ````md
-  ```jsx copy=false
+  ```jsx copyable=false
   ```
   ````
 


### PR DESCRIPTION
Closes #853 

## Description

Updates the documentation on how to turn off the copy button. We had renamed the property from `copy` to `copyable` but forgot to update the documentation.