### PR TITLE
fix: revert bump to react-live to fix component examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-helmet": "^6.1.0",
-    "react-live": "^2.2.3",
+    "react-live": "^2.2.2",
     "react-markdown": "^5.0.0",
     "react-middle-ellipsis": "^1.1.0",
     "react-shadow": "^18.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15923,19 +15923,6 @@ react-live@^2.2.2:
     react-simple-code-editor "^0.10.0"
     unescape "^1.0.1"
 
-react-live@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/react-live/-/react-live-2.2.3.tgz#260f99194213799f0005e473e7a4154c699d6a7c"
-  integrity sha512-tpKruvfytNETuzO3o1mrQUj180GVrq35IE8F5gH1NJVPt4szYCx83/dOSCOyjgRhhc3gQvl0pQ3k/CjOjwJkKQ==
-  dependencies:
-    buble "0.19.6"
-    core-js "^2.4.1"
-    dom-iterator "^1.0.0"
-    prism-react-renderer "^1.0.1"
-    prop-types "^15.5.8"
-    react-simple-code-editor "^0.10.0"
-    unescape "^1.0.1"
-
 react-markdown@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-5.0.2.tgz#d15a8beb37b4ec34fc23dd892e7755eb7040b8db"


### PR DESCRIPTION
## Description
Fixes our component examples not rendering (i.e. [Button](developer.newrelic.com/components/button/?size=n_10_n)).

## Related Issue
* Closes #1000