### PR TITLE
Fix an incorrect resource link. Use absolute URLs instead of relative

### DIFF
--- a/src/markdown-pages/explore-docs/custom-viz.mdx
+++ b/src/markdown-pages/explore-docs/custom-viz.mdx
@@ -42,7 +42,7 @@ With the New Relic One SDK, you can create a Nerdpack, which houses your visuali
 
 ### Your first visualization
 
-To build your first custom visualization, [install the New Relic One SDK](../../automate-workflows/get-started-new-relic-cli) and make sure you have the latest version:
+To build your first custom visualization, [install the New Relic One SDK](/automate-workflows/get-started-new-relic-cli) and make sure you have the latest version:
 
 ```sh
 nr1 update
@@ -82,8 +82,8 @@ Enter values into the fields under **Configure visualization properties** and se
 
 Here is a list of resources for building custom visualizations:
 
-- [Build a custom visualization for dashboards **(Guide)**](../../build-apps//build-visualization)
-- [Custom visualizations and the New Relic One SDK **(Guide)**](../../build-apps/custom-visualizations-and-the-new-relic-one-sdk)
+- [Build a custom visualization for dashboards **(Guide)**](/build-apps/build-visualization)
+- [Custom visualizations and the New Relic One SDK **(Guide)**](/build-apps/custom-visualizations-and-the-new-relic-one-sdk)
 - [Dashboards and Custom Visualizations **(Video)**](https://www.youtube.com/watch?v=_F61mxtKfGA)
 
 ## Customize your visualization
@@ -97,7 +97,7 @@ You have a lot of control over how your visualization operates. You can choose w
 Here is a list of resources for configuring custom visualizations:
 
 - [Configuration options **(Documentation)**](configuration-options)
-- [Customize visualizations with configuration **(Guide)**](../../build-apps/customize-visualizations-with-configuration)
+- [Customize visualizations with configuration **(Guide)**](/build-apps/customize-visualizations-with-configuration)
 - [Configuring custom visualizations for dashboards **(Video)**](https://www.youtube.com/watch?v=sFpG_iG7Xa8)
 
 ## Use your custom visualization

--- a/src/markdown-pages/explore-docs/custom-viz.mdx
+++ b/src/markdown-pages/explore-docs/custom-viz.mdx
@@ -96,7 +96,7 @@ You have a lot of control over how your visualization operates. You can choose w
 
 Here is a list of resources for configuring custom visualizations:
 
-- [Configuration options **(Documentation)**](configuration-options)
+- [Configuration options **(Documentation)**](/explore-docs/custom-viz/configuration-options)
 - [Customize visualizations with configuration **(Guide)**](/build-apps/customize-visualizations-with-configuration)
 - [Configuring custom visualizations for dashboards **(Video)**](https://www.youtube.com/watch?v=sFpG_iG7Xa8)
 


### PR DESCRIPTION
## Description

One of the resource links on the custom viz doc had 2 slashes in the URL, which linked to a 404 page. This fixes that link + updates the other resources links to be relative to the root instead of the current page. This better futureproofs those URLS in case the location of the current viz page changes.