### PR TITLE
Update md links with full relative paths in AB guides

### DIFF
--- a/src/markdown-pages/build-apps/create-an-ab-test-application/catalog-info.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/catalog-info.mdx
@@ -7,9 +7,9 @@ description: 'Describe your app for the catalog'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add navigation to your nerdlet_](../navigation), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add navigation to your nerdlet_](/build-apps/ab-test/navigation), before starting this one.
 
 </Callout>
 
@@ -43,7 +43,7 @@ This creates a _catalog_ directory with template files for inputting custom info
 
 <Callout variant="tip">
 
-Read [our documentation](../../publish-deploy#add-images-and-metadata-to-your-apps) to learn more about the catalog directory.
+Read [our documentation](/build-apps/publish-deploy#add-images-and-metadata-to-your-apps) to learn more about the catalog directory.
 
 </Callout>
 
@@ -126,6 +126,6 @@ In the next lesson, you'll publish your app, submit your catalog information, an
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Publish your New Relic One application_](../publish).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Publish your New Relic One application_](/build-apps/ab-test/publish).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/chart-components-intro.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/chart-components-intro.mdx
@@ -7,9 +7,9 @@ description: 'Add chart components to your A/B test application'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Serve your New Relic One application_](../serve-app), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Serve your New Relic One application_](/build-apps/ab-test/serve-app), before starting this one.
 
 </Callout>
 
@@ -25,6 +25,6 @@ You’ll refer back to this mockup many times throughout this course. It shows y
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add your first chart_](../first-chart).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add your first chart_](/build-apps/ab-test/first-chart).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/chart-group.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/chart-group.mdx
@@ -7,9 +7,9 @@ description: 'Add a chart group'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add tables_](../table-charts), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add tables_](/build-apps/ab-test/table-charts), before starting this one.
 
 </Callout>
 
@@ -202,6 +202,6 @@ Now your application is filled with charts, but it doesn't look great. The chart
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add user interface components to your application_](../add-ui).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add user interface components to your application_](/build-apps/ab-test/add-ui).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/chart-headings.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/chart-headings.mdx
@@ -7,9 +7,9 @@ description: 'Add chart headings'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add a grid_](../grid), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add a grid_](/build-apps/ab-test/grid), before starting this one.
 
 </Callout>
 
@@ -325,6 +325,6 @@ Well done! You've created all the charts that are laid out in your design guide.
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add version descriptions_](../version-descriptions).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add version descriptions_](/build-apps/ab-test/version-descriptions).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/confirmation-modal.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/confirmation-modal.mdx
@@ -7,9 +7,9 @@ description: 'Present an end test confirmation modal'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Persist the selected version_](../persist-version), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Persist the selected version_](/build-apps/ab-test/persist-version), before starting this one.
 
 </Callout>
 
@@ -1047,6 +1047,6 @@ Congratulations! You've done a lot of work and it shows in the usefulness of you
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add NrqlQuery components to your nerdlet_](../nrql).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add NrqlQuery components to your nerdlet_](/build-apps/ab-test/nrql).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/create-nerdpack.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/create-nerdpack.mdx
@@ -35,7 +35,7 @@ ls ab-test
 
 ### Javascript files
 
-_package.json_, _package-lock.json_, and _node_modules_ are important for running your JavaScript application, but aren't unique to Nerdpacks. You can learn about these modules from JavaScript courses should you need to tweak them. For now, take a look at _nr1.json_, one of the most relevant files in this directory.
+_package.json_, _package-lock.json_, and *node_modules* are important for running your JavaScript application, but aren't unique to Nerdpacks. You can learn about these modules from JavaScript courses should you need to tweak them. For now, take a look at _nr1.json_, one of the most relevant files in this directory.
 
 ### Metadata file
 
