### PR TITLE
Clarify steps for publishing a custom viz

### DIFF
--- a/src/markdown-pages/build-apps/build-visualization.mdx
+++ b/src/markdown-pages/build-apps/build-visualization.mdx
@@ -203,7 +203,7 @@ When your visualization is ready to be added to a dashboard, just follow these s
 
   <Step>
 
-Open and follow the guide to [publish and deploy the Nerdpack to New Relic One and subscribe accounts to it](/build-apps/publish-deploy). Note that you must first subscribe to your new app, log out and log back in to New Relic One, before being able to view the visualization in the Custom Visualizations app itself (where you saw it running locally).
+Open and follow the guide to [publish and deploy the Nerdpack to New Relic One and subscribe accounts to it](/build-apps/publish-deploy). Note that you must stop running the Nerdpack locally and remove the nerdpacks=local query parameter, then subscribe to your new Nerdpack before being able to view the visualization in the Custom Visualizations app (where you saw it running locally).
 
   </Step>
 

--- a/src/markdown-pages/build-apps/build-visualization.mdx
+++ b/src/markdown-pages/build-apps/build-visualization.mdx
@@ -203,7 +203,7 @@ When your visualization is ready to be added to a dashboard, just follow these s
 
   <Step>
 
-Open and follow the guide to [publish and deploy the Nerdpack to New Relic One and subscribe accounts to it](/build-apps/publish-deploy).
+Open and follow the guide to [publish and deploy the Nerdpack to New Relic One and subscribe accounts to it](/build-apps/publish-deploy). Note that you must first subscribe to your new app, log out and log back in to New Relic One, before being able to view the visualization in the Custom Visualizations app itself (where you saw it running locally).
 
   </Step>
 


### PR DESCRIPTION
## Description
When you serve a nerdpack locally for a custom visualization, you can see it right away in the Custom Visualization app (Apps > custom visualizations).  When you officially publish and deploy the custom viz app you have to first subscribe to the nerdpack in the NR1 catalog, log out and log back in, before the custom viz shows up in the custom visualization app.  Myself and other colleagues overlooked this step because when you're testing, you become used to just going straight to the custom visualizations app and having to subscribe to the nerdpack first (after publish and deploy) is no longer intuitive.

## Use `chore`

* for minor changes / additions / corrections to content.
* for minor changes / additions / corrections to images.
* for minor non-functional changes / additions to github actions, github templates, package or config updates, etc

```bash
git commit -m "chore: clarify steps to access published custom visualization"
```
