### PR TITLE
Adds the new `account-id` type

### DIFF
--- a/src/markdown-pages/build-apps/build-visualization.mdx
+++ b/src/markdown-pages/build-apps/build-visualization.mdx
@@ -94,6 +94,7 @@ The `nr1.json` file provides metadata. The `configuration` key in this metadat
 - `json`
 - `enum`: a developer-defined list of string options.
 - `nrql`: a single NRQL query string.
+- `account-id`: a New Relic account picker will be shown.
 - `namespace`: a group of input fields to be displayed together under a shared heading in the prop-editing UI.
 - `collection`: a repeatable group of input fields to be displayed together under a shared heading in the prop-editing UI. The `nrqlQueries` entry is an example of a collection type.
 

--- a/src/markdown-pages/build-apps/build-visualization.mdx
+++ b/src/markdown-pages/build-apps/build-visualization.mdx
@@ -86,17 +86,7 @@ As a result, you have a new visualization directory matching the name you gave y
 
 The files created provide an example visualization – a radar chart populated by a basic NRQL query.
 
-The `nr1.json` file provides metadata. The `configuration` key in this metadata defines the prop-input fields to be shown in the UI. These are the fields users will fill in to create an instance of the visualization. Supported input types are:
-
-- `boolean`
-- `string`
-- `number`
-- `json`
-- `enum`: a developer-defined list of string options.
-- `nrql`: a single NRQL query string.
-- `account-id`: a New Relic account picker will be shown.
-- `namespace`: a group of input fields to be displayed together under a shared heading in the prop-editing UI.
-- `collection`: a repeatable group of input fields to be displayed together under a shared heading in the prop-editing UI. The `nrqlQueries` entry is an example of a collection type.
+The `nr1.json` file provides metadata. The `configuration` key in this metadata defines the prop-input fields to be shown in the UI. To learn more about the options available under the `configuration` key, check out the [Configure your custom visualization](/explore-docs/custom-viz/configuration-options) article.
 
 The `index.js` file is where you define the React component that receives the props and renders the visualization. You can install and import any JavaScript libraries you find useful. The example component imports [Recharts](https://recharts.org), a library that wraps [D3](https://d3js.org) submodules for easy-to-compose visualizations.
 


### PR DESCRIPTION
We've got a new field type for Visualization configuration fields. The CLI supports the new field type, but the UI doesn't yet so this PR is not quite ready to merge. Just getting into place for after we update the Custom Visualizations UI.

## Description

Add a short description about the purpose of this PR here.

## Reviewer Notes

If there are links or steps needed to test this work, add them here.

## Related Issue(s) / Ticket(s)

If there are any related [GitHub Issues](https://github.com/newrelic/developer-website/issues) or JIRA tickets, add links to them here.
* [issue]()

## Screenshot(s)

If relevant, add screenshots here.

## Use Conventional Commits

Please help the maintainers by leveraging the following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
standards in your pull request title and commit messages.

## Use `chore`

* for minor changes / additions / corrections to content.
* for minor changes / additions / corrections to images.
* for minor non-functional changes / additions to github actions, github templates, package or config updates, etc

```bash
git commit -m "chore: adjusting config and content"
```

## Use `fix`

* for minor functional corrections to code.

```bash
git commit -m "fix: typo and prop error in the code of conduct"
```

## Use `feat`

* for major functional changes or additions to code.

```bash
git commit -m "feat(media): creating a video landing page"
```