@@ -100,9 +100,9 @@ Now, you've customized your Nerdpack, Nerdlet, and launcher with informative dis
 import React from 'react';
 
 export default class AbTestNerdletNerdlet extends React.Component {
-  render() {
-    return <h1>Hello, ab-test-nerdlet Nerdlet!</h1>;
-  }
+    render() {
+        return <h1>Hello, ab-test-nerdlet Nerdlet!</h1>;
+    }
 }
 ```
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/create-nerdpack.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/create-nerdpack.mdx
@@ -7,9 +7,9 @@ description: 'Create a Nerdpack'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Install and configure the New Relic One CLI_](../install-nr1), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Install and configure the New Relic One CLI_](/build-apps/ab-test/install-nr1), before starting this one.
 
 </Callout>
 
@@ -35,7 +35,7 @@ ls ab-test
 
 ### Javascript files
 
-_package.json_, _package-lock.json_, and *node_modules* are important for running your JavaScript application, but aren't unique to Nerdpacks. You can learn about these modules from JavaScript courses should you need to tweak them. For now, take a look at _nr1.json_, one of the most relevant files in this directory.
+_package.json_, _package-lock.json_, and _node_modules_ are important for running your JavaScript application, but aren't unique to Nerdpacks. You can learn about these modules from JavaScript courses should you need to tweak them. For now, take a look at _nr1.json_, one of the most relevant files in this directory.
 
 ### Metadata file
 
@@ -100,9 +100,9 @@ Now, you've customized your Nerdpack, Nerdlet, and launcher with informative dis
 import React from 'react';
 
 export default class AbTestNerdletNerdlet extends React.Component {
-    render() {
-        return <h1>Hello, ab-test-nerdlet Nerdlet!</h1>;
-    }
+  render() {
+    return <h1>Hello, ab-test-nerdlet Nerdlet!</h1>;
+  }
 }
 ```
 
@@ -135,6 +135,6 @@ In the next lesson, you'll learn how to serve your Nerdpack locally and see your
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Serve your New Relic One application_](../serve-app).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Serve your New Relic One application_](/build-apps/ab-test/serve-app).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/demo-setup.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/demo-setup.mdx
@@ -8,7 +8,7 @@ duration: '5 min'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 </Callout>
 
@@ -91,10 +91,10 @@ docker-compose down
 
 </Steps>
 
-Now you're ready to build your New Relic One application! The first step is to [install and configure the New Relic One CLI](../install-nr1).
+Now you're ready to build your New Relic One application! The first step is to [install and configure the New Relic One CLI](/build-apps/ab-test/install-nr1).
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Install and configure the New Relic One CLI_](../install-nr1).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Install and configure the New Relic One CLI_](/build-apps/ab-test/install-nr1).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/end-test.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/end-test.mdx
@@ -7,9 +7,9 @@ description: 'Add a section to end your test'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add version descriptions_](../version-descriptions), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add version descriptions_](/build-apps/ab-test/version-descriptions), before starting this one.
 
 </Callout>
 
@@ -259,6 +259,6 @@ However, you need to make a few improvements to this code. When you select a ver
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Persist the selected version_](../persist-version).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Persist the selected version_](/build-apps/ab-test/persist-version).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/first-chart.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/first-chart.mdx
@@ -55,34 +55,34 @@ export default class NewsletterSignups extends React.Component {
     render() {
         const versionASignups = {
             metadata: {
-              id: 'version-a-newsletter-signups',
-              name: 'Version A',
-              viz: 'main',
-              color: 'blue',
+                id: 'version-a-newsletter-signups',
+                name: 'Version A',
+                viz: 'main',
+                color: 'blue',
             },
             data: [
-              { x: 0, y: 0 },
-              { x: 10, y: 10 },
-              { x: 20, y: 15 },
-              { x: 30, y: 5 },
-              { x: 40, y: 30 },
-              { x: 50, y: 25 },
+                { x: 0, y: 0 },
+                { x: 10, y: 10 },
+                { x: 20, y: 15 },
+                { x: 30, y: 5 },
+                { x: 40, y: 30 },
+                { x: 50, y: 25 },
             ],
         }
         const versionBSignups = {
             metadata: {
-              id: 'version-b-newsletter-signups',
-              name: 'Version B',
-              viz: 'main',
-              color: 'green',
+                id: 'version-b-newsletter-signups',
+                name: 'Version B',
+                viz: 'main',
+                color: 'green',
             },
             data: [
-              { x: 0, y: 20 },
-              { x: 10, y: 5 },
-              { x: 20, y: 25 },
-              { x: 30, y: 45 },
-              { x: 40, y: 50 },
-              { x: 50, y: 35 },
+                { x: 0, y: 20 },
+                { x: 10, y: 5 },
+                { x: 20, y: 25 },
+                { x: 30, y: 45 },
+                { x: 40, y: 50 },
+                { x: 50, y: 35 },
             ],
         }
         return <LineChart data={[versionASignups, versionBSignups]} fullWidth />

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/first-chart.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/first-chart.mdx
@@ -7,9 +7,9 @@ description: 'Add your first chart'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add chart components to your A/B test application_](../add-charts), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add chart components to your A/B test application_](/build-apps/ab-test/add-charts), before starting this one.
 
 </Callout>
 
