### PR TITLE
Live chart previews on the charts guide

### DIFF
--- a/gatsby/wrap-page-element.js
+++ b/gatsby/wrap-page-element.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { BreadcrumbContext } from '../src/components/BreadcrumbContext';
 import { PageContext } from '../src/components/PageContext';
+import GlobalStyles from '../src/components/GlobalStyles';
 
 import createBreadcrumbs from '../src/utils/create-breadcrumbs';
 import pages from '../src/data/sidenav.json';
@@ -10,11 +11,14 @@ const wrapPageElement = ({ element, props }) => {
   const crumbs = createBreadcrumbs(props.path ?? '/404', pages);
 
   return (
-    <PageContext.Provider value={props.pageContext}>
-      <BreadcrumbContext.Provider value={crumbs}>
-        {element}
-      </BreadcrumbContext.Provider>
-    </PageContext.Provider>
+    <>
+      <GlobalStyles />
+      <PageContext.Provider value={props.pageContext}>
+        <BreadcrumbContext.Provider value={crumbs}>
+          {element}
+        </BreadcrumbContext.Provider>
+      </PageContext.Provider>
+    </>
   );
 };
 

--- a/src/components/GlobalStyles.js
+++ b/src/components/GlobalStyles.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Global, css } from '@emotion/core';
+
+const GlobalStyles = () => (
+  <Global
+    styles={css`
+      // hide tooltips created by the NR1 SDK charts that render outside the
+      // shadow DOM in the live previews
+      [data-tooltip-chart-id] {
+        display: none;
+      }
+    `}
+  />
+);
+
+export default GlobalStyles;

--- a/src/components/MDXContainer.js
+++ b/src/components/MDXContainer.js
@@ -6,6 +6,7 @@ import { MDXProvider } from '@mdx-js/react';
 
 import Intro from './Intro';
 import Iframe from './Iframe';
+import SDKPreview from './SDKPreview';
 import Tutorial from './Tutorial';
 import TutorialStep from './TutorialStep';
 import TutorialSection from './TutorialSection';
@@ -18,6 +19,14 @@ import {
 } from '@newrelic/gatsby-theme-newrelic';
 
 import styles from './MDXContainer.module.scss';
