### PR TITLE
Fix names of Slack and PagerDuty

### DIFF
--- a/src/markdown-pages/automate-workflows/get-started-terraform.mdx
+++ b/src/markdown-pages/automate-workflows/get-started-terraform.mdx
@@ -357,7 +357,7 @@ To finalize your golden signal alerts configuration, run `terraform apply` one l
 
 <Callout variant="tip" title="Extra Credit">
 
-`new_relic_alert_channel` [supports several types](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/alert_channel#argument-reference) of notification channels, including: email, slack, and pagerduty. So, if you want to explore this more, try creating an alert channel for a second channel type, such as Slack:
+`new_relic_alert_channel` [supports several types](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/alert_channel#argument-reference) of notification channels, including email, Slack, and PagerDuty. So, if you want to explore this more, try creating an alert channel for a second channel type, such as Slack:
 
 ```hcl
 # Slack notification channel


### PR DESCRIPTION
## Description

The page isn't using the proper capitalization for these vendors