### PR TITLE
chore: Fix typos/grammar errors on Nerdlog page

### DIFF
--- a/src/pages/nerdlog.js
+++ b/src/pages/nerdlog.js
@@ -71,7 +71,7 @@ const NerdlogPage = () => {
               <div>
                 <h2>What is the Nerdlog?</h2>
                 <p>
-                  The Nerdlog is our brand new live stream changelog on {'·'}
+                  The Nerdlog is our brand new live stream changelog on {'  '}
                   <a·href="https://www.twitch.tv/new_relic">Twitch</a>.
                   Every Thursday, you can:
                 </p>

--- a/src/pages/nerdlog.js
+++ b/src/pages/nerdlog.js
@@ -71,7 +71,8 @@ const NerdlogPage = () => {
               <div>
                 <h2>What is the Nerdlog?</h2>
                 <p>
-                  The Nerdlog is our brand new live stream changelog on <a href="https://www.twitch.tv/new_relic">Twitch</a>. 
+                  The Nerdlog is our brand new live stream changelog on {'·'}
+                  <a·href="https://www.twitch.tv/new_relic">Twitch</a>.
                   Every Thursday, you can:
                 </p>
                 <div>

--- a/src/pages/nerdlog.js
+++ b/src/pages/nerdlog.js
@@ -72,7 +72,7 @@ const NerdlogPage = () => {
                 <h2>What is the Nerdlog?</h2>
                 <p>
                   The Nerdlog is our brand new live stream changelog on {'  '}
-                  <a·href="https://www.twitch.tv/new_relic">Twitch</a>.
+                  <a href="https://www.twitch.tv/new_relic">Twitch</a>.
                   Every Thursday, you can:
                 </p>
                 <div>


### PR DESCRIPTION
## Description

Noticed that New Relic had a typo (`New relic`) and wanted to fix some little grammar things as well. 

## Reviewer Notes

No code changes, only content updates.