### PR TITLE
Make o11y pack landing more responsive

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/react';
+
+const Select = ({ disabled, ...props }) => (
+  <div
+    css={css`
+      height: 28px;
+      display: grid;
+      grid-template-areas: 'select';
+      align-items: center;
+      width: 100%;
+      min-width: 15ch;
+      border: 1px solid var(--color-neutrals-500);
+      border-radius: 0.25rem;
+      padding: 0.25rem 0.5rem;
+      cursor: pointer;
+      position: relative;
+
+      ${disabled &&
+      css`
+        cursor: not-allowed;
+        opacity: 0.5;
+
+        .light-mode & {
+          background-color: var(--color-neutrals-100);
+        }
+      `}
+
+      .dark-mode & {
+        border: 1px solid var(--color-dark-300);
+        background-color: var(--color-dark-300);
+      }
+
+      &::after {
+        content: '';
+        grid-area: select;
+        justify-self: end;
+        width: 0.5rem;
+        height: 0.25rem;
+        clip-path: polygon(100% 0%, 0 0%, 50% 100%);
+        background-color: var(--color-neutrals-700);
+
+        .dark-mode & {
+          background-color: var(--color-dark-700);
+        }
+      }
+    `}
+  >
+    <select
+      disabled={disabled}
+      css={css`
+        grid-area: select;
+        appearance: none;
+        background-color: transparent;
+        border: none;
+        padding: 0 1em 0 0;
+        margin: 0;
+        width: 100%;
+        font-family: inherit;
+        font-size: 14px;
+        cursor: inherit;
+        line-height: inherit;
+        outline: none;
+
+        &:focus + .focus-ring {
+          position: absolute;
+          top: -1px;
+          left: -1px;
+          right: -1px;
+          bottom: -1px;
+          border: 2px solid var(--color-brand-500);
+          border-radius: inherit;
+        }
+
+        .dark-mode & {
+          color: var(--color-dark-900);
+
+          option {
+            color: var(--color-dark-050);
+          }
+        }
+      `}
+      {...props}
+    />
+    <span className="focus-ring" />
+  </div>
+);
+
+Select.propTypes = {
+  disabled: PropTypes.bool,
+};
+
+export default Select;

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -5,12 +5,11 @@ import { css } from '@emotion/react';
 const Select = ({ disabled, ...props }) => (
   <div
     css={css`
-      height: 28px;
+      height: 1.75rem;
       display: grid;
       grid-template-areas: 'select';
       align-items: center;
       width: 100%;
-      min-width: 15ch;
       border: 1px solid var(--color-neutrals-500);
       border-radius: 0.25rem;
       padding: 0.25rem 0.5rem;
@@ -61,7 +60,6 @@ const Select = ({ disabled, ...props }) => (
         font-size: 14px;
         cursor: inherit;
         line-height: inherit;
-        outline: none;
 
         &:focus + .focus-ring {
           position: absolute;

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -60,6 +60,7 @@ const Select = ({ disabled, ...props }) => (
         font-size: 14px;
         cursor: inherit;
         line-height: inherit;
+        outline: none;
 
         &:focus + .focus-ring {
           position: absolute;
@@ -67,7 +68,7 @@ const Select = ({ disabled, ...props }) => (
           left: -1px;
           right: -1px;
           bottom: -1px;
-          border: 2px solid var(--color-brand-500);
+          outline: 2px solid var(--color-brand-500);
           border-radius: inherit;
         }
 

--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -5,8 +5,19 @@ import DevSiteSeo from '../components/DevSiteSeo';
 import { css } from '@emotion/react';
 import PackTile from '../components/PackTile';
 import PackList from '../components/PackList';
+import Select from '../components/Select';
 import { SearchInput, Button, Dropdown } from '@newrelic/gatsby-theme-newrelic';
 import { useQueryParam, StringParam } from 'use-query-params';
+
+const sortOptionValues = ['Alphabetical', 'Reverse', 'Popularity'];
+const packContentsFilterValues = [
+  'Anything',
+  'Dashboards',
+  'Alerts',
+  'Visualizations',
+  'Synthetics Checks',
+  'Applications',
+];
 
 const ObservabilityPacksPage = ({ data, location }) => {
   const {
@@ -106,12 +117,26 @@ const ObservabilityPacksPage = ({ data, location }) => {
           .dark-mode & {
             background-color: var(--color-dark-100);
           }
+          @media screen and (max-width: 1180px) {
+            flex-direction: column;
+            align-items: normal;
+            > * {
+              margin: 0.5rem 0;
+            }
+          }
         `}
       >
         <span>Showing {filteredPacks.length} results</span>
         <div
           css={css`
             display: flex;
+            @media screen and (max-width: 1180px) {
+              flex-direction: column;
+              align-items: normal;
+              > * {
+                margin: 0.5rem 0;
+              }
+            }
           `}
         >
           <div
@@ -119,123 +144,46 @@ const ObservabilityPacksPage = ({ data, location }) => {
               margin: 0 0.5rem;
             `}
           >
-            <span
-              css={css`
-                font-size: 12px;
-                font-weight: bold;
-              `}
-            >
-              Sort by
-            </span>
-            <Dropdown align="left">
-              <Dropdown.Toggle
-                css={css`
-                  background-color: var(--color-white);
-                  .dark-mode & {
-                    background-color: transparent;
-                  }
-                `}
-                size={Button.SIZE.SMALL}
-                variant={Button.VARIANT.OUTLINE}
+            <FormControl>
+              <Label htmlFor="sortFilter">Sort by</Label>
+              <Select
+                id="sortFilter"
+                value={sortState}
+                onChange={(e) => {
+                  setSortState(e.target.value);
+                }}
               >
-                {sortState}
-              </Dropdown.Toggle>
-              <Dropdown.Menu>
-                <Dropdown.MenuItem
-                  onClick={() => {
-                    setSortState('Alphabetical');
-                  }}
-                >
-                  Alphabetical
-                </Dropdown.MenuItem>
-                <Dropdown.MenuItem
-                  onClick={() => {
-                    setSortState('Reverse');
-                  }}
-                >
-                  Reverse
-                </Dropdown.MenuItem>
-                <Dropdown.MenuItem
-                  onClick={() => {
-                    setSortState('Popularity');
-                  }}
-                >
-                  Popularity
-                </Dropdown.MenuItem>
-              </Dropdown.Menu>
-            </Dropdown>
+                {sortOptionValues.map((sortOption) => (
+                  <option key={sortOption} value={sortOption}>
+                    {sortOption}
+                  </option>
+                ))}
+              </Select>
+            </FormControl>
           </div>
           <div
             css={css`
               margin: 0 0.5rem;
             `}
           >
-            <span
-              css={css`
-                font-size: 12px;
-                font-weight: bold;
-              `}
-            >
-              Filter packs containing
-            </span>
-            <Dropdown align="left">
-              <Dropdown.Toggle
-                css={css`
-                  background-color: var(--color-white);
-                  .dark-mode & {
-                    background-color: transparent;
-                  }
-                `}
-                size={Button.SIZE.SMALL}
-                variant={Button.VARIANT.OUTLINE}
+            <FormControl>
+              <Label htmlFor="packContentsFilter">
+                Filter packs containing
+              </Label>
+              <Select
+                id="packContentsFilter"
+                value={containingFilterState}
+                onChange={(e) => {
+                  setContainingFilterState(e.target.value);
+                }}
               >
-                {containingFilterState}
-              </Dropdown.Toggle>
-              <Dropdown.Menu>
-                <Dropdown.MenuItem
-                  onClick={() => {
-                    setContainingFilterState('Anything');
-                  }}
-                >
-                  Anything
-                </Dropdown.MenuItem>
-                <Dropdown.MenuItem
-                  onClick={() => {
-                    setContainingFilterState('Dashboards');
-                  }}
-                >
-                  Dashboards
-                </Dropdown.MenuItem>
-                <Dropdown.MenuItem
-                  onClick={() => {
-                    setContainingFilterState('Alerts');
-                  }}
-                >
-                  Alerts
-                </Dropdown.MenuItem>
-                <Dropdown.MenuItem
-                  onClick={() => {
-                    setContainingFilterState('Visualizations');
-                  }}
-                >
-                  Visualizations
-                </Dropdown.MenuItem>
-                <Dropdown.MenuItem
-                  onClick={() => {
-                    setContainingFilterState('Synthetics');
-                  }}
-                >
-                  Synthetic Checks
-                </Dropdown.MenuItem>
-                <Dropdown.MenuItem
-                  onClick={() => {
-                    setContainingFilterState('Applications');
-                  }}
-                >
-                  Applications
-                </Dropdown.MenuItem>
-              </Dropdown.Menu>
-            </Dropdown>
+                {packContentsFilterValues.map((packContentsItem) => (
+                  <option key={packContentsItem} value={packContentsItem}>
+                    {packContentsItem}
+                  </option>
+                ))}
+              </Select>
+            </FormControl>
           </div>
         </div>
         <div>
@@ -303,5 +251,36 @@ export const pageQuery = graphql`
     }
   }
 `;
+
+const Label = ({ children, htmlFor }) => (
+  <label
+    htmlFor={htmlFor}
+    css={css`
+      display: block;
+      font-size: 12px;
+      font-weight: bold;
+      margin-bottom: 0.25rem;
+    `}
+  >
+    {children}
+  </label>
+);
+
+Label.propTypes = {
+  children: PropTypes.node,
+  htmlFor: PropTypes.string,
+};
+
+const FormControl = ({ children }) => (
+  <div
+    css={css`
+      &:not(:last-child) {
+        margin-bottom: 1.5rem;
+      }
+    `}
+  >
+    {children}
+  </div>
+);
 
 export default ObservabilityPacksPage;

--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -6,7 +6,7 @@ import { css } from '@emotion/react';
 import PackTile from '../components/PackTile';
 import PackList from '../components/PackList';
 import Select from '../components/Select';
-import { SearchInput, Button, Dropdown } from '@newrelic/gatsby-theme-newrelic';
+import { SearchInput, Button } from '@newrelic/gatsby-theme-newrelic';
 import { useQueryParam, StringParam } from 'use-query-params';
 
 const sortOptionValues = ['Alphabetical', 'Reverse', 'Popularity'];
@@ -282,5 +282,9 @@ const FormControl = ({ children }) => (
     {children}
   </div>
 );
+
+FormControl.propTypes = {
+  children: PropTypes.node,
+};
 
 export default ObservabilityPacksPage;

--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -146,6 +146,7 @@ const ObservabilityPacksPage = ({ data, location }) => {
               value={sortState}
               onChange={(e) => {
                 setSortState(e.target.value);
+                document.getElementById(e.target.id).blur();
               }}
             >
               {sortOptionValues.map((sortOption) => (
@@ -163,6 +164,7 @@ const ObservabilityPacksPage = ({ data, location }) => {
               value={containingFilterState}
               onChange={(e) => {
                 setContainingFilterState(e.target.value);
+                document.getElementById(e.target.id).blur();
               }}
             >
               {packContentsFilterValues.map((packContentsItem) => (

--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -139,52 +139,39 @@ const ObservabilityPacksPage = ({ data, location }) => {
             }
           `}
         >
