### PR TITLE
Adjust resource URL path in serve.mdx

### DIFF
--- a/src/markdown-pages/build-apps/serve-publish-subscribe/serve.mdx
+++ b/src/markdown-pages/build-apps/serve-publish-subscribe/serve.mdx
@@ -9,7 +9,7 @@ tileShorthand:
   description: 'Serve your Nerdpack locally'
 resources:
   - title: 'nr1 nerdpack:serve'
-    url: ../../../explore-docs/nr1-nerdpack#nr1-nerdpackserve
+    url: /explore-docs/nr1-nerdpack#nr1-nerdpackserve
   - title: 'Create a "Hello, World!" application'
     url: /build-apps/build-hello-world-app
 tags:


### PR DESCRIPTION
## Description

The related resources job failed when it came across this url, changing it to the format we've been using

## Reviewer Notes

Make sure the nerdpack serve related resource still links to its page from the `/build-apps/publish-deploy/serve` guide