### PR TITLE
1332 load data into graphql

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -142,6 +142,23 @@ module.exports = {
         path: `${__dirname}/src/markdown-pages`,
       },
     },
+    {
+      resolve: 'gatsby-source-filesystem',
+      options: {
+        name: 'observability-packs',
+        path: `${__dirname}/src/data/observability-packs.json`
+      }
+    },
+    {
+      resolve: 'gatsby-transformer-json',
+      options: {
+        // If we need to source json files other than the i18n/nav, we should
+        // consider making this dynamic. See the docs for ways to do this.
+        //
+        // https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json
+        typeName: 'ObservabilityPacks',
+      },
+    },
     'gatsby-remark-images',
     'gatsby-transformer-remark',
     {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gatsby-remark-autolink-headers": "^2.9.0",
     "gatsby-remark-images": "^5.0.0",
     "gatsby-source-filesystem": "^3.3.0",
+    "gatsby-transformer-json": "^3.3.0",
     "gatsby-transformer-remark": "^4.0.0",
     "gatsby-transformer-sharp": "^3.3.0",
     "js-cookie": "^2.2.1",

--- a/src/data/observability-packs.json
+++ b/src/data/observability-packs.json
@@ -1,5 +1,4 @@
- {
-  "observabilityPacks": [
+[
     {
       "authors": [
         "New Relic",
@@ -532,4 +531,3 @@
       "website": "https://varnish-cache.org/"
     }
   ]
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8474,6 +8474,14 @@ gatsby-telemetry@^2.5.0:
     node-fetch "^2.6.1"
     uuid "3.4.0"
 
+gatsby-transformer-json@^3.3.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/gatsby-transformer-json/-/gatsby-transformer-json-3.6.0.tgz#a322aeea490ac5b13b6ba34b16992a743414c18f"
+  integrity sha512-QS+AzekZufFtC6zkdOMLQ54gchrwQ6dNzao8G6+uYlv0gInCQR21AtOgD3U1hOW5FOUJ/yvR1CMMzV9xbWyRRw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    bluebird "^3.7.2"
+
 gatsby-transformer-remark@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/gatsby-transformer-remark/-/gatsby-transformer-remark-4.0.0.tgz#3dcfc1786d69206768a84eae28ad49facfa108ec"


### PR DESCRIPTION
* pr to load data from observability-packs.json into graphql
* i also removed the top level field of observability-packs from the data since @roadlittledawn pointed out that produces an extra level of nesting in graphql that we dont need.

Resolves: #1332 