### PR TITLE
chore: updated contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,6 @@
     - [Step 1: Update the release number in `gatsby-config`](#step-1-update-the-release-number-in-gatsby-config)
     - [Step 2: Add any new APIs or components to our constants list](#step-2-add-any-new-apis-or-components-to-our-constants-list)
     - [Step 3: Add any new APIs or components to the navigation](#step-3-add-any-new-apis-or-components-to-the-navigation)
-    - [Step 4: Misc Info](#step-4-misc-info)
 
 <!-- /TOC -->
 
@@ -422,9 +421,3 @@ with the new components.
 If there are new APIs or components, we will want to list them in the navigation
 so that a user can easily discover them. [Add an entry to `nav.yml`](https://github.com/newrelic/developer-website/blob/develop/src/data/nav.yml)
 to get the new API/component in the nav.
-
-### Step 4: Misc Info
-
-- This [file](https://github.com/newrelic/developer-website/blob/develop/plugins/gatsby-source-newrelic-sdk/src/navigationApi.js) contains the manually generated navigation API this is currently missing from the API.
-- [Here](https://github.com/newrelic/developer-website/blob/develop/plugins/gatsby-source-newrelic-sdk/src/getPropTypes.js#L123-L128) is how prop type functions are extracted.
-- Similarly, any methods on a component will need to be updated [here](https://github.com/newrelic/developer-website/blob/develop/plugins/gatsby-source-newrelic-sdk/src/getMethods.js).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,10 +42,11 @@
     - [Step 3](#step-3)
     - [Step 4](#step-4)
     - [Step 5](#step-5)
-  - [Updating the documentation bundle](#updating-the-documentation-bundle)
+  - [Updating the SDK documentation bundle](#updating-the-sdk-documentation-bundle)
     - [Step 1: Update the release number in `gatsby-config`](#step-1-update-the-release-number-in-gatsby-config)
     - [Step 2: Add any new APIs or components to our constants list](#step-2-add-any-new-apis-or-components-to-our-constants-list)
     - [Step 3: Add any new APIs or components to the navigation](#step-3-add-any-new-apis-or-components-to-the-navigation)
+    - [Step 4: Misc Info](#step-4-misc-info)
 
 <!-- /TOC -->
 
@@ -119,7 +120,7 @@ All pull requests should be made against the `develop` branch.
 
 ### Branch Protection
 
-The `develop` and `main` branches have "Branch Protection" enabled in Github. In order to merge a pull request into `develop`, you must have (at least) one approval. Additionally a few of the "PR Checks" are required and must pass before the pull request can be merged in. 
+The `develop` and `main` branches have "Branch Protection" enabled in Github. In order to merge a pull request into `develop`, you must have (at least) one approval. Additionally a few of the "PR Checks" are required and must pass before the pull request can be merged in.
 
 You can review full Branch Protection details [here](https://docs.google.com/document/d/1O1SGS0i3OmPfvPhylpFe1CTMkE20889iAOF_cMFJ344/edit#heading=h.cy3jfpnyvv5z), and check out a visual representation of the workflow below:
 
@@ -390,7 +391,7 @@ A good metric:
 
 Run the experiment and pick a winner!
 
-## Updating the documentation bundle
+## Updating the SDK documentation bundle
 
 Periodically we need to update the NR1 SDK bundle that we use to generate our
 component documentation. In order to update the SDK, there are a few steps that
@@ -398,30 +399,32 @@ need to happen:
 
 ### Step 1: Update the release number in `gatsby-config`
 
-We use a local plugin to source our documentation into GraphQL. This plugin has
-some configuration that tells it what release number to use. [Update
-`gatsby-config.js`](https://github.com/newrelic/developer-website/blob/ae42737f5f1cf556f3c44d864655c9a571739e28/gatsby-config.js#L161)
-with the new release number to update.
+- We use a [local Gatsby plugin `gatsby-source-newrelic-sdk`](https://github.com/newrelic/developer-website/tree/develop/plugins/gatsby-source-newrelic-sdk)
+to source our documentation into GraphQL. This plugin has some configuration that tells it what release number to use.
 
-To obtain the release number visit the `wanda-ec-ui` repository on GH enterprise and
-look at the release version.
+- [Update `gatsby-config.js`](https://github.com/newrelic/developer-website/blob/ae42737f5f1cf556f3c44d864655c9a571739e28/gatsby-config.js#L161)
+with the new release number to update the bundle release version.
+
+- To obtain the version release number visit the `wanda-ec-ui` repository on Github enterprise and look at the release version.
 
 ### Step 2: Add any new APIs or components to our constants list
 
-At the time of this writing, we rely on the 1st party documentation bundle to
-power the developer docs. While the 1st party bundle provides many of the same
-components/APIs, there are a few minor differences between the 1st and 3rd party
-SDKs. To account for this, we list out the components we document on the site.
-If there are any new components or APIs, [update the constants
+- We rely on the 1st party documentation bundle to power the developer docs. While the 1st party bundle provides many of the same components/APIs, there are a few minor differences between the 1st and 3rd party SDKs. To account for this, we white list the specific components we document on the site.
+- If there are any new components or APIs, [update the constants
 list](https://github.com/newrelic/developer-website/blob/develop/plugins/gatsby-source-newrelic-sdk/src/constants.js)
-with the new components. Pages will be automatically generated for each of
-these.
+with the new components.
+- Pages will be then automatically generated for each of these.
 
-Once we get a 3rd party bundle built for us, we should no longer need this step
-as that will contain only 3rd party SDK documentation.
+> Once we have a 3rd party bundle automatically built for us, we should no longer need this step as that will contain only 3rd party SDK documentation. That is an open request to the NR One Core Team.
 
 ### Step 3: Add any new APIs or components to the navigation
 
 If there are new APIs or components, we will want to list them in the navigation
 so that a user can easily discover them. [Add an entry to `nav.yml`](https://github.com/newrelic/developer-website/blob/develop/src/data/nav.yml)
 to get the new API/component in the nav.
+
+### Step 4: Misc Info
+
+- This [file](https://github.com/newrelic/developer-website/blob/develop/plugins/gatsby-source-newrelic-sdk/src/navigationApi.js) contains the manually generated navigation API this is currently missing from the API.
+- [Here](https://github.com/newrelic/developer-website/blob/develop/plugins/gatsby-source-newrelic-sdk/src/getPropTypes.js#L123-L128) is how prop type functions are extracted.
+- Similarly, any methods on a component will need to be updated [here](https://github.com/newrelic/developer-website/blob/develop/plugins/gatsby-source-newrelic-sdk/src/getMethods.js).


### PR DESCRIPTION
This PR updates the section on the SDK bundle to offer more context of how we do updates to documentation as it relates to the SDK bundle from One Core.