### PR TITLE
fix: enable branch protection with correct check

### DIFF
--- a/.github/workflows/fetch-related-content.yml
+++ b/.github/workflows/fetch-related-content.yml
@@ -93,7 +93,7 @@ jobs:
               required_status_checks: {
                 strict: false,
                 contexts: [
-                  'checkout-and-build'
+                  'Gatsby Build'
                 ]
               },
               restrictions: null,


### PR DESCRIPTION
# Description
The current workflow enables branch protection with a required check for `checkout-and-build`, however, it's only triggered by pushes to develop and PRs from develop to main do not trigger that job. I have updated this to `Gatsby Build` which is the equivalent for PRs.