### PR TITLE
chore: Fix broken callout

### DIFF
--- a/src/markdown-pages/automate-workflows/diagnose-problems/error-alerts.mdx
+++ b/src/markdown-pages/automate-workflows/diagnose-problems/error-alerts.mdx
@@ -191,7 +191,7 @@ Visualize service dependencies using service maps. First, navigate back to **APM
 
 Both **Telco-Web Portal** and **Telco-Warehouse Portal** depend on **Telco-Login Service**. So, when the login service goes down, you start seeing errors in both portals.
 
-<Callout title="Extra Credit">
+<Callout variant="tip" title="Extra Credit">
 
 Use the same steps you used to investigate issues in the web portal to confirm there are issues in the warehouse portal.
 


### PR DESCRIPTION
## Description

This callout didn't have a `variant`.
