### PR TITLE
Remove unnecessary trailing backticks

### DIFF
--- a/src/markdown-pages/build-apps/howto-use-nrone-table-components.mdx
+++ b/src/markdown-pages/build-apps/howto-use-nrone-table-components.mdx
@@ -50,8 +50,8 @@ Clone the [nr1-how-to](https://github.com/newrelic/nr1-how-to) example applicati
 The example app lets you experiment with tables.
 
 ```sh lineNumbers=false copy=false
-git clone https://github.com/newrelic/nr1-how-to.git`
-cd nr1-how-to/create-a-table/nerdlets/create-a-table-nerdlet`
+git clone https://github.com/newrelic/nr1-how-to.git
+cd nr1-how-to/create-a-table/nerdlets/create-a-table-nerdlet
 ```
 
 </Step><Step>


### PR DESCRIPTION
## Description

Fixes a code block that has unnecessary trailing backticks in the commands