@@ -55,34 +55,34 @@ export default class NewsletterSignups extends React.Component {
     render() {
         const versionASignups = {
             metadata: {
-                id: 'version-a-newsletter-signups',
-                name: 'Version A',
-                viz: 'main',
-                color: 'blue',
+              id: 'version-a-newsletter-signups',
+              name: 'Version A',
+              viz: 'main',
+              color: 'blue',
             },
             data: [
-                { x: 0, y: 0 },
-                { x: 10, y: 10 },
-                { x: 20, y: 15 },
-                { x: 30, y: 5 },
-                { x: 40, y: 30 },
-                { x: 50, y: 25 },
+              { x: 0, y: 0 },
+              { x: 10, y: 10 },
+              { x: 20, y: 15 },
+              { x: 30, y: 5 },
+              { x: 40, y: 30 },
+              { x: 50, y: 25 },
             ],
         }
         const versionBSignups = {
             metadata: {
-                id: 'version-b-newsletter-signups',
-                name: 'Version B',
-                viz: 'main',
-                color: 'green',
+              id: 'version-b-newsletter-signups',
+              name: 'Version B',
+              viz: 'main',
+              color: 'green',
             },
             data: [
-                { x: 0, y: 20 },
-                { x: 10, y: 5 },
-                { x: 20, y: 25 },
-                { x: 30, y: 45 },
-                { x: 40, y: 50 },
-                { x: 50, y: 35 },
+              { x: 0, y: 20 },
+              { x: 10, y: 5 },
+              { x: 20, y: 25 },
+              { x: 30, y: 45 },
+              { x: 40, y: 50 },
+              { x: 50, y: 35 },
             ],
         }
         return <LineChart data={[versionASignups, versionBSignups]} fullWidth />
@@ -161,6 +161,6 @@ In seven steps, you’ve breathed life into your New Relic One application. Inst
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add pie charts_](../pie-charts).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add pie charts_](/build-apps/ab-test/pie-charts).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/grid.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/grid.mdx
@@ -7,9 +7,9 @@ description: 'Add a grid'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add user interface components to your application_](../chart-group), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add user interface components to your application_](/build-apps/ab-test/add-ui), before starting this one.
 
 </Callout>
 
@@ -133,6 +133,6 @@ In just six steps, you significantly improved the readability and usability of y
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add chart headings_](../chart-headings).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add chart headings_](/build-apps/ab-test/chart-headings).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/index.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/index.mdx
@@ -23,7 +23,7 @@ Throughout this course, you’re going to build a real-world New Relic One appli
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the first lesson: [_Spin up your demo services_](../build-apps/ab-test/demo-setup).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the first lesson: [_Spin up your demo services_](/build-apps/ab-test/demo-setup).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/install-sdk.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/install-sdk.mdx
@@ -7,9 +7,9 @@ description: 'Install and configure the New Relic One CLI'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Spin up your demo services_](../demo-setup), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Spin up your demo services_](/build-apps/ab-test/demo-setup), before starting this one.
 
 </Callout>
 
@@ -119,6 +119,6 @@ Now, you’re ready to build an application with the New Relic One CLI.
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Create a Nerdpack_](../create-nerdpack).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Create a Nerdpack_](/build-apps/ab-test/create-nerdpack).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/navigation.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/navigation.mdx
@@ -7,9 +7,9 @@ description: 'Add navigation to your Nerdlet'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add PlatformStateContext to your nerdlet_](../platform-state-context), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add PlatformStateContext to your nerdlet_](/build-apps/ab-test/platform-state-context), before starting this one.
 
 </Callout>
 
