### PR TITLE
Add default branch to siteMetadata

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,6 +8,7 @@ module.exports = {
     author: 'New Relic',
     repository: 'https://github.com/newrelic/developer-website',
     siteUrl: 'https://developer.newrelic.com',
+    branch: 'develop',
   },
   plugins: [
     'gatsby-plugin-sharp',


### PR DESCRIPTION
## Description

Make sure the default branch is specified as `develop` so that the edit links point to the proper place.