### PR TITLE
Update ChaelCodes' Bio.

### DIFF
--- a/src/data/relicansData.js
+++ b/src/data/relicansData.js
@@ -356,9 +356,9 @@ export const teamMembers = [
     avatar: rachaelAvatar,
     bio: (
       <p>
-        Rachael wants to share the joy and beauty of programming through programming
+        Rachael wants to share the joy and beauty of programming through·programming
         games and regular open-source streams on Twitch. She's been a professional dev
-        since 2012, 3x Team Lead, and manages an open-source repo for playing games of 
+        since 2012, 3x Team Lead, and manages an open-source repo for playing games of
         Monster of the Week. Currently, she works as a Developer Relations Engineer for New Relic.
       </p>
     ),

--- a/src/data/relicansData.js
+++ b/src/data/relicansData.js
@@ -356,9 +356,10 @@ export const teamMembers = [
     avatar: rachaelAvatar,
     bio: (
       <p>
-        Rachael's been building software and web apps since 2012. Now she builds
-        her open-source vue/rails app live on Twitch. Enough people thought that
-        was cool, so she's been invited here.
+        Rachael wants to share the joy and beauty of programming through programming
+        games and regular open-source streams on Twitch. She's been a professional dev
+        since 2012, 3x Team Lead, and manages an open-source repo for playing games of 
+        Monster of the Week. Currently, she works as a Developer Relations Engineer for New Relic.
       </p>
     ),
     socials: [

--- a/src/data/relicansData.js
+++ b/src/data/relicansData.js
@@ -356,11 +356,11 @@ export const teamMembers = [
     avatar: rachaelAvatar,
     bio: (
       <p>
-        Rachael wants to share the joy and beauty of programming
-        through programming games and regular open-source streams on Twitch.
-She's been a professional dev since 2012, 3x Team Lead, and manages 
-an open-source repo for playing games of Monster of the Week. Currently, 
-she works as a Developer Relations Engineer for New Relic.
+        Rachael wants to share the joy and beauty of programming through
+        programming games and regular open-source streams on Twitch. She's been
+        a professional dev since 2012, 3x Team Lead, and manages an open-source
+        repo for playing games of Monster of the Week. Currently, she works as a
+        Developer Relations Engineer for New Relic.
       </p>
     ),
     socials: [

--- a/src/data/relicansData.js
+++ b/src/data/relicansData.js
@@ -361,7 +361,6 @@ export const teamMembers = [
 She's been a professional dev since 2012, 3x Team Lead, and manages 
 an open-source repo for playing games of Monster of the Week. Currently, 
 she works as a Developer Relations Engineer for New Relic.
-        open-source repo for playing games of Monster of the Week. Currently,
       </p>
     ),
     socials: [

--- a/src/data/relicansData.js
+++ b/src/data/relicansData.js
@@ -358,7 +358,9 @@ export const teamMembers = [
       <p>
         Rachael wants to share the joy and beauty of programming
         through programming games and regular open-source streams on Twitch.
-        She's been a professional dev since 2012, 3x Team Lead, and manages an
+She's been a professional dev since 2012, 3x Team Lead, and manages 
+an open-source repo for playing games of Monster of the Week. Currently, 
+she works as a Developer Relations Engineer for New Relic.
         open-source repo for playing games of Monster of the Week. Currently,
         she works as a Developer Relations Engineer for New Relic.
       </p>

--- a/src/data/relicansData.js
+++ b/src/data/relicansData.js
@@ -362,7 +362,6 @@ She's been a professional dev since 2012, 3x Team Lead, and manages
 an open-source repo for playing games of Monster of the Week. Currently, 
 she works as a Developer Relations Engineer for New Relic.
         open-source repo for playing games of Monster of the Week. Currently,
-        she works as a Developer Relations Engineer for New Relic.
       </p>
     ),
     socials: [

--- a/src/data/relicansData.js
+++ b/src/data/relicansData.js
@@ -356,10 +356,11 @@ export const teamMembers = [
     avatar: rachaelAvatar,
     bio: (
       <p>
-        Rachael wants to share the joy and beauty of programming through·programming
-        games and regular open-source streams on Twitch. She's been a professional dev
-        since 2012, 3x Team Lead, and manages an open-source repo for playing games of
-        Monster of the Week. Currently, she works as a Developer Relations Engineer for New Relic.
+        Rachael wants to share the joy and beauty of programming
+        through programming games and regular open-source streams on Twitch.
+        She's been a professional dev since 2012, 3x Team Lead, and manages an
+        open-source repo for playing games of Monster of the Week. Currently,
+        she works as a Developer Relations Engineer for New Relic.
       </p>
     ),
     socials: [


### PR DESCRIPTION
## Description

Update ChaelCodes' bio. The old one was no good.

## Reviewer Notes

At `/relicans` the bio for Rachael Wright-Munn should be updated to
"Rachael wants to share the joy and beauty of programming through programming games and regular open-source streams on Twitch. She's been a professional dev since 2012, 3x Team Lead, and manages an open-source repo for playing games of Monster of the Week. Currently, she works as a Developer Relations Engineer for New Relic."