@@ -380,6 +380,6 @@ You've really accomplished a lot throughout this course, so far. There are only 
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Describe your app for the catalog_](../catalog).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Describe your app for the catalog_](/build-apps/ab-test/catalog).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/nerdstorage.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/nerdstorage.mdx
@@ -7,9 +7,9 @@ description: 'Access NerdStorage from your Nerdlet'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Customize NRQL data_](../nrql-customizations), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Customize NRQL data_](/build-apps/ab-test/nrql-customizations), before starting this one.
 
 </Callout>
 
@@ -749,6 +749,6 @@ In this lesson, you learned how to use NerdStorage to query and mutate data in y
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Access NerdStorageVault from your nerdlet_](../nerdstoragevault).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Access NerdStorageVault from your nerdlet_](/build-apps/ab-test/nerdstoragevault).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/nerdstoragevault.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/nerdstoragevault.mdx
@@ -7,9 +7,9 @@ description: 'Access NerdStorageVault from your Nerdlet'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Access NerdStorage from your nerdlet_](../nerdstorage), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Access NerdStorage from your nerdlet_](/build-apps/ab-test/nerdstorage), before starting this one.
 
 </Callout>
 
@@ -1271,6 +1271,6 @@ Whether it's been with `NrqlQuery`, `AccountStorageQuery`, `AccountStorageMutati
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Fetch data from a third-party service_](../third-party-service).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Fetch data from a third-party service_](/build-apps/ab-test/third-party-service).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/nrql-customizations.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/nrql-customizations.mdx
@@ -7,9 +7,9 @@ description: 'Customize NRQL data'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add NrqlQuery components to your nerdlet_](../nrql), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add NrqlQuery components to your nerdlet_](/build-apps/ab-test/nrql), before starting this one.
 
 </Callout>
 
@@ -469,6 +469,6 @@ Unfortunately, your demo application doesn't create custom New Relic events when
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Access NerdStorage from your nerdlet_](../nerdstorage).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Access NerdStorage from your nerdlet_](/build-apps/ab-test/nerdstorage).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/nrql.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/nrql.mdx
@@ -7,9 +7,9 @@ description: 'Add NrqlQuery components to your Nerdlet'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Present an end test confirmation modal_](../confirmation-modal), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Present an end test confirmation modal_](/build-apps/ab-test/confirmation-modal), before starting this one.
 
 </Callout>
 
@@ -38,7 +38,7 @@ const versionASignups = {
 
 A chart's `data` prop is useful for supplying manually-crafted data like this or even reformatted third-party data. But for many of your charts, you want to show real-time New Relic data. For example, **Newsletter subscriptions by version** should show subscription data, which exists in New Relic's database, NRDB for short.
 
-To query NRDB, you first need to know what data you're looking for. Remember your [demo backend service](../demo-setup)? Well, that service reports a subscription event to New Relic when a user subscribes to a newsletter from your site. You can view these subscription events in New Relic while your demo services are running.
+To query NRDB, you first need to know what data you're looking for. Remember your [demo backend service](/build-apps/ab-test/demo-setup)? Well, that service reports a subscription event to New Relic when a user subscribes to a newsletter from your site. You can view these subscription events in New Relic while your demo services are running.
 
 ## View Subscription Events in New Relic
 
@@ -440,6 +440,6 @@ You have to handle these differently than you did for the charts you've been dea
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Customize NRQL data_](../nrql-customizations).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Customize NRQL data_](/build-apps/ab-test/nrql-customizations).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/persist-selected-version.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/persist-selected-version.mdx
@@ -7,9 +7,9 @@ description: 'Persist the selected version'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add a section to end your test_](../end-test), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add a section to end your test_](/build-apps/ab-test/end-test), before starting this one.
 
 </Callout>
 
