### PR TITLE
fix: referrer field not being sent on sign up

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "^1.6.19",
     "@mdx-js/react": "^1.6.19",
-    "@newrelic/gatsby-theme-newrelic": "^2.0.0",
+    "@newrelic/gatsby-theme-newrelic": "^2.0.1",
     "@splitsoftware/splitio-react": "^1.2.0",
     "@xstate/react": "^1.0.2",
     "classnames": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2052,10 +2052,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-2.0.0.tgz#77c5d26d9c89390ef7996acdd6a4adf6107ff0d3"
-  integrity sha512-Jo8hvtsmCEflIt9z2YYwiP8rfOIf7iaGzE3PJYI1oFVmz8Qd/s1omjuUwQJssPUf1pdhcXSL79Ccg/yNvONsmw==
+"@newrelic/gatsby-theme-newrelic@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-2.0.1.tgz#44ff836e6b4d3430fdec528d6245ac55c0c00100"
+  integrity sha512-CQ7OLUMWJ2qUFmuJD8Yt3mUlXE2dSwEowfCSauoLPNyiFGtDariRd7IJThRagXbmz+8b+a96goJYxvkun+UOZQ==
   dependencies:
     "@elastic/react-search-ui" "^1.5.1"
     "@elastic/react-search-ui-views" "^1.5.1"


### PR DESCRIPTION
## Description
The `gatsby-plugin-newrelic` dependency was not properly passing the referral field to segment. This updates to the newest version with a fix.

Partly closes https://github.com/newrelic/docs-website/issues/1816