### PR TITLE
chore: fixed use of old tip component

### DIFF
--- a/src/markdown-pages/apis/index.mdx
+++ b/src/markdown-pages/apis/index.mdx
@@ -40,51 +40,49 @@ different programmability use cases.
 We offer several APIs that allow you to get MELT data types (metrics, events logs, and traces) into New Relic without the use of an installed agent.
 
 <Table>
-  <table>
-    <thead>
-      <tr>
-        <th>Data Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>
-          <a href="https://docs.newrelic.com/docs/telemetry-data-platform/get-data/apis/introduction-metric-api">
-            Metric API
-          </a>
-        </td>
-        <td>
-          Send metrics to New Relic from any source (including other telemetry
-          monitoring services).
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://docs.newrelic.com/docs/telemetry-data-platform/ingest-manage-data/ingest-apis/use-event-api-report-custom-events">
-            Event API
-          </a>
-        </td>
-        <td>Send event data to New Relic.</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://docs.newrelic.com/docs/logs/log-management/log-api/introduction-log-api">
-            Log API
-          </a>
-        </td>
-        <td>Send your log data to New Relic.</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api">
-            Trace API
-          </a>
-        </td>
-        <td>Send distributed tracing data to New Relic.</td>
-      </tr>
-    </tbody>
-  </table>
+  <thead>
+    <tr>
+      <th>Data Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <a href="https://docs.newrelic.com/docs/telemetry-data-platform/get-data/apis/introduction-metric-api">
+          Metric API
+        </a>
+      </td>
+      <td>
+        Send metrics to New Relic from any source (including other telemetry
+        monitoring services).
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://docs.newrelic.com/docs/telemetry-data-platform/ingest-manage-data/ingest-apis/use-event-api-report-custom-events">
+          Event API
+        </a>
+      </td>
+      <td>Send event data to New Relic.</td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://docs.newrelic.com/docs/logs/log-management/log-api/introduction-log-api">
+          Log API
+        </a>
+      </td>
+      <td>Send your log data to New Relic.</td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api">
+          Trace API
+        </a>
+      </td>
+      <td>Send distributed tracing data to New Relic.</td>
+    </tr>
+  </tbody>
 </Table>
 
 # GraphQL API

--- a/src/markdown-pages/automate-workflows/diagnose-problems/error-alerts.mdx
+++ b/src/markdown-pages/automate-workflows/diagnose-problems/error-alerts.mdx
@@ -35,11 +35,11 @@ Log in to [New Relic One](https://one.newrelic.com) and select **APM** from the 
 
 ![Error alerts](../../../images/telco-lite/error-alerts.png)
 
-<Tip>
+<Callout variant="tip">
 
 If you don't see all the same alerts, don't worry. The simulated issues happen at regular intervals, so you should start seeing these problems in New Relic within 30 minutes to an hour.
 
-</Tip>
+</Callout>
 
 The deployment has created an alert condition for cases where a service's error percentage rises above 10% for 5 minutes or longer. A critical violation means that the service's conditions violate that threshold.
 
@@ -183,7 +183,7 @@ You also know the login service is effecting the web portal, because that is wha
 
 <Step>
 
-Visualize service dependencies using service maps. First, navigate back to **APM**, and from **Telco-Login Service**, select  **Monitor > Service map**:
+Visualize service dependencies using service maps. First, navigate back to **APM**, and from **Telco-Login Service**, select **Monitor > Service map**:
 
 ![Login service map](../../../images/telco-lite/login-service-map.png)
 

--- a/src/markdown-pages/automate-workflows/diagnose-problems/error-alerts.mdx
+++ b/src/markdown-pages/automate-workflows/diagnose-problems/error-alerts.mdx
@@ -189,11 +189,11 @@ Visualize service dependencies using service maps. First, navigate back to **APM
 
 Both **Telco-Web Portal** and **Telco-Warehouse Portal** depend on **Telco-Login Service**. So, when the login service goes down, you start seeing errors in both portals.
 
-<Tip title="Extra Credit">
+<Callout title="Extra Credit">
 
 Use the same steps you used to investigate issues in the web portal to confirm there are issues in the warehouse portal.
 
-</Tip>
+</Callout>
 
 </Step>
 

--- a/src/markdown-pages/automate-workflows/diagnose-problems/index.mdx
+++ b/src/markdown-pages/automate-workflows/diagnose-problems/index.mdx
@@ -54,7 +54,7 @@ It's time to deploy and instrument the Telco Lite services using `demo-deployer`
 
 Follow the [Deployment guide](https://github.com/newrelic/demo-deployer/tree/main/demo/README.md#deploy-your-services) in the deployer's repository for a thorough explanation of how to use the deployer in a local Docker environment. When you run the deployment script, make sure to pass the url you copied for `<demo-url>`.
 
-> NOTE: Since Telco Lite contains several services, the deployment can take over half an hour. 
+> NOTE: Since Telco Lite contains several services, the deployment can take over half an hour.
 
 When the deloyer is finished, you should see some output stating that the deployment was successful:
 
@@ -171,11 +171,11 @@ Yikes! The alerts, high response times, and red-colored indicators suggest thing
 - [Issue 1: The Warehouse Portal has abnormally high response times](diagnose-problems/high-response-times)
 - [Issue 2: Multiple services are raising error alerts](diagnose-problems/error-alerts)
 
-<Tip>
+<Callout variant="tip">
 
 Don't worry if you don't see all the same alerts. The simulator triggers issues at regular intervals, so you should start seeing these problems in New Relic within 30 minutes to an hour.
 
-</Tip>
+</Callout>
 
 ## Tear down Telco Lite
 


### PR DESCRIPTION
## Description
- fixes the use of the old tip component in a couple guides. 
- fixes the "double" table on the API index page.
