### PR TITLE
Fix local dev warning by adding trailing slashes to embeds

### DIFF
--- a/plugins/gatsby-plugin-embed-pages/gatsby-node.js
+++ b/plugins/gatsby-plugin-embed-pages/gatsby-node.js
@@ -28,7 +28,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       body,
     } = node;
     const nodePath = frontmatter.path || slug;
-    const pagePath = path.join(nodePath, 'embed');
+    const pagePath = path.join(nodePath, 'embed', '/');
     const contentSourcePath = nodePath;
 
     createPage({


### PR DESCRIPTION
## Description

The theme forces all URL paths to use trailing slashes. If a site creates pages with a path that does not have a trailing slash, you may see warnings when running local dev server re: non-deterministic routing (because it thinks the same page is being created twice).

This just ensures we add a trailing slash to `/embed` pages.

## Related Issue(s) / Ticket(s)
TBD


