### PR TITLE
chore: bump theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^10.0.27",
     "@mdx-js/mdx": "^1.6.19",
     "@mdx-js/react": "^1.6.19",
-    "@newrelic/gatsby-theme-newrelic": "^1.36.0",
+    "@newrelic/gatsby-theme-newrelic": "^1.38.0",
     "@splitsoftware/splitio-react": "^1.2.0",
     "@xstate/react": "^1.0.2",
     "classnames": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2515,15 +2515,15 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^1.36.0":
-  version "1.36.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.36.0.tgz#c31e268543db00bd1f1b982087da56d24e4d1d75"
-  integrity sha512-wT3TkzuY70hbS5GkTlwpgI93inqWZbj1iHlbrGfE9hWGnAt8AWh1uds7RqXiWX9RsgNA1btagxI+0RUcoXrawQ==
+"@newrelic/gatsby-theme-newrelic@^1.38.0":
+  version "1.38.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-1.38.0.tgz#78a557e54396cfd857a30923077ed4c9c8d82a09"
+  integrity sha512-Pr+94Kjub0SjLR1ku+KtdZidnQDD6InF739EPyinL1pV0B98JsBnxO9Blw098BpN4PtRdx0hinRZArsyHtsgqQ==
   dependencies:
     "@elastic/react-search-ui" "^1.4.1"
     "@elastic/react-search-ui-views" "^1.4.1"
     "@elastic/search-ui-site-search-connector" "^1.4.1"
-    "@wry/equality" "^0.3.0"
+    "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.1.0"
     babel-plugin-prismjs "^2.0.1"
     date-fns "^2.16.1"
@@ -3549,12 +3549,12 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@wry/equality@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.3.0.tgz#4b022a0907f01f32c07a1a665d9430155a59ea06"
-  integrity sha512-DRDAu/e3oWBj826OWNV/GCmSdHD248mASXImgNoLE/3SDvpgb+k6G/+TAmdpIB35ju264+kB22Rx92eXg52DnA==
+"@wry/equality@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.4.0.tgz#474491869a8d0590f4a33fd2a4850a77a0f63408"
+  integrity sha512-DxN/uawWfhRbgYE55zVCPOoe+jvsQ4m7PT1Wlxjyb/LCCLuU1UsucV2BbCxFAX8bjcSueFBbB5Qfj1Zfe8e7Fw==
   dependencies:
-    tslib "^1.9.3"
+    tslib "^2.1.0"
 
 "@xobotyi/scrollbar-width@1.9.5":
   version "1.9.5"
@@ -18749,6 +18749,11 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
   integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
+
+tslib@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
This PR bumps the theme which removes UTM params from the sign up button clicks, which `should` resolve some analytics problems.