-          <div
-            css={css`
-              margin: 0 0.5rem;
-            `}
-          >
-            <FormControl>
-              <Label htmlFor="sortFilter">Sort by</Label>
-              <Select
-                id="sortFilter"
-                value={sortState}
-                onChange={(e) => {
-                  setSortState(e.target.value);
-                }}
-              >
-                {sortOptionValues.map((sortOption) => (
-                  <option key={sortOption} value={sortOption}>
-                    {sortOption}
-                  </option>
-                ))}
-              </Select>
-            </FormControl>
-          </div>
-          <div
-            css={css`
-              margin: 0 0.5rem;
-            `}
-          >
-            <FormControl>
-              <Label htmlFor="packContentsFilter">
-                Filter packs containing
-              </Label>
-              <Select
-                id="packContentsFilter"
-                value={containingFilterState}
-                onChange={(e) => {
-                  setContainingFilterState(e.target.value);
-                }}
-              >
-                {packContentsFilterValues.map((packContentsItem) => (
-                  <option key={packContentsItem} value={packContentsItem}>
-                    {packContentsItem}
-                  </option>
-                ))}
-              </Select>
-            </FormControl>
-          </div>
+          <FormControl>
+            <Label htmlFor="sortFilter">Sort by</Label>
+            <Select
+              id="sortFilter"
+              value={sortState}
+              onChange={(e) => {
+                setSortState(e.target.value);
+              }}
+            >
+              {sortOptionValues.map((sortOption) => (
+                <option key={sortOption} value={sortOption}>
+                  {sortOption}
+                </option>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl>
+            <Label htmlFor="packContentsFilter">Filter packs containing</Label>
+            <Select
+              id="packContentsFilter"
+              value={containingFilterState}
+              onChange={(e) => {
+                setContainingFilterState(e.target.value);
+              }}
+            >
+              {packContentsFilterValues.map((packContentsItem) => (
+                <option key={packContentsItem} value={packContentsItem}>
+                  {packContentsItem}
+                </option>
+              ))}
+            </Select>
+          </FormControl>
         </div>
         <div>
           <Button variant={Button.VARIANT.PRIMARY}>Grid view</Button>
@@ -274,8 +261,10 @@ Label.propTypes = {
 const FormControl = ({ children }) => (
   <div
     css={css`
-      &:not(:last-child) {
-        margin-bottom: 1.5rem;
+      margin: 0 0.5rem;
+
+      @media screen and (max-width: 1180px) {
+        margin: 0.5rem 0;
       }
     `}
   >


### PR DESCRIPTION
## Description

Adds more responsive-ness to landing page, especially form controls / filters. Adds some custom form components for more control over styling and behavior. Very similar to those used in docs site's data dictionary page.

The grid view is already responsive.

## Reviewer notes
* we may want to further refactor how filters work with state and URL params. i noticed that if you load a page with query params, the defaults are applied, then state is updated from query params.

## Related Issue(s) / Ticket(s)
Closes https://github.com/newrelic/developer-website/issues/1349

we may need to wait or merge the work for [list view](https://github.com/newrelic/developer-website/pull/1371) && [adding logos for featured images](https://github.com/newrelic/developer-website/pull/1372)

## Screenshot(s)

![2021-06-07_16-51-10](https://user-images.githubusercontent.com/2952843/121092389-50d89c80-c7a0-11eb-833e-1c5a148a9675.png)

![2021-06-07_16-51-02](https://user-images.githubusercontent.com/2952843/121092395-5504ba00-c7a0-11eb-867c-3d686a1fcd54.png)


