### PR TITLE
[Related Resources] Update Swiftype query to only get results for specific sites

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -58,7 +58,7 @@ module.exports = {
                 },
                 filters: {
                   page: {
-                    type: ['!blog', '!forum'],
+                    type: ['docs', 'developer', 'opensource'],
                     document_type: [
                       '!views_page_menu',
                       '!term_page_api_menu',


### PR DESCRIPTION
## Description

Updates the swiftype query filter on `type` to explicitly set which sites to get results from. This reduces noise from some of the site indexes and also avoids accidentally pulling in records for translated pages like `type: docs-jp`.

## Related issues
Closes https://github.com/newrelic/developer-website/issues/1264