@@ -489,6 +489,6 @@ Voila! When you select a new version as the winner of the A/B test, that version
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Present an end test confirmation modal_](../confirmation-modal).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Present an end test confirmation modal_](/build-apps/ab-test/confirmation-modal).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/pie-charts.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/pie-charts.mdx
@@ -7,9 +7,9 @@ description: 'Add pie charts'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add your first chart_](../first-chart), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add your first chart_](/build-apps/ab-test/first-chart), before starting this one.
 
 </Callout>
 
@@ -196,6 +196,6 @@ Your application is starting to take shape. You’ve created a line chart and tw
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add tables_](../table-charts).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add tables_](/build-apps/ab-test/table-charts).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/platform-state-context.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/platform-state-context.mdx
@@ -7,9 +7,9 @@ description: 'Add PlatformStateContext to your Nerdlet'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Fetch data from a third-party service_](../third-party-service), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Fetch data from a third-party service_](/build-apps/ab-test/third-party-service), before starting this one.
 
 </Callout>
 
@@ -299,6 +299,6 @@ The Platform API components offer a lot more functionality, too, including the a
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add navigation to your nerdlet_](../navigation).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add navigation to your nerdlet_](/build-apps/ab-test/navigation).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/publish.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/publish.mdx
@@ -7,9 +7,9 @@ description: 'Publish your New Relic One application'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Describe your app for the catalog_](../catalog), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Describe your app for the catalog_](/build-apps/ab-test/catalog), before starting this one.
 
 </Callout>
 
@@ -94,8 +94,8 @@ In _package.json_, set `version` to `1.0.0`:
         "react-dom": "^16.6.3"
     },
     "browserslist": [
-        "last 2 versions",
-        "not ie < 11",
+        "last 2 versions", 
+        "not ie < 11", 
         "not dead"
     ]
 }
@@ -317,6 +317,6 @@ Now that your app is published and its metadata is submitted, you can subscribe 
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Subscribe to your New Relic One application_](../subscribe).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Subscribe to your New Relic One application_](/build-apps/ab-test/subscribe).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/publish.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/publish.mdx
@@ -94,8 +94,8 @@ In _package.json_, set `version` to `1.0.0`:
         "react-dom": "^16.6.3"
     },
     "browserslist": [
-        "last 2 versions", 
-        "not ie < 11", 
+        "last 2 versions",
+        "not ie < 11",
         "not dead"
     ]
 }

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/serve-app.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/serve-app.mdx
@@ -7,9 +7,9 @@ description: 'Locally serve your New Relic One application'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Create a Nerdpack_](../create-nerdpack), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Create a Nerdpack_](/build-apps/ab-test/create-nerdpack), before starting this one.
 
 </Callout>
 
@@ -76,9 +76,9 @@ Notice, in the command's output, that the server reloads when you change files i
 import React from 'react';
 
 export default class AbTestNerdletNerdlet extends React.Component {
-    render() {
-        return <h1>A/B test results</h1>;
-    }
+  render() {
+    return <h1>A/B test results</h1>;
+  }
 }
 ```
 
@@ -88,6 +88,6 @@ Your app automatically refreshes to show the new heading:
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add chart components to your A/B test application_](../add-charts).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add chart components to your A/B test application_](/build-apps/ab-test/add-charts).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/serve-app.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/serve-app.mdx
@@ -76,9 +76,9 @@ Notice, in the command's output, that the server reloads when you change files i
 import React from 'react';
 
 export default class AbTestNerdletNerdlet extends React.Component {
-  render() {
-    return <h1>A/B test results</h1>;
-  }
+    render() {
+        return <h1>A/B test results</h1>;
+    }
 }
 ```
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/subscribe.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/subscribe.mdx
@@ -7,9 +7,9 @@ description: 'Subscribe to your New Relic One application'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Publish your New Relic One application_](../publish), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Publish your New Relic One application_](/build-apps/ab-test/publish), before starting this one.
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/table-charts.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/table-charts.mdx
@@ -7,9 +7,9 @@ description: 'Add tables'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add pie charts_](../pie-charts), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add pie charts_](/build-apps/ab-test/pie-charts), before starting this one.
 
 </Callout>
 
