### PR TITLE
chore:add instruction for undeploying an app

### DIFF
--- a/src/markdown-pages/build-apps/publish-deploy.mdx
+++ b/src/markdown-pages/build-apps/publish-deploy.mdx
@@ -216,6 +216,32 @@ To deploy an application, run `nr1 nerdpack:deploy`.
 
 </Steps>
 
+## Undeploy your app
+
+Undeploying an app is detaching a Nerdpack version from a specific channel. Before undeploying, you need to unsubscribe your account from the deployed Nerdpack, then specify the UUID of the Nerdpack you've unsubscribed as the one to undeploy.
+
+<Steps>
+
+<Step>
+
+To get a list of deployed Nerdpacks that your account is subscribed to, run `nr1 subscription:list`.
+
+</Step>
+
+<Step>
+
+Copy the UUID of the Nerdpack that you want to unsubscribe and pass it to the `nerdpack-id` option of the `unsubscribe command`: `nr1 nerdpack:unsubscribe --nerdpack-id=<UUID>`. You should get a result like this: `Unsubscribed account <your account ID> from the nerdpack <Nerdpack UUID>`.
+
+</Step>
+
+<Step>
+
+Unsubscribe the Nerdpack UUID used in step 2: `nr1 nerdpack:undeploy --nerdpack-id=<UUID> -t STABLE`. You should get the result `Undeployed nerdpack <Nerdpack UUID> from the STABLE channel`.
+
+</Step>
+
+</Steps>
+
 ## Subscribe or unsubscribe apps
 
 Whether you want to subscribe accounts to an app you've created or to apps already available in the catalog, the process is the same. Note that if you subscribe to an app in the catalog, you'll automatically get any updates that are added to the app.

--- a/src/markdown-pages/build-apps/publish-deploy.mdx
+++ b/src/markdown-pages/build-apps/publish-deploy.mdx
@@ -218,7 +218,7 @@ To deploy an application, run `nr1 nerdpack:deploy`.
 
 ## Undeploy your app
 
-Undeploying an app is detaching a Nerdpack version from a specific channel. Before undeploying, you need to unsubscribe your account from the deployed Nerdpack, then specify the UUID of the Nerdpack you've unsubscribed as the one to undeploy.
+You can also manually undeploy an app. Undeploying an app is detaching a Nerdpack version from a specific channel. Before undeploying, you need to unsubscribe your account from the deployed Nerdpack, then specify the UUID of the Nerdpack you've unsubscribed as the one to undeploy.
 
 <Steps>
 
@@ -230,13 +230,24 @@ To get a list of deployed Nerdpacks that your account is subscribed to, run `nr1
 
 <Step>
 
-Copy the UUID of the Nerdpack that you want to unsubscribe and pass it to the `nerdpack-id` option of the `unsubscribe command`: `nr1 nerdpack:unsubscribe --nerdpack-id=<UUID>`. You should get a result like this: `Unsubscribed account <your account ID> from the nerdpack <Nerdpack UUID>`.
+Copy the UUID of the Nerdpack that you want to unsubscribe and pass it to the `nerdpack-id` option of the `unsubscribe command`: 
+
+```
+nr1 nerdpack:unsubscribe --nerdpack-id=<UUID>
+``` 
+You should get a result like this: `Unsubscribed account <your account ID> from the nerdpack <Nerdpack UUID>`.
 
 </Step>
 
 <Step>
 
-Unsubscribe the Nerdpack UUID used in step 2: `nr1 nerdpack:undeploy --nerdpack-id=<UUID> -t STABLE`. You should get the result `Undeployed nerdpack <Nerdpack UUID> from the STABLE channel`.
+Unsubscribe the Nerdpack UUID used in step 2: 
+
+```
+nr1 nerdpack:undeploy --nerdpack-id=<UUID> -t STABLE
+```
+
+You should get the result `Undeployed nerdpack <Nerdpack UUID> from the STABLE channel`.
 
 </Step>
 


### PR DESCRIPTION
## Description

This pull request adds a new section for showing users how to undeploying an app on New Relic.

It contains three steps:
- Get a list of subscribed deployed Nerdpacks for a New Relic account.
- Unsubscribe a particular Nerdpack ID from the account.
- Undeploy that Nerdpack ID.
