### PR TITLE
chore: added new exempt labels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,6 +5,8 @@ daysUntilClose: 10
 # Issues with these labels will never be considered stale
 exemptLabels:
   - security
+  - sustaining
+  - new guide
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
This PR adds 2 new labels to the exempt list for stale bot so that new guides and sustaining issues don't get marked as stale. 