### PR TITLE
fix: Search onClear functionality

### DIFF
--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -111,7 +111,8 @@ const ObservabilityPacksPage = ({ data, location }) => {
         css={css`
           margin: 15px 0;
         `}
-        onClear={() => null}
+        value={searchTerm}
+        onClear={() => setSearchTerm('')}
         placeholder="Search for an observability pack"
         onChange={(e) => {
           setSearchTerm(e.target.value.toLowerCase());


### PR DESCRIPTION
`X` button now appears when there's a value in input, and clicking it clears the value

The `SearchInput` component requires `value` and `onClear` to be present to display the `X` button