### PR TITLE
Update the gatsby theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "^1.6.19",
     "@mdx-js/react": "^1.6.19",
-    "@newrelic/gatsby-theme-newrelic": "2.2.0",
+    "@newrelic/gatsby-theme-newrelic": "2.2.2",
     "@splitsoftware/splitio-react": "^1.2.0",
     "@xstate/react": "^1.0.2",
     "classnames": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2052,10 +2052,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-2.2.0.tgz#9d0719c7084436354f5aab9112986aabd974e79f"
-  integrity sha512-0B3Mzs8KEm/p9aHE4pjyn2/u9tTFvd93X9TkZ5/JYeEKYTiLUvAg3CFPw+JWAP303lpGE7aoUsydFcLF91rAHw==
+"@newrelic/gatsby-theme-newrelic@2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-2.2.2.tgz#342c68a56f94ba7a6c7316a4e75e0402b41d838d"
+  integrity sha512-ig9LC+p0BFDN8IzHc8Ny8QQbRSknCcVU9r/MvgreiEGxWKUp33kD07HohYMsax4eOaCa4SdjUPHWN8R3/OM2fw==
   dependencies:
     "@elastic/react-search-ui" "^1.5.1"
     "@elastic/react-search-ui-views" "^1.5.1"
@@ -2070,7 +2070,7 @@
     gatsby-plugin-react-helmet "^4.3.0"
     gatsby-plugin-robots-txt "^1.5.5"
     gatsby-plugin-sharp "^3.3.0"
-    gatsby-plugin-sitemap "^4.0.0-next.0"
+    gatsby-plugin-sitemap "^4.1.0-next.1"
     gatsby-plugin-use-dark-mode "^1.3.0"
     gatsby-source-filesystem "^3.3.0"
     gatsby-transformer-sharp "^3.3.0"
@@ -8348,6 +8348,16 @@ gatsby-plugin-sitemap@^4.0.0-next.0:
   version "4.0.0-next.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-4.0.0-next.0.tgz#23296d97120ed7cc8a7009e8834dfb204ac991c4"
   integrity sha512-VDmnJKRwNqKnNvLWnSklGAzdU7xnwu+OQG1T3OM+bYdRFL8EtdSz4ADE5CVfGWFw0jahJ1eMOde2CDiaCcIMuQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    common-tags "^1.8.0"
+    minimatch "^3.0.4"
+    sitemap "^6.3.0"
+
+gatsby-plugin-sitemap@^4.1.0-next.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-4.1.0.tgz#13641c92b5b75bdc0d936acc26d99ea81913e341"
+  integrity sha512-ZpBnZLPE5eF+R9Zm0kuak6b+WlErTQfe4iWB0hTZ+1BDMVUg3FWpAg/PWt/o5NRr0ia7qLoY+StaAaJzGg0HeQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     common-tags "^1.8.0"


### PR DESCRIPTION
## Description

Updates to 2.2.2 which includes a reduction in console warnings and whitespace wrapping in codeblocks