### PR TITLE
chore: fix social media links in relicansData

### DIFF
--- a/src/data/relicansData.js
+++ b/src/data/relicansData.js
@@ -66,11 +66,11 @@ export const teamMembers = [
     socials: [
       {
         name: 'twitter',
-        url: 'https://twitter.com/aishacodes',
+        url: 'https://twitter.com/aishablake',
       },
       {
         name: 'twitch',
-        url: 'https://twitch.tv/aishablake',
+        url: 'https://twitch.tv/aishacodes',
       },
       {
         name: 'instagram',


### PR DESCRIPTION
## Description

Someone let me know that my social media information was incorrect on the Relicans page. Looks like my Twitter and Twitch usernames were swapped, so I've corrected them! No code changes, but you should now actually find me when you click on the Twitch and Twitter links from `/relicans`.