### PR TITLE
Fix failing builds

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -37,6 +37,11 @@ module.exports = {
                 authorizationKey: process.env.SPLITIO_AUTH_KEY || 'localhost',
               },
             },
+            production: {
+              core: {
+                authorizationKey: process.env.SPLITIO_AUTH_KEY || 'localhost',
+              },
+            },
           },
         },
         newrelic: {


### PR DESCRIPTION
## Descriptions
Our builds were failing once we bumped the theme to `v1.15.0`. This was because our builds expecting a `SPLITIO_AUTH_KEY` to be defined in our `gatsby-config.js`.