### PR TITLE
updated TF provider version to most current

### DIFF
--- a/src/markdown-pages/automate-workflows/get-started-terraform.mdx
+++ b/src/markdown-pages/automate-workflows/get-started-terraform.mdx
@@ -66,7 +66,7 @@ terraform {
   required_providers {
     newrelic = {
       source  = "newrelic/newrelic"
-      version = "~> 2.12"
+      version = "~> 2.21"
     }
   }
 }


### PR DESCRIPTION
This PR bumps the version in the guide to the most current of our TF provider. 