@@ -52,9 +52,9 @@ import React from 'react';
 import { TableChart } from 'nr1';
 
 export default class VersionTotals extends React.Component {
-    constructor(props) {
-        super(props);
-    }
+  constructor(props) {
+    super(props);
+  }
 
     render() {
         const versionATotals = {
@@ -99,12 +99,12 @@ import VersionTotals from './totals';
 export default class AbTestNerdletNerdlet extends React.Component {
     render() {
         return <div>
-            <NewsletterSignups />
-            <TotalSubscriptions />
-            <TotalCancellations />
-            <VersionTotals version='a' />
-            <VersionTotals version='b' />
-        </div>
+              <NewsletterSignups />
+              <TotalSubscriptions />
+              <TotalCancellations />
+              <VersionTotals version='a' />
+              <VersionTotals version='b' />
+          </div>
     }
 }
 ```
@@ -172,6 +172,6 @@ Each chart you’ll add to your application throughout this course is unique in 
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add a chart group_](../chart-group).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add a chart group_](/build-apps/ab-test/chart-group).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/table-charts.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/table-charts.mdx
@@ -52,9 +52,9 @@ import React from 'react';
 import { TableChart } from 'nr1';
 
 export default class VersionTotals extends React.Component {
-  constructor(props) {
-    super(props);
-  }
+    constructor(props) {
+        super(props);
+    }
 
     render() {
         const versionATotals = {
@@ -99,12 +99,12 @@ import VersionTotals from './totals';
 export default class AbTestNerdletNerdlet extends React.Component {
     render() {
         return <div>
-              <NewsletterSignups />
-              <TotalSubscriptions />
-              <TotalCancellations />
-              <VersionTotals version='a' />
-              <VersionTotals version='b' />
-          </div>
+            <NewsletterSignups />
+            <TotalSubscriptions />
+            <TotalCancellations />
+            <VersionTotals version='a' />
+            <VersionTotals version='b' />
+        </div>
     }
 }
 ```

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/third-party-service.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/third-party-service.mdx
@@ -7,9 +7,9 @@ description: 'Fetch data from a third-party service'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Access NerdStorageVault from your nerdlet_](../nerdstoragevault), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Access NerdStorageVault from your nerdlet_](/build-apps/ab-test/nerdstoragevault), before starting this one.
 
 </Callout>
 
@@ -193,6 +193,6 @@ From here, there is only one more set of APIs in the New Relic One SDK that you'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add PlatformStateContext to your nerdlet_](../platform-state-context).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add PlatformStateContext to your nerdlet_](/build-apps/ab-test/platform-state-context).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/user-interface-components-intro.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/user-interface-components-intro.mdx
@@ -7,9 +7,9 @@ description: 'Add user interface components to your application'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add a chart group_](../chart-group), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add a chart group_](/build-apps/ab-test/chart-group), before starting this one.
 
 </Callout>
 
@@ -23,6 +23,6 @@ In the next lesson, you arrange your charts to look like they do in your design 
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add a grid_](../grid).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add a grid_](/build-apps/ab-test/grid).
 
 </Callout>

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/version-descriptions.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/version-descriptions.mdx
@@ -7,9 +7,9 @@ description: 'Add version descriptions'
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](../../../ab-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add chart headings_](../chart-headings), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add chart headings_](/build-apps/ab-test/chart-headings), before starting this one.
 
 </Callout>
 
@@ -174,6 +174,6 @@ Now, you've added descriptions for your competing designs and your charts. In th
 
 <Callout variant="tip" title="Course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add a section to end your test_](../end-test).
+This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add a section to end your test_](/build-apps/ab-test/end-test).
 
 </Callout>


### PR DESCRIPTION
## Description

Currently certain relative links are not working in embedded pages of the dev site. It seems like this has to do with the way the paths for the links were set up, though I don't actually know what about the `/embed` pages breaks this. It does seem however that supplying the full relative path works. This is also how we generally add links on the site so most pages should be okay. 

## Reviewer Notes

Check out one of the AB test app guides at the /embed url. Try following one of the first couple links. You should find that it links back to the site

## Related Issue(s) / Ticket(s)

Closes https://github.com/newrelic/developer-website/issues/1227

