### PR TITLE
feat: pack list view

### DIFF
--- a/src/components/PackGrid.js
+++ b/src/components/PackGrid.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import PropTypes from 'prop-types';
+
+const PackGrid = ({ children, className }) => {
+  return (
+    <div
+      className={className}
+      css={css`
+        display: grid;
+        grid-template-columns: repeat(4, minmax(260px, 1fr));
+        grid-gap: 1rem;
+        grid-auto-rows: minmax(var(--guide-list-row-height, 150px), auto);
+        align-items: stretch;
+        width: 100%;
+
+        @media (max-width: 1180px) {
+          grid-template-columns: 1fr;
+          grid-gap: 3rem;
+        }
+      `}
+    >
+      {children}
+    </div>
+  );
+};
+
+PackGrid.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+};
+
+export default PackGrid;

--- a/src/components/PackGridTile.js
+++ b/src/components/PackGridTile.js
@@ -26,10 +26,11 @@ const PackGridTile = ({
     `}
   >
     <div>
-      <div 
+      <div
         css={css`
           background-color: white;
-        `}>
+        `}
+      >
         {featuredImageUrl ? (
           <img
             src={featuredImageUrl}

--- a/src/components/PackGridTile.js
+++ b/src/components/PackGridTile.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/react';
+import { Link, Icon, Surface } from '@newrelic/gatsby-theme-newrelic';
+
+const PackGridTile = ({
+  name,
+  description,
+  featuredImageUrl,
+  supportLevel,
+  to,
+  className,
+}) => (
+  <Surface
+    as={Link}
+    to={to}
+    className={className}
+    base={Surface.BASE.PRIMARY}
+    interactive
+    css={css`
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+      border-radius: 0.25rem;
+      position: relative;
+      transition: all 0.15s ease-out;
+    `}
+  >
+    <div>
+      <div>
+        {featuredImageUrl && (
+          <img
+            src={featuredImageUrl}
+            alt="Preview of the pack in action"
+            css={css`
+              display: block;
+              object-fit: cover;
+              width: 100%;
+              height: 200px;
+            `}
+          />
+        )}
+      </div>
+      <div
+        css={css`
+          padding: 1rem;
+        `}
+      >
+        <div
+          css={css`
+            display: grid;
+            grid-template-columns: 1fr auto;
+            grid-gap: 0.5rem;
+            align-items: baseline;
+          `}
+        >
+          <h4>
+            {name}{' '}
+            {supportLevel === 'NEWRELIC' && (
+              <span title="New Relic supported">
+                <Icon
+                  css={css`
+                    stroke: none;
+                    width: 2rem;
+                    height: 2rem;
+                  `}
+                  name="nr-check-shield"
+                />
+              </span>
+            )}
+          </h4>
+        </div>
+        <p
+          css={css`
+            font-size: 0.875rem;
+            color: var(--secondary-text-color);
+            flex: 1;
+            text-align: left;
+            padding: 0;
+          `}
+        >
+          {description}
+        </p>
+      </div>
+    </div>
+  </Surface>
+);
+
+PackGridTile.propTypes = {
+  name: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  featuredImageUrl: PropTypes.string,
+  supportLevel: PropTypes.string,
+  to: PropTypes.string.isRequired,
+  className: PropTypes.string,
+};
+
+export default PackGridTile;

--- a/src/components/PackGridTile.js
+++ b/src/components/PackGridTile.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { Link, Icon, Surface } from '@newrelic/gatsby-theme-newrelic';
+import NewRelicIcon from '@newrelic/gatsby-theme-newrelic/src/icons/logo/newrelic.js';
 
 const PackGridTile = ({
   name,
@@ -27,13 +28,24 @@ const PackGridTile = ({
   >
     <div>
       <div>
-        {featuredImageUrl && (
+        {featuredImageUrl ? (
           <img
             src={featuredImageUrl}
             alt="Preview of the pack in action"
             css={css`
               display: block;
-              object-fit: cover;
+              object-fit: scale-down;
+              margin-left: auto;
+              margin-right: auto;
+              width: 90%;
+              height: 200px;
+            `}
+          />
+        ) : (
+          <NewRelicIcon
+            css={css`
+              display: block;
+              object-fit: scale-down;
               width: 100%;
               height: 200px;
             `}

--- a/src/components/PackGridTile.js
+++ b/src/components/PackGridTile.js
@@ -22,12 +22,14 @@ const PackGridTile = ({
       display: grid;
       grid-template-rows: auto 1fr auto;
       border-radius: 0.25rem;
-      position: relative;
       transition: all 0.15s ease-out;
     `}
   >
     <div>
-      <div>
+      <div 
+        css={css`
+          background-color: white;
+        `}>
         {featuredImageUrl ? (
           <img
             src={featuredImageUrl}

--- a/src/components/PackList.js
+++ b/src/components/PackList.js
@@ -7,17 +7,9 @@ const PackList = ({ children, className }) => {
     <div
       className={className}
       css={css`
-        display: grid;
-        grid-template-columns: repeat(4, minmax(260px, 1fr));
-        grid-gap: 1rem;
-        grid-auto-rows: minmax(var(--guide-list-row-height, 150px), auto);
+        display: list-item;
         align-items: stretch;
         width: 100%;
-
-        @media (max-width: 1180px) {
-          grid-template-columns: 1fr;
-          grid-gap: 3rem;
-        }
       `}
     >
       {children}

--- a/src/components/PackList.js
+++ b/src/components/PackList.js
@@ -7,7 +7,7 @@ const PackList = ({ children, className }) => {
     <div
       className={className}
       css={css`
-        display: list-item;
+        display: grid;
         align-items: stretch;
         width: 100%;
       `}

--- a/src/components/PackListTile.js
+++ b/src/components/PackListTile.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { Link, Icon, Surface } from '@newrelic/gatsby-theme-newrelic';
+import NewRelicIcon from '@newrelic/gatsby-theme-newrelic/src/icons/logo/newrelic.js';
+
 
 const PackListTile = ({
   name,
@@ -45,13 +47,26 @@ const PackListTile = ({
           }
         `}
       >
-        {featuredImageUrl && (
+        {featuredImageUrl ? (
           <img
             src={featuredImageUrl}
             alt="Preview of the pack in action"
             css={css`
               display: block;
-              object-fit: cover;
+              object-fit: scale-down;
+              width: 100%;
+              height: 100%;
+
+              @media (max-width: 1080px) {
+                display: none;
+              }
+            `}
+          />
+        ) : (
+          <NewRelicIcon
+            css={css`
+              display: block;
+              object-fit: scale-down;
               width: 100%;
               height: 100%;
 

--- a/src/components/PackListTile.js
+++ b/src/components/PackListTile.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { Link, Icon, Surface } from '@newrelic/gatsby-theme-newrelic';
 
-const PackTile = ({
+const PackListTile = ({
   name,
   description,
   featuredImageUrl,
@@ -19,14 +19,32 @@ const PackTile = ({
     interactive
     css={css`
       display: grid;
-      grid-template-rows: auto 1fr auto;
       border-radius: 0.25rem;
       position: relative;
       transition: all 0.15s ease-out;
+      margin-bottom: 1rem;
     `}
   >
-    <div>
-      <div>
+    <div
+      css={css`
+        display: grid;
+        grid-template-columns: 1fr 3fr;
+        grid-auto-rows: minmax(var(--guide-list-row-height, 150px), auto);
+
+        @media (max-width: 1080px) {
+          grid-template-columns: 1fr;
+        }
+      `}
+    >
+      <div
+        css={css`
+          padding: 1rem;
+          max-height: 150px;
+          @media (max-width: 1080px) {
+            display: none;
+          }
+        `}
+      >
         {featuredImageUrl && (
           <img
             src={featuredImageUrl}
@@ -35,7 +53,11 @@ const PackTile = ({
               display: block;
               object-fit: cover;
               width: 100%;
-              height: 200px;
+              height: 100%;
+
+              @media (max-width: 1080px) {
+                display: none;
+              }
             `}
           />
         )}
@@ -43,6 +65,7 @@ const PackTile = ({
       <div
         css={css`
           padding: 1rem;
+          width: 100%;
         `}
       >
         <div
@@ -85,7 +108,7 @@ const PackTile = ({
   </Surface>
 );
 
-PackTile.propTypes = {
+PackListTile.propTypes = {
   name: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   featuredImageUrl: PropTypes.string,
@@ -94,4 +117,4 @@ PackTile.propTypes = {
   className: PropTypes.string,
 };
 
-export default PackTile;
+export default PackListTile;

--- a/src/components/PackListTile.js
+++ b/src/components/PackListTile.js
@@ -21,7 +21,6 @@ const PackListTile = ({
     css={css`
       display: grid;
       border-radius: 0.25rem;
-      position: relative;
       transition: all 0.15s ease-out;
       margin-bottom: 1rem;
     `}
@@ -41,6 +40,8 @@ const PackListTile = ({
         css={css`
           padding: 1rem;
           max-height: 150px;
+          background-color: white;
+
           @media (max-width: 1080px) {
             display: none;
           }
@@ -53,8 +54,11 @@ const PackListTile = ({
             css={css`
               display: block;
               object-fit: scale-down;
-              width: 100%;
+              width: 90%;
               height: 100%;
+              margin-left: auto;
+              margin-right: auto;
+              background-color: white;
 
               @media (max-width: 1080px) {
                 display: none;
@@ -68,6 +72,9 @@ const PackListTile = ({
               object-fit: scale-down;
               width: 100%;
               height: 100%;
+              margin-left: auto;
+              margin-right: auto;
+              background-color: white;
 
               @media (max-width: 1080px) {
                 display: none;

--- a/src/components/PackListTile.js
+++ b/src/components/PackListTile.js
@@ -4,7 +4,6 @@ import { css } from '@emotion/react';
 import { Link, Icon, Surface } from '@newrelic/gatsby-theme-newrelic';
 import NewRelicIcon from '@newrelic/gatsby-theme-newrelic/src/icons/logo/newrelic.js';
 
-
 const PackListTile = ({
   name,
   description,

--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -3,7 +3,9 @@ import { graphql } from 'gatsby';
 import React, { useState, useEffect } from 'react';
 import DevSiteSeo from '../components/DevSiteSeo';
 import { css } from '@emotion/react';
-import PackTile from '../components/PackTile';
+import PackGrid from '../components/PackGrid';
+import PackGridTile from '../components/PackGridTile';
+import PackListTile from '../components/PackListTile';
 import PackList from '../components/PackList';
 import { SearchInput, Button, Dropdown } from '@newrelic/gatsby-theme-newrelic';
 import { useQueryParam, StringParam } from 'use-query-params';
@@ -34,6 +36,11 @@ const ObservabilityPacksPage = ({ data, location }) => {
     }
   }, [querySearch, queryFilter, querySort]);
 
+  const [packView, setPackView] = useState('GRID_VIEW');
+
+  useEffect(() => {
+    setPackView(packView);
+  }, [packView]);
   useEffect(() => {
     let tempFilteredPacks = o11yPacks.filter(
       (pack) =>
@@ -239,30 +246,72 @@ const ObservabilityPacksPage = ({ data, location }) => {
           </div>
         </div>
         <div>
-          <Button variant={Button.VARIANT.PRIMARY}>Grid view</Button>
-          <Button variant={Button.VARIANT.OUTLINE}>List view</Button>
+          <Button
+            variant={
+              packView === 'GRID_VIEW'
+                ? Button.VARIANT.PRIMARY
+                : Button.VARIANT.OUTLINE
+            }
+            onClick={() => setPackView('GRID_VIEW')}
+          >
+            Grid view
+          </Button>
+          <Button
+            variant={
+              packView === 'LIST_VIEW'
+                ? Button.VARIANT.PRIMARY
+                : Button.VARIANT.OUTLINE
+            }
+            onClick={() => setPackView('LIST_VIEW')}
+          >
+            List view
+          </Button>
         </div>
       </div>
       <div>
-        <PackList>
-          {filteredPacks.map((pack) => {
-            // TODO: Figure out what image should be shown
-            // if not added to API explicitly
-            const imgSrc = pack.dashboards?.[0]?.screenshots?.[0];
-            return (
-              <PackTile
-                name={pack.name}
-                key={pack.id}
-                supportLevel={pack.level}
-                description={pack.description}
-                featuredImageUrl={
-                  imgSrc || 'https://via.placeholder.com/400x275.png?text=Image'
-                }
-                to={`${pack.fields.slug}`}
-              />
-            );
-          })}
-        </PackList>
+        {packView === 'GRID_VIEW' ? (
+          <PackGrid>
+            {filteredPacks.map((pack) => {
+              // TODO: Figure out what image should be shown
+              // if not added to API explicitly
+              const imgSrc = pack.dashboards?.[0]?.screenshots?.[0];
+              return (
+                <PackGridTile
+                  name={pack.name}
+                  key={pack.id}
+                  supportLevel={pack.level}
+                  description={pack.description}
+                  featuredImageUrl={
+                    imgSrc ||
+                    'https://via.placeholder.com/400x275.png?text=Image'
+                  }
+                  to={`${pack.fields.slug}`}
+                />
+              );
+            })}
+          </PackGrid>
+        ) : (
+          <PackList>
+            {filteredPacks.map((pack) => {
+              // TODO: Figure out what image should be shown
+              // if not added to API explicitly
+              const imgSrc = pack.dashboards?.[0]?.screenshots?.[0];
+              return (
+                <PackListTile
+                  name={pack.name}
+                  key={pack.id}
+                  supportLevel={pack.level}
+                  description={pack.description}
+                  featuredImageUrl={
+                    imgSrc ||
+                    'https://via.placeholder.com/400x275.png?text=Image'
+                  }
+                  to={`${pack.fields.slug}`}
+                />
+              );
+            })}
+          </PackList>
+        )}
       </div>
     </>
   );

--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -274,7 +274,6 @@ const ObservabilityPacksPage = ({ data, location }) => {
             {filteredPacks.map((pack) => {
               // TODO: Figure out what image should be shown
               // if not added to API explicitly
-              const imgSrc = pack.dashboards?.[0]?.screenshots?.[0];
               return (
                 <PackGridTile
                   name={pack.name}
@@ -282,7 +281,7 @@ const ObservabilityPacksPage = ({ data, location }) => {
                   supportLevel={pack.level}
                   description={pack.description}
                   featuredImageUrl={
-                    imgSrc ||
+                    pack.logo ||
                     'https://via.placeholder.com/400x275.png?text=Image'
                   }
                   to={`${pack.fields.slug}`}
@@ -295,7 +294,6 @@ const ObservabilityPacksPage = ({ data, location }) => {
             {filteredPacks.map((pack) => {
               // TODO: Figure out what image should be shown
               // if not added to API explicitly
-              const imgSrc = pack.dashboards?.[0]?.screenshots?.[0];
               return (
                 <PackListTile
                   name={pack.name}
@@ -303,7 +301,7 @@ const ObservabilityPacksPage = ({ data, location }) => {
                   supportLevel={pack.level}
                   description={pack.description}
                   featuredImageUrl={
-                    imgSrc ||
+                    pack.logo ||
                     'https://via.placeholder.com/400x275.png?text=Image'
                   }
                   to={`${pack.fields.slug}`}


### PR DESCRIPTION
Added alternate List view for all packs which is responsive to view size

Changed the name of a couple of components to keep them in line with functionality:

`PackList` -> `PackGrid` (the list view uses `PackList` and vice-versa
`PackTile` -> `PackGridTile` (to differentiate from `PackListTile`