### PR TITLE
chore: Use new course callout

### DIFF
--- a/COMPONENT_GUIDE.md
+++ b/COMPONENT_GUIDE.md
@@ -361,7 +361,7 @@ In this case, `Tutorial` will show _first-file.js_, but it won't indicate that t
 
 ### Usage
 
-You can use the `HideWhenEmbedded` component to hide content displayed for an embedded page. 
+You can use the `HideWhenEmbedded` component to hide content displayed for an embedded page.
 
 When the page is not embedded, the content is displayed as normal.
 
@@ -372,7 +372,7 @@ You can hide any content with this component, including other components. This a
 ```md
 ## Hidden Embed
 <HideWhenEmbedded>
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -386,7 +386,7 @@ Other text ...
 ### VS.
 
 ## Normal Embed
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/catalog-info.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/catalog-info.mdx
@@ -8,7 +8,7 @@ duration: '5 min'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -129,7 +129,7 @@ In the next lesson, you'll publish your app, submit your catalog information, an
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Publish your New Relic One application_](/build-apps/ab-test/publish).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/chart-components-intro.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/chart-components-intro.mdx
@@ -7,7 +7,7 @@ description: 'Add chart components to your A/B test application'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -29,7 +29,7 @@ You’ll refer back to this mockup many times throughout this course. It shows y
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add your first chart_](/build-apps/ab-test/first-chart).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/chart-group.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/chart-group.mdx
@@ -7,7 +7,7 @@ description: 'Add a chart group'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -206,7 +206,7 @@ Now your application is filled with charts, but it doesn't look great. The chart
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add user interface components to your application_](/build-apps/ab-test/add-ui).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/chart-headings.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/chart-headings.mdx
@@ -7,7 +7,7 @@ description: 'Add chart headings'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -329,7 +329,7 @@ Well done! You've created all the charts that are laid out in your design guide.
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add version descriptions_](/build-apps/ab-test/version-descriptions).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/confirmation-modal.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/confirmation-modal.mdx
@@ -7,7 +7,7 @@ description: 'Present an end test confirmation modal'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -1051,7 +1051,7 @@ Congratulations! You've done a lot of work and it shows in the usefulness of you
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add NrqlQuery components to your nerdlet_](/build-apps/ab-test/nrql).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/create-nerdpack.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/create-nerdpack.mdx
@@ -7,7 +7,7 @@ description: 'Create a Nerdpack'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -139,7 +139,7 @@ In the next lesson, you'll learn how to serve your Nerdpack locally and see your
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Serve your New Relic One application_](/build-apps/ab-test/serve-app).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/demo-setup.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/demo-setup.mdx
@@ -8,7 +8,7 @@ duration: '5 min'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -99,7 +99,7 @@ Now you're ready to build your New Relic One application!
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Install and configure the New Relic One CLI_](/build-apps/ab-test/install-nr1).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/end-test.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/end-test.mdx
@@ -7,7 +7,7 @@ description: 'Add a section to end your test'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -263,7 +263,7 @@ However, you need to make a few improvements to this code. When you select a ver
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Persist the selected version_](/build-apps/ab-test/persist-version).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/first-chart.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/first-chart.mdx
@@ -7,7 +7,7 @@ description: 'Add your first chart'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -165,7 +165,7 @@ In seven steps, you’ve breathed life into your New Relic One application. Inst
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add pie charts_](/build-apps/ab-test/pie-charts).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/grid.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/grid.mdx
@@ -7,7 +7,7 @@ description: 'Add a grid'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -137,7 +137,7 @@ In just six steps, you significantly improved the readability and usability of y
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add chart headings_](/build-apps/ab-test/chart-headings).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/index.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/index.mdx
@@ -21,7 +21,7 @@ With custom React code, SDK components, and the wide world of open source librar
 
 Throughout this course, you’re going to build a real-world New Relic One application for running and managing A/B tests. You’ll visualize Browser data for your competing designs, see historical data from past tests, and even choose a winning design and end the test, all from your New Relic One application! But before you get into the weeds of building charts and making http requests, you need to learn what New Relic One applications are made of.
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the first lesson: [_Spin up your demo services_](/build-apps/ab-test/demo-setup).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/install-sdk.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/install-sdk.mdx
@@ -7,7 +7,7 @@ description: 'Install and configure the New Relic One CLI'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -123,7 +123,7 @@ Now, you’re ready to build an application with the New Relic One CLI.
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Create a Nerdpack_](/build-apps/ab-test/create-nerdpack).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/navigation.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/navigation.mdx
@@ -8,7 +8,7 @@ duration: '10 min'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -431,7 +431,7 @@ You've really accomplished a lot throughout this course, so far. There are only 
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Describe your app for the catalog_](/build-apps/ab-test/catalog).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/nerdstorage.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/nerdstorage.mdx
@@ -7,7 +7,7 @@ description: 'Access NerdStorage from your Nerdlet'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -763,7 +763,7 @@ In this lesson, you learned how to use NerdStorage to query and mutate data in y
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Access NerdStorageVault from your nerdlet_](/build-apps/ab-test/nerdstoragevault).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/nerdstoragevault.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/nerdstoragevault.mdx
@@ -7,7 +7,7 @@ description: 'Access NerdStorageVault from your Nerdlet'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -1298,7 +1298,7 @@ Whether it's been with `NrqlQuery`, `AccountStorageQuery`, `AccountStorageMutati
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Fetch data from a third-party service_](/build-apps/ab-test/third-party-service).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/nrql-customizations.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/nrql-customizations.mdx
@@ -7,7 +7,7 @@ description: 'Customize NRQL data'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -497,7 +497,7 @@ Unfortunately, your demo application doesn't create custom New Relic events when
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Access NerdStorage from your nerdlet_](/build-apps/ab-test/nerdstorage).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/nrql.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/nrql.mdx
@@ -7,7 +7,7 @@ description: 'Add NrqlQuery components to your Nerdlet'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -480,7 +480,7 @@ You have to handle these differently than you did for the charts you've been dea
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Customize NRQL data_](/build-apps/ab-test/nrql-customizations).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/persist-selected-version.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/persist-selected-version.mdx
@@ -7,7 +7,7 @@ description: 'Persist the selected version'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -493,7 +493,7 @@ Voila! When you select a new version as the winner of the A/B test, that version
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Present an end test confirmation modal_](/build-apps/ab-test/confirmation-modal).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/pie-charts.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/pie-charts.mdx
@@ -7,7 +7,7 @@ description: 'Add pie charts'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -199,7 +199,7 @@ Your application is starting to take shape. You’ve created a line chart and tw
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add tables_](/build-apps/ab-test/table-charts).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/platform-state-context.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/platform-state-context.mdx
@@ -8,7 +8,7 @@ duration: '10 min'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -304,7 +304,7 @@ The Platform API components offer a lot more functionality, too, including the a
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add navigation to your nerdlet_](/build-apps/ab-test/navigation).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/publish.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/publish.mdx
@@ -7,7 +7,7 @@ description: 'Publish your New Relic One application'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -327,7 +327,7 @@ Now that your app is published and its metadata is submitted, you can subscribe 
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Subscribe to your New Relic One application_](/build-apps/ab-test/subscribe).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/serve-app.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/serve-app.mdx
@@ -7,7 +7,7 @@ description: 'Locally serve your New Relic One application'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -92,7 +92,7 @@ Your app automatically refreshes to show the new heading:
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add chart components to your A/B test application_](/build-apps/ab-test/add-charts).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/subscribe.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/subscribe.mdx
@@ -7,7 +7,7 @@ description: 'Subscribe to your New Relic One application'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -139,7 +139,7 @@ Now that you know how to build a New Relic One application, you can read the SDK
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is the final part of a course that teaches you how to build a New Relic One application from the ground up. Congratulations on making it to the end!
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/table-charts.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/table-charts.mdx
@@ -7,7 +7,7 @@ description: 'Add tables'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -176,7 +176,7 @@ Each chart you’ll add to your application throughout this course is unique in 
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add a chart group_](/build-apps/ab-test/chart-group).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/third-party-service.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/third-party-service.mdx
@@ -7,7 +7,7 @@ description: 'Fetch data from a third-party service'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -208,7 +208,7 @@ From here, there is only one more set of APIs in the New Relic One SDK that you'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add PlatformStateContext to your nerdlet_](/build-apps/ab-test/platform-state-context).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/user-interface-components-intro.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/user-interface-components-intro.mdx
@@ -7,7 +7,7 @@ description: 'Add user interface components to your application'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -27,7 +27,7 @@ In the next lesson, you arrange your charts to look like they do in your design 
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add a grid_](/build-apps/ab-test/grid).
 

--- a/src/markdown-pages/build-apps/create-an-ab-test-application/version-descriptions.mdx
+++ b/src/markdown-pages/build-apps/create-an-ab-test-application/version-descriptions.mdx
@@ -7,7 +7,7 @@ description: 'Add version descriptions'
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
@@ -178,7 +178,7 @@ Now, you've added descriptions for your competing designs and your charts. In th
 
 <HideWhenEmbedded>
 
-<Callout variant="tip" title="Course">
+<Callout variant="course">
 
 This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add a section to end your test_](/build-apps/ab-test/end-test).
 


### PR DESCRIPTION
## Description

Use the new "course" callouts instead of tips.

## Reviewer Notes

Here's what it looks like:

<img width="856" alt="Screen Shot 2021-04-21 at 5 26 07 PM" src="https://user-images.githubusercontent.com/8672090/115623319-091cb500-a2c7-11eb-8069-18559c381c4b.png">