### PR TITLE
chore: update docs on deploy previews for gatsby cloud

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@
       - [Use `fix`](#use-fix)
       - [Use `feat`](#use-feat)
     - [Draft PRs](#draft-prs)
-    - [Deploy previews with Amplify](#deploy-previews-with-amplify)
+    - [Deploy previews](#deploy-previews)
   - [Style guide adherence](#style-guide-adherence)
   - [Reusable components](#reusable-components)
   - [Technical reference contribution guidelines](#technical-reference-contribution-guidelines)
@@ -168,9 +168,11 @@ To submit a [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-req
    `PR` you wish to submit.
 3. Once you are ready to have the `PR` reviewed and merge, click the Ready for review button on the `PR`.
 
-### Deploy previews with Amplify
+### Deploy previews 
 
-PRs that are opened from a branch in this repo (not forks) will generate preview links on Amplify automatically. Amplify preview links can be found within the PR under the `Checks` Tab.
+PRs that are opened from a branch in this repo (not forks) will generate preview links on Gatsby Cloud automatically. Gatsby Cloud preview links will be added to the PR as a comment.
+
+PRs coming from forks must still use Amplify. Amplify preview links can be found within the PR under the `Checks` Tab.
 
 ## Style guide adherence
 


### PR DESCRIPTION
## Description

Update documentation on PR previews to include notes on Gatsby Cloud. 

Closes #1270 and #1338 