### PR TITLE
Fixed broken link to chart components

### DIFF
--- a/src/markdown-pages/explore-docs/query-and-store-data.mdx
+++ b/src/markdown-pages/explore-docs/query-and-store-data.mdx
@@ -100,6 +100,6 @@ Similarly, a mutation can happen either way; either declaratively or imperativel
 
 - `NERD_GRAPH`: Returns the format in which it arrives from NerdGraph.
 - `RAW`: The format exposed by default in Insights and dashboards when being plotted as JSON. This format is useful if you have a pre-existing script in this format that you're willing to migrate to or incorporate with.
-- `CHART`: The format used by the charting engine that we also expose. You can find a more detailed explanation of how to manipulate this format in the [guide to chart components](/intro-to-sdk), and some examples.
+- `CHART`: The format used by the charting engine that we also expose. You can find a more detailed explanation of how to manipulate this format in the [guide to chart components](/explore-docs/intro-to-sdk), and some examples.
 
 If you are willing to push data, we currently do not expose `NrqlMutation`. To do that, see the [Event API]() for how to add custom events.


### PR DESCRIPTION
this is currently pointing to https://developer.newrelic.com/intro-to-sdk which gives a 404 and I _think_ it should point to https://developer.newrelic.com/explore-docs/intro-to-sdk right?

## Description

PR to fix a currently broken link

## Reviewer Notes

Check [query and store data page](https://developer.newrelic.com/explore-docs/query-and-store-data) and link within page `guide to chart components` points to `/intro-to-sdk` but should be `/explore-docs/intro-to-sdk`

## Use Conventional Commits

Please help the maintainers by leveraging the following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
standards in your pull request title and commit messages.

## Use `chore`

* for minor changes / additions / corrections to content.
* for minor changes / additions / corrections to images.
* for minor non-functional changes / additions to github actions, github templates, package or config updates, etc

