### PR TITLE
add image gallery component

### DIFF
--- a/src/components/ImageGallery/ImageGallery.js
+++ b/src/components/ImageGallery/ImageGallery.js
@@ -8,7 +8,17 @@ const noImagePlaceholder =
 
 const CreateImageBlock = (image) => {
   return (
-    <a href={image} target="_blank" rel="noreferrer">
+    <a
+      href={image}
+      target="_blank"
+      rel="noreferrer"
+      css={css`
+        height: 207px;
+
+        margin-right: 16px;
+        margin-bottom: 6px;
+      `}
+    >
       <img
         src={image}
         alt="placeholder-text"
@@ -28,9 +38,6 @@ const CreateImageBlock = (image) => {
           box-shadow: inset 0px 0px 0px 4px #ffffff;
           border-radius: 4px;
           padding: 3px;
-
-          margin-right: 16px;
-          margin-bottom: 6px;
 
           object-fit: cover;
         `}

--- a/src/components/ImageGallery/ImageGallery.js
+++ b/src/components/ImageGallery/ImageGallery.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/react';
+
+// TODO: replace with import of image, rather than grabbing one off the web
+const noImagePlaceholder =
+  'https://socialistmodernism.com/wp-content/uploads/2017/07/placeholder-image.png';
+
+const CreateImageBlock = (image) => {
+  return (
+    <a href={image} target="_blank" rel="noreferrer">
+      <img
+        src={image}
+        alt="placeholder-text"
+        css={css`
+          width: 285px;
+          height: 207px;
+
+          background: linear-gradient(0deg, #f3f4f4, #f3f4f4),
+            linear-gradient(
+              293.05deg,
+              #70d3af -73.46%,
+              #007e8a -24.52%,
+              #052a3a 69.75%
+            );
+          border: 1px solid rgba(0, 0, 0, 0.1);
+          box-sizing: border-box;
+          box-shadow: inset 0px 0px 0px 4px #ffffff;
+          border-radius: 4px;
+          padding: 3px;
+
+          margin-right: 16px;
+          margin-bottom: 6px;
+
+          object-fit: cover;
+        `}
+      />
+    </a>
+  );
+};
+
+/**
+ * @param {Object} props
+ * @param {String[]} props.images - Array of images urls.
+ * @param {String} props.className
+ */
+const ImageGallery = ({ images, className }) => {
+  return (
+    <div
+      className={className}
+      css={css`
+        display: flex;
+        white-space: nowrap;
+        overflow-x: auto;
+        margin-bottom: 32px;
+      `}
+    >
+      {images && images.length > 0
+        ? images.map((image) => {
+            return CreateImageBlock(image);
+          })
+        : CreateImageBlock(noImagePlaceholder)}
+    </div>
+  );
+};
+
+ImageGallery.propTypes = {
+  images: PropTypes.arrayOf(PropTypes.string),
+  className: PropTypes.string,
+};
+
+export default ImageGallery;

--- a/src/components/ImageGallery/index.js
+++ b/src/components/ImageGallery/index.js
@@ -1,0 +1,1 @@
+export { default } from './ImageGallery';

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -5,8 +5,8 @@ import DevSiteSeo from '../components/DevSiteSeo';
 import PropTypes from 'prop-types';
 import PageLayout from '../components/PageLayout';
 import Tabs from '../components/Tabs';
-import noImagePlaceholder from '../images/no-image-placeholder.png';
 import { Layout, PageTools, Button } from '@newrelic/gatsby-theme-newrelic';
+import ImageGallery from '../components/ImageGallery';
 
 const ObservabilityPackDetails = ({ data, location }) => {
   const pack = data.observabilityPacks;
@@ -74,11 +74,7 @@ const ObservabilityPackDetails = ({ data, location }) => {
             {/* carousel component if we decide to use multiple images */}
             <Tabs.Pages>
               <Tabs.Page id="overview">
-                <img
-                  src={noImagePlaceholder}
-                  alt="placeholder"
-                  height="250px"
-                />
+                <ImageGallery images={[]} />
                 <h3>Description</h3>
                 <p>{pack.description}</p>
               </Tabs.Page>
@@ -86,17 +82,7 @@ const ObservabilityPackDetails = ({ data, location }) => {
                 {pack.dashboards?.map((dashboard) => (
                   <>
                     <h3>{dashboard.name}</h3>
-                    {dashboard.screenshots?.map((screenshot, index) => (
-                      <img
-                        key={index}
-                        alt="dashboard example"
-                        src={screenshot}
-                        css={css`
-                          height: 200px;
-                          margin: 1rem;
-                        `}
-                      />
-                    ))}
+                    <ImageGallery images={dashboard.screenshots} />
                     {dashboard.description && (
                       <>
                         <h4>Description</h4>


### PR DESCRIPTION
This PR adds an ImageGallery component for displaying images.

Aside from the visual organization, there is additional functionality:
* if passed no images, the component displays a single default image.
* each image is clickable and opens the full resolution image in a new tab.

You can see it in action on every observability pack page of the site. As an example: https://observabilitypacks-1341addimagegallery.gtsb.io/observability-packs/apache/QXBhY2hl/

Resolves: #1341 

### Screenshots
![Screen Shot 2021-06-04 at 4 34 32 PM](https://user-images.githubusercontent.com/70179215/120872278-11694080-c553-11eb-8b2d-323bf7c76d91.png)
![Screen Shot 2021-06-04 at 4 34 43 PM](https://user-images.githubusercontent.com/70179215/120872281-13330400-c553-11eb-8d94-dcc56f682959.png)
![Screen Shot 2021-06-04 at 4 37 11 PM](https://user-images.githubusercontent.com/70179215/120872297-2219b680-c553-11eb-9045-344cd53edbd5.png)
