### PR TITLE
Fix guide links

### DIFF
--- a/src/markdown-pages/build-apps/add-nerdgraphquery-guide.mdx
+++ b/src/markdown-pages/build-apps/add-nerdgraphquery-guide.mdx
@@ -50,7 +50,7 @@ If you've already installed the New Relic One CLI, but you can't remember your a
 
 </Callout>
 
-For additional details, see [Set up your development environment](set-up-dev-env).
+For additional details, see [Set up your development environment](/build-apps/set-up-dev-env).
 
 ## Prepare the sample code
 

--- a/src/markdown-pages/build-apps/add-time-picker-guide.mdx
+++ b/src/markdown-pages/build-apps/add-time-picker-guide.mdx
@@ -43,7 +43,7 @@ If you've already installed the New Relic One CLI, but you can't remember your a
 
 </Callout>
 
-For additional details, see [Set up your development environment](set-up-dev-env).
+For additional details, see [Set up your development environment](/build-apps/set-up-dev-env).
 
 ## Prepare the time picker sample code
 

--- a/src/markdown-pages/build-apps/build-hello-world-app.mdx
+++ b/src/markdown-pages/build-apps/build-hello-world-app.mdx
@@ -41,7 +41,7 @@ If you haven't already installed it, do the following:
 - Install [Node.js](https://nodejs.org/en/download/).
 - Complete all the steps in the [CLI quick start](https://one.newrelic.com/launcher/developer-center.launcher?pane=eyJuZXJkbGV0SWQiOiJkZXZlbG9wZXItY2VudGVyLmRldmVsb3Blci1jZW50ZXIifQ==).
 
-For additional details about setting up your environment, see [Set up your development environment](set-up-dev-env).
+For additional details about setting up your environment, see [Set up your development environment](/build-apps/set-up-dev-env).
 
 <Callout variant="tip">
 

--- a/src/markdown-pages/explore-docs/nr1-cli.mdx
+++ b/src/markdown-pages/explore-docs/nr1-cli.mdx
@@ -56,7 +56,7 @@ Use the [NR1 VS Code extension](https://marketplace.visualstudio.com/items?itemN
 
 This table provides descriptions for the New Relic One commands. For more context, including usage and option details, click any individual command or the command category.
 
-For details on user permissions, see [Authentication and permissions](/build-apps/set-up-dev-env).
+For details on user permissions, see [Authentication and permissions](/build-apps/permission-manage-apps).
 
 For more on how to serve and publish your application, see our guide on [Deploying your New Relic One app](/build-tools/new-relic-one-applications/publish-deploy).
 


### PR DESCRIPTION
## Description

Noticed a broken set-up-dev-env link

Also thinking we want to link to a different guide than is currently linked to in the nr1 cli guide (it links to the set up dev env guide for info on permissions. thinking we want the permissions guide)

## Reviewer Notes

Check out the 404 when clicking the "Set up your dev environment" link
https://developer.newrelic.com/build-apps/add-nerdgraphquery-guide

And the guide linked when clicking "Authentication and permissions"
https://developer.newrelic.com/explore-docs/nr1-cli