### PR TITLE
chore(podcasts): Add The Relicans Launchies and Polyglot podcast embeds

### DIFF
--- a/src/pages/podcasts.js
+++ b/src/pages/podcasts.js
@@ -1,11 +1,26 @@
-import React from 'react';
-import cx from 'classnames';
-import SEO from '../components/Seo';
 import PageLayout from '../components/PageLayout';
+import React from 'react';
+import SEO from '../components/Seo';
+import cx from 'classnames';
 import podcastsHeader from '../images/podcasts/podcasts.jpg';
 import styles from './podcasts.module.scss';
 
 const PodcastsPage = () => {
+  const podcastIds = ['1225223', '1677727', '1677670'];
+
+  const podcastEmbeds = podcastIds.map((podcastId) => {
+    return (
+      <section className={cx(styles.section, styles.player)} key={podcastId}>
+        <div>
+          <iframe
+            title="buzzsprout"
+            src={`https://www.buzzsprout.com/${podcastId}?client_source=large_player&iframe=true&referrer=https://www.buzzsprout.com/${podcastId}.js?container_id=buzzsprout-large-player-${podcastId}&player=large`}
+          />
+        </div>
+      </section>
+    );
+  });
+
   return (
     <>
       <SEO />
@@ -54,14 +69,8 @@ const PodcastsPage = () => {
               alt="podcasts header"
             />
           </section>
-          <section className={cx(styles.section, styles.player)}>
-            <div id="buzzsprout-player">
-              <iframe
-                title="buzzsprout"
-                src="https://www.buzzsprout.com/1225223?client_source=large_player&iframe=true&referrer=https://www.buzzsprout.com/1225223.js?container_id=buzzsprout-large-player-1225223&player=large"
-              />
-            </div>
-          </section>
+
+          {podcastEmbeds}
         </PageLayout.Content>
       </PageLayout>
     </>

--- a/src/pages/podcasts.js
+++ b/src/pages/podcasts.js
@@ -6,20 +6,20 @@ import podcastsHeader from '../images/podcasts/podcasts.jpg';
 import styles from './podcasts.module.scss';
 
 const PodcastsPage = () => {
-  const podcastIds = ['1225223', '1677727', '1677670'];
-
-  const podcastEmbeds = podcastIds.map((podcastId) => {
-    return (
-      <section className={cx(styles.section, styles.player)} key={podcastId}>
-        <div>
-          <iframe
-            title="buzzsprout"
-            src={`https://www.buzzsprout.com/${podcastId}?client_source=large_player&iframe=true&referrer=https://www.buzzsprout.com/${podcastId}.js?container_id=buzzsprout-large-player-${podcastId}&player=large`}
-          />
-        </div>
-      </section>
-    );
-  });
+  const podcastsMeta = [
+    {
+      id: '1225223',
+      title: 'Observy McObservface',
+    },
+    {
+      id: '1677727',
+      title: 'Polyglot',
+    },
+    {
+      id: '1677670',
+      title: 'Launchies',
+    },
+  ];
 
   return (
     <>
@@ -70,7 +70,19 @@ const PodcastsPage = () => {
             />
           </section>
 
-          {podcastEmbeds}
+          {podcastsMeta.map((podcastMeta) => {
+            return (
+              <section
+                className={cx(styles.section, styles.player)}
+                key={podcastMeta.id}
+              >
+                <iframe
+                  title={`${podcastMeta.title} podcast player`}
+                  src={`https://www.buzzsprout.com/${podcastMeta.id}?client_source=large_player&iframe=true&referrer=https://www.buzzsprout.com/${podcastMeta.id}.js?container_id=buzzsprout-large-player-${podcastMeta.id}&player=large`}
+                />
+              </section>
+            );
+          })}
         </PageLayout.Content>
       </PageLayout>
     </>


### PR DESCRIPTION
## Description

Add Buzzsprout embeds for the other Relicans Podcasts

- https://twitter.com/LaunchiesShow
- https://twitter.com/PolyglotShow

## Reviewer Notes

On the [Podcasts page](https://developer.newrelic.com/podcasts) there should now be 3 embeds. Two listed above and the original Observy McObserveface

## Screenshot(s)

<img width="1359" alt="CleanShot 2021-03-08 at 15 39 47@2x" src="https://user-images.githubusercontent.com/97928/110379234-8f857c00-8024-11eb-8ff3-0f38615ca224.png">
