### PR TITLE
O11y pack details mobile view

### DIFF
--- a/src/components/ImageGallery/ImageGallery.js
+++ b/src/components/ImageGallery/ImageGallery.js
@@ -14,7 +14,6 @@ const CreateImageBlock = (image) => {
       rel="noreferrer"
       css={css`
         height: 207px;
-
         margin-right: 16px;
         margin-bottom: 6px;
       `}
@@ -23,9 +22,7 @@ const CreateImageBlock = (image) => {
         src={image}
         alt="placeholder-text"
         css={css`
-          width: 285px;
           height: 207px;
-
           background: linear-gradient(0deg, #f3f4f4, #f3f4f4),
             linear-gradient(
               293.05deg,
@@ -38,8 +35,6 @@ const CreateImageBlock = (image) => {
           box-shadow: inset 0px 0px 0px 4px #ffffff;
           border-radius: 4px;
           padding: 3px;
-
-          object-fit: cover;
         `}
       />
     </a>

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -20,6 +20,9 @@ const ObservabilityPackDetails = ({ data, location }) => {
             title={pack.name}
             css={css`
               border-bottom: none;
+              @media (max-width: 480px) {
+                gap: 1rem;
+              }
             `}
           >
             <Button variant={Button.VARIANT.PRIMARY} size={Button.SIZE.MEDIUM}>

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -20,9 +20,7 @@ const ObservabilityPackDetails = ({ data, location }) => {
             title={pack.name}
             css={css`
               border-bottom: none;
-              @media (max-width: 480px) {
-                gap: 1rem;
-              }
+              gap: 1rem;
             `}
           >
             <Button variant={Button.VARIANT.PRIMARY} size={Button.SIZE.MEDIUM}>
@@ -74,7 +72,6 @@ const ObservabilityPackDetails = ({ data, location }) => {
           </PageLayout.Header>
 
           <Layout.Content>
-            {/* carousel component if we decide to use multiple images */}
             <Tabs.Pages>
               <Tabs.Page id="overview">
                 <ImageGallery images={[]} />


### PR DESCRIPTION
## Description

Added some space in the header column for packs but otherwise things are looking good

**TODO**
- [x] pull in image gallery and make sure mobile is still copasetic

## Related Issue(s) / Ticket(s)

Closes https://github.com/newrelic/developer-website/issues/1352
Tweaks https://github.com/newrelic/developer-website/issues/1341

## Screenshots
<img width="340" alt="Screen Shot 2021-06-08 at 4 26 48 PM" src="https://user-images.githubusercontent.com/39655074/121270400-818b0580-c876-11eb-9884-35196068677a.png">
<img width="329" alt="Screen Shot 2021-06-08 at 4 26 54 PM" src="https://user-images.githubusercontent.com/39655074/121270401-83ed5f80-c876-11eb-8f39-96c26fbcff80.png">
<img width="1318" alt="Screen Shot 2021-06-08 at 4 30 22 PM" src="https://user-images.githubusercontent.com/39655074/121270618-e8a8ba00-c876-11eb-9691-3f5730150514.png">
