### PR TITLE
fix: typo changed "multple" to "multiple"

### DIFF
--- a/src/markdown-pages/terraform/terragrunt-configuration.mdx
+++ b/src/markdown-pages/terraform/terragrunt-configuration.mdx
@@ -3,10 +3,10 @@ path: '/terraform/terragrunt-configuration'
 duration: '30 min'
 title: 'Using Terragrunt to Manage Multiple Environments'
 template: 'GuideTemplate'
-description: 'Learn how to use [Terragrunt](https://www.terraform.io/) to manage configurations in multple environments'
+description: 'Learn how to use [Terragrunt](https://www.terraform.io/) to manage configurations in multiple environments'
 tileShorthand:
   title: 'Using Terragrunt configurations'
-  description: 'Learn how to use Terragrunt to manage configurations in multple environments'
+  description: 'Learn how to use Terragrunt to manage configurations in multiple environments'
 resources:
   - title: 'Terraform New Relic Provider'
     url: 'https://github.com/newrelic/terraform-provider-newrelic'


### PR DESCRIPTION
## Description

Fixed small typo on the terraform mini site

