### PR TITLE
chore: updated home page for future stack

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -104,15 +104,6 @@ const IndexPage = ({ data, pageContext, location }) => {
             >
               <Video id="wyjntz5y24" type="wistia" />
             </div>
-            {/* <p>
-              <Button
-                as={Link}
-                variant={Button.VARIANT.PRIMARY}
-                to="https://web.cvent.com/event/ac440313-3922-45f5-b5b9-0812f29f4a51/summary?RefId=WEBL31&rt=DKI6UYQP806AeXIj4Q4uxw"
-              >
-                Register
-              </Button>
-            </p> */}
           </section>
 
           <section className={cx(styles.section, styles.stripedSection)}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -56,7 +56,7 @@ const IndexPage = ({ data, pageContext, location }) => {
     <PageContext.Provider value={pageContext}>
       <DevSiteSeo location={location} />
       <PageLayout type={PageLayout.TYPE.SINGLE_COLUMN}>
-        <PageLayout.Header title="Getting started with New Relic and Terraform" />
+        <PageLayout.Header title="Futurestack: Master Observability" />
 
         <PageLayout.Content>
           <section>
@@ -80,35 +80,39 @@ const IndexPage = ({ data, pageContext, location }) => {
           >
             <div className={styles.introText}>
               <p>
-                <a href="https://www.terraform.io/">Terraform</a> is a popular
-                infrastructure-as-code software tool built by HashiCorp. You use
-                it to provision all kinds of infrastructure and services,
-                including New Relic alerts.
-                <br />
-                <br />
-                In this guide, you learn how to set up New Relic alerts with
-                Terraform. More specifically, you provision an alert policy,
-                four alert conditions, and a notification channel.
+                Data Nerds, get ready to hack the future. Level Up your
+                observability game at{' '}
+                <a href="https://newrelic.com/futurestack">Futurestack</a> 2021.
               </p>
               <p>
-                <Button
-                  as={Link}
-                  variant={Button.VARIANT.PRIMARY}
-                  to="/automate-workflows/get-started-terraform"
-                >
-                  Get Started with Terraform
-                </Button>
+                Rack up your experience points with new tools, new skills, and
+                whole new ways to play with your data through Observability.
+              </p>
+              <p>
+                Connect with Nerds from across the globe to learn, share, and
+                get inspired as we reinvent the future of software — and have
+                lots of fun doing it.
               </p>
             </div>
             <div
               css={css`
                 flex: 1;
                 margin-top: 0;
+                margin-left: 50px;
                 width: 100%;
               `}
             >
-              <Video id="vifxeilp2h" type="wistia" />
+              <Video id="wyjntz5y24" type="wistia" />
             </div>
+            {/* <p>
+              <Button
+                as={Link}
+                variant={Button.VARIANT.PRIMARY}
+                to="https://web.cvent.com/event/ac440313-3922-45f5-b5b9-0812f29f4a51/summary?RefId=WEBL31&rt=DKI6UYQP806AeXIj4Q4uxw"
+              >
+                Register
+              </Button>
+            </p> */}
           </section>
 
           <section className={cx(styles.section, styles.stripedSection)}>


### PR DESCRIPTION
This PR removes the Terraform CTAs and makes the home page all about Future Stack. As a note I commented out the registration button as that's a normal pattern we use, as the banner has the CTA to register in it.