### PR TITLE
Force trailing slashes on page paths

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -16,6 +16,7 @@ module.exports = {
     {
       resolve: '@newrelic/gatsby-theme-newrelic',
       options: {
+        forceTrailingSlashes: true,
         layout: {
           contentPadding: '2rem',
           maxWidth: '1700px',

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -82,7 +82,9 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     }
 
     createPage({
-      path: frontmatter.path || slug,
+      path: frontmatter.path
+        ? path.join(frontmatter.path, '/')
+        : path.join(slug, '/'),
       component: path.resolve(`src/templates/${frontmatter.template}.js`),
       context: {
         slug,
@@ -101,7 +103,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     } = node;
 
     createPage({
-      path: slug,
+      path: path.join(slug, '/'),
       component: path.resolve('./src/templates/ComponentReferenceTemplate.js'),
       context: {
         slug,
@@ -115,7 +117,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     } = node;
 
     createPage({
-      path: slug,
+      path: path.join(slug, '/'),
       component: path.resolve('./src/templates/ApiReferenceTemplate.js'),
       context: {
         slug,

--- a/src/templates/GuideTemplate.js
+++ b/src/templates/GuideTemplate.js
@@ -75,8 +75,8 @@ GuideTemplate.propTypes = {
 };
 
 export const pageQuery = graphql`
-  query($path: String!) {
-    mdx(frontmatter: { path: { eq: $path } }) {
+  query($slug: String!) {
+    mdx(fields: { slug: { eq: $slug } }) {
       body
       frontmatter {
         duration

--- a/src/templates/OverviewTemplate.js
+++ b/src/templates/OverviewTemplate.js
@@ -60,8 +60,8 @@ OverviewTemplate.propTypes = {
 };
 
 export const pageQuery = graphql`
-  query($path: String!, $guidesFilter: String!) {
-    mdx(frontmatter: { path: { eq: $path } }) {
+  query($slug: String!, $guidesFilter: String!) {
+    mdx(fields: { slug: { eq: $slug } }) {
       body
       frontmatter {
         path


### PR DESCRIPTION
## Description

Adds theme config option to force trailing slashes to try to make sure the sitemap includes trailing slashes to hopefully allow swiftype to index without encountering 302s.

## Related Issue(s) / Ticket(s)
- I _think_ this will close #1296 