+
+const SDKCodeBlock = (props) => (
+  <MDXCodeBlock
+    components={{ Preview: SDKPreview }}
+    scope={window.__NR1_SDK__.default}
+    {...props}
+  />
+);
 
 const components = {
   Callout,
@@ -33,7 +42,7 @@ const components = {
   TutorialSection,
   Intro,
   iframe: Iframe,
-  code: MDXCodeBlock,
+  code: SDKCodeBlock,
   pre: (props) => props.children,
 };
 

--- a/src/components/ReferenceExample.js
+++ b/src/components/ReferenceExample.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styles from './ReferenceExample.module.scss';
-import ReferencePreview from './ReferencePreview';
+import SDKPreview from './SDKPreview';
 import { CodeBlock } from '@newrelic/gatsby-theme-newrelic';
 
 const platformStateContextMock = {
@@ -40,7 +40,7 @@ const ReferenceExample = ({
 
   const Preview = useCallback(
     ({ className }) => (
-      <ReferencePreview
+      <SDKPreview
         className={className}
         style={previewStyle}
         useToastManager={useToastManager}

--- a/src/components/SDKPreview.js
+++ b/src/components/SDKPreview.js
@@ -312,7 +312,7 @@ const EXAMPLE_CSS = `
 }
 `;
 
-const ReferencePreview = ({ className, style, useToastManager }) => {
+const SDKPreview = ({ className, style, useToastManager }) => {
   const [stylesLoaded, setStylesLoaded] = useState(false);
   const { ToastManager } = window.__NR1_SDK__;
   const { newRelicSdk } = useStaticQuery(graphql`
@@ -347,10 +347,10 @@ const ReferencePreview = ({ className, style, useToastManager }) => {
   );
 };
 
-ReferencePreview.propTypes = {
+SDKPreview.propTypes = {
   className: PropTypes.string,
   style: PropTypes.object,
   useToastManager: PropTypes.bool,
 };
 
-export default ReferencePreview;
+export default SDKPreview;

--- a/src/markdown-pages/components/charts/index.mdx
+++ b/src/markdown-pages/components/charts/index.mdx
@@ -27,7 +27,7 @@ In some cases, you want to fetch data from New Relic's database. For example, yo
 
 With your chart component, set the `accountId` and `query` props to query your New Relic data using [NRQL](https://docs.newrelic.com/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language):
 
-```jsx
+```jsx preview=true
 <LineChart accountId={1234} query="SELECT count(*) FROM Transaction" />
 ```
 
@@ -35,7 +35,7 @@ With your chart component, set the `accountId` and `query` props to query your N
 
 Alternatively, you can fetch data with a `NrqlQuery` and set the `data` prop:
 
-```jsx
+```jsx preview=true
 <NrqlQuery accountId={1234} query="SELECT count(*) FROM Transaction">
   {({ data }) => <LineChart data={data} />}
 </NrqlQuery>
@@ -54,28 +54,31 @@ Whether you use custom data sets or the results of a `NrqlQuery`, a chart's `dat
 
 For example, create a chart consisting of a line between two points by supplying two x-y coordinates in its `data` field:
 
-```jsx
-const data = [
-  {
-    metadata: {
-      id: 'series-1',
-      name: 'My series',
-      viz: 'main',
-      color: 'blue',
+```jsx preview=true
+() => {
+  const data = [
+    {
+      metadata: {
+        id: 'series-1',
+        name: 'My series',
+        viz: 'main',
+        color: 'blue',
+      },
+      data: [
+        {
+          x: 0,
+          y: 0,
+        },
+        {
+          x: 20,
+          y: 10,
+        },
+      ],
     },
-    data: [
-      {
-        x: 0,
-        y: 0,
-      },
-      {
-        x: 20,
-        y: 10,
-      },
-    ],
-  },
-];
-<LineChart data={data} />;
+  ];
+
+  return <LineChart data={data} />;
+};
 ```
 
 <br />
@@ -84,47 +87,49 @@ This `LineChart` plots a line between coordinates `(0, 0)` and `(20, 10)`. Use x
 
 Because `data` accepts an array, you can supply two series to the same chart:
 
-```jsx
-const data = [
-  {
-    metadata: {
-      id: 'series-1',
-      name: 'My series',
-      viz: 'main',
-      color: 'blue',
+```jsx preview=true
+() => {
+  const data = [
+    {
+      metadata: {
+        id: 'series-1',
+        name: 'My series',
+        viz: 'main',
+        color: 'blue',
+      },
+      data: [
+        {
+          x: 0,
+          y: 0,
+        },
+        {
+          x: 20,
+          y: 10,
+        },
+      ],
     },
-    data: [
-      {
-        x: 0,
-        y: 0,
+    {
+      metadata: {
+        id: 'series-2',
+        name: 'My second series',
+        viz: 'main',
+        color: 'red',
       },
-      {
-        x: 20,
-        y: 10,
-      },
-    ],
-  },
-  {
-    metadata: {
-      id: 'series-2',
-      name: 'My second series',
-      viz: 'main',
-      color: 'red',
+      data: [
+        {
+          x: 0,
+          y: 50,
+        },
+        {
+          x: 20,
+          y: 100,
+        },
+      ],
     },
-    data: [
-      {
-        x: 0,
-        y: 50,
-      },
-      {
-        x: 20,
-        y: 100,
-      },
-    ],
-  },
-];
+  ];
 
-<LineChart data={data} />;
+  return <LineChart data={data} />;
+};
 ```
 
 <br />
@@ -383,23 +388,25 @@ The chart plots the series's width based on `x0` and `x1` and height based on `y
 
 `JsonChart` is a special case because it processes any valid data. For example, you can set an arbitrary JSON object for the chart's `data`:
 
-```jsx
-const data = {
+```jsx preview=true
+() => {
+  const data = {
     data: [
-        {
-            id: 1,
-            name: 'Foo',
-            price: 123,
-            tags: ['Bar', 'Eek'],
-            stock: {
-                warehouse: 300,
-                retail: 20,
-            }
-        }
+      {
+        id: 1,
+        name: 'Foo',
+        price: 123,
+        tags: ['Bar', 'Eek'],
+        stock: {
+          warehouse: 300,
+          retail: 20,
+        },
+      },
     ],
-}
+  };
 
-<JsonChart data={data} />
+  return <JsonChart data={data} />;
+};
 ```
 
 </Callout>
@@ -419,7 +426,7 @@ As you've seen, you use `query` or `data` to supply data to your chart, but you 
 
 Under some circumstances, you might want to synchronize events, such as dragging or scrubbing, across multiple charts. To do this, use a `ChartGroup`. All charts in a `ChartGroup` synchronize their events:
 
-```jsx
+```jsx preview=true
 <ChartGroup>
   <Stack>
     <StackItem>


### PR DESCRIPTION
## Description

Adds the ability to render live previews of SDK components within guides. This updates the charts guide specifically to render live previews of the line charts used in the guide.

## Screenshot(s)

<img width="1920" alt="Screen Shot 2020-12-17 at 11 31 04 PM" src="https://user-images.githubusercontent.com/565661/102587054-1418cc00-40c0-11eb-8b37-f12c804893c0.png">
