### PR TITLE
Update Theme Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^10.0.27",
     "@mdx-js/mdx": "^1.6.19",
     "@mdx-js/react": "^1.6.19",
-    "@newrelic/gatsby-theme-newrelic": "^1.16.3",
+    "@newrelic/gatsby-theme-newrelic": "^1.18.1",
     "@splitsoftware/splitio-react": "^1.2.0",
     "@xstate/react": "^1.0.2",
     "classnames": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3206,15 +3206,16 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^1.16.3":
-  version "1.16.3"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.16.3.tgz#baae6b72a42cd838beff591ee958bdacaecf0773"
-  integrity sha512-OgZkEeOwWse7DEVYaDAxVRg0PUkYPuRJlamkj6r4+jW5qz1ZnKJKAS/tmq26P/Hxz8aexRas8NnTGkGI4r1nig==
+"@newrelic/gatsby-theme-newrelic@^1.18.1":
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.18.1.tgz#beb0376b2abc663f040376c3cac2ce4cce141773"
+  integrity sha512-TG633+UxjEWWAeRNjxacthJaQgxu6WNCISX/ZKjzoJjGwYoKwe3rNifnwghJJ7J1D49mCHrvkiYY/494wRN0fg==
   dependencies:
     "@elastic/react-search-ui" "^1.4.1"
     "@elastic/react-search-ui-views" "^1.4.1"
     "@elastic/search-ui-site-search-connector" "^1.4.1"
     "@wry/equality" "^0.3.0"
+    "@xstate/react" "^1.1.0"
     babel-plugin-prismjs "^2.0.1"
     date-fns "^2.16.1"
     gatsby-plugin-emotion "^4.3.10"
@@ -3236,10 +3237,13 @@
     react-middle-ellipsis "^1.1.0"
     react-simple-code-editor "^0.11.0"
     react-spring "^8.0.27"
+    react-typist "^2.0.5"
+    react-use "^15.3.4"
     use-dark-mode "^2.3.1"
     use-media "^1.4.0"
     use-persisted-state "^0.3.0"
     warning "^4.0.3"
+    xstate "^4.15.1"
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -4211,6 +4215,14 @@
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.0.3.tgz#90cb051e54feca35f6e9ffaf8d39e0357ae35434"
   integrity sha512-uNyy2GJCT6ecme4yWNKoXQDfj1WOfDc4WD7yjpS7mwb3ST18gfkjJoCZoZGHBUBeLn9ptkt0JyKY1ZjSQacBoA==
+  dependencies:
+    use-isomorphic-layout-effect "^1.0.0"
+    use-subscription "^1.3.0"
+
+"@xstate/react@^1.1.0":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.2.2.tgz#54d32034d40384782ee11145bbbb31b841a5a464"
+  integrity sha512-pXcUtts6EaEUmquzpMZ2yhAZZLAFYxKVaaHnQ8MPWpGuby0B5QMch17Ij59+LGQACQTSE0nDqXrvvBQId6m8qQ==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
     use-subscription "^1.3.0"
@@ -20669,6 +20681,11 @@ xstate@^4.14.0:
   version "4.14.1"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.14.1.tgz#8902304944aa78ef5bdfa818ca2ca5fd109a3959"
   integrity sha512-1LyR5c6wgA41660Cp8Dq5VWRtS75l+KnjysgpgZI9FVLvYl5BF2FmkfT5CAlTIo+CKfj/4IznQYkYfURxuY6WA==
+
+xstate@^4.15.1:
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.15.2.tgz#52213ecbca7b9458ff9162c977c4944ee16891c8"
+  integrity sha512-C+3jzJbhkp9ywGB+E2YMbS4mLyuxv366+KGi2RBX6y99xZFezbrGfaPQGRvFvn58OlLlCuSfCwn6bPcp78aMyw==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## Description
This PR bumps the theme from [`v1.16.3` to `v1.18.1`](https://github.com/newrelic/gatsby-theme-newrelic/compare/v1.16.3...v1.18.1). Notable improvements include:
* `<SimpleFeedback />` component
* Terminal & Code Block improvements
* Simplified new issue flow
* Misc. adjustments / improvements