### PR TITLE
update button for terraform guide

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -80,9 +80,9 @@ const IndexPage = ({ data, pageContext }) => {
               </p>
               <p>
                 <Button
-                  as={ExternalLink}
+                  as={Link}
                   variant={Button.VARIANT.PRIMARY}
-                  href="https://developer.newrelic.com/automate-workflows/get-started-terraform"
+                  to="/automate-workflows/get-started-terraform"
                 >
                   Get Started with Terraform
                 </Button>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -82,7 +82,7 @@ const IndexPage = ({ data, pageContext }) => {
                 <Button
                   as={ExternalLink}
                   variant={Button.VARIANT.PRIMARY}
-                  href="https://newrelicchangesthegame.com/"
+                  href="https://developer.newrelic.com/automate-workflows/get-started-terraform"
                 >
                   Get Started with Terraform
                 </Button>


### PR DESCRIPTION
current button directs to annemunition promotion from re:invent - need to update to the terraform guide.
