### PR TITLE
Add break point for o11y pack grid view

### DIFF
--- a/src/components/PackGrid.js
+++ b/src/components/PackGrid.js
@@ -13,7 +13,9 @@ const PackGrid = ({ children, className }) => {
         grid-auto-rows: minmax(var(--guide-list-row-height, 150px), auto);
         align-items: stretch;
         width: 100%;
-
+        @media (max-width: 1450px) {
+          grid-template-columns: repeat(3, minmax(260px, 1fr));
+        }
         @media (max-width: 1180px) {
           grid-template-columns: 1fr;
           grid-gap: 3rem;


### PR DESCRIPTION
## Description

Adds a break point to reduce the grid to 3 columns instead of 4 at a certain width. Not sure if there are nicer ways to get this done with grid but it might do the trick

## Related Issue(s) / Ticket(s)

Closes https://github.com/newrelic/newrelic-observability-packs/issues/57

## Screenshot(s)

<img width="1106" alt="Screen Shot 2021-06-09 at 11 29 21 AM" src="https://user-images.githubusercontent.com/39655074/121409143-feb98780-c915-11eb-844c-f6f05681df2c.png">
<img width="1108" alt="Screen Shot 2021-06-09 at 11 29 39 AM" src="https://user-images.githubusercontent.com/39655074/121409148-011be180-c916-11eb-9f45-b1ddd8558926.png">
