### PR TITLE
Add fade to image gallery

### DIFF
--- a/src/components/ImageGallery/ImageGallery.js
+++ b/src/components/ImageGallery/ImageGallery.js
@@ -52,6 +52,7 @@ const ImageGallery = ({ images, className }) => {
           white-space: nowrap;
           overflow-x: auto;
           &:after {
+            pointer-events: none;
             content: '';
             position: absolute;
             background: linear-gradient(

--- a/src/components/ImageGallery/ImageGallery.js
+++ b/src/components/ImageGallery/ImageGallery.js
@@ -57,7 +57,7 @@ const ImageGallery = ({ images, className }) => {
             position: absolute;
             background: linear-gradient(
               to right,
-              transparent 75%,
+              transparent 87%,
               var(--primary-background-color)
             );
             width: 100%;

--- a/src/components/ImageGallery/ImageGallery.js
+++ b/src/components/ImageGallery/ImageGallery.js
@@ -14,8 +14,7 @@ const CreateImageBlock = (image) => {
       rel="noreferrer"
       css={css`
         height: 207px;
-        margin-right: 16px;
-        margin-bottom: 6px;
+        margin-right: 1rem;
       `}
     >
       <img
@@ -23,18 +22,10 @@ const CreateImageBlock = (image) => {
         alt="placeholder-text"
         css={css`
           height: 207px;
-          background: linear-gradient(0deg, #f3f4f4, #f3f4f4),
-            linear-gradient(
-              293.05deg,
-              #70d3af -73.46%,
-              #007e8a -24.52%,
-              #052a3a 69.75%
-            );
-          border: 1px solid rgba(0, 0, 0, 0.1);
           box-sizing: border-box;
-          box-shadow: inset 0px 0px 0px 4px #ffffff;
+          box-shadow: inset 0px 0px 0px 4px var(--divider-color);
           border-radius: 4px;
-          padding: 3px;
+          padding: 0.25rem;
         `}
       />
     </a>
@@ -49,19 +40,36 @@ const CreateImageBlock = (image) => {
 const ImageGallery = ({ images, className }) => {
   return (
     <div
-      className={className}
       css={css`
-        display: flex;
-        white-space: nowrap;
-        overflow-x: auto;
-        margin-bottom: 32px;
+        position: relative;
+        margin-bottom: 2rem;
       `}
     >
-      {images && images.length > 0
-        ? images.map((image) => {
-            return CreateImageBlock(image);
-          })
-        : CreateImageBlock(noImagePlaceholder)}
+      <div
+        className={className}
+        css={css`
+          display: flex;
+          white-space: nowrap;
+          overflow-x: auto;
+          &:after {
+            content: '';
+            position: absolute;
+            background: linear-gradient(
+              to right,
+              transparent 75%,
+              var(--primary-background-color)
+            );
+            width: 100%;
+            height: 100%;
+          }
+        `}
+      >
+        {images && images.length > 0
+          ? images.map((image) => {
+              return CreateImageBlock(image);
+            })
+          : CreateImageBlock(noImagePlaceholder)}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Description

This adds a fade to the right side of the image gallery to suggest there is more to scroll. I'm not sure if we want to add animation and get rid of the fade when you reach the last image 🤷‍♀️ but here's a first pass 🎉 

## Related Issue(s) / Ticket(s)

Closes https://github.com/newrelic/developer-website/issues/1385

## Screenshot(s)
<img width="959" alt="Screen Shot 2021-06-09 at 5 51 29 PM" src="https://user-images.githubusercontent.com/39655074/121447986-a604e180-c94b-11eb-91e7-acd6a09f5eb5.png">
<img width="966" alt="Screen Shot 2021-06-09 at 5 51 41 PM" src="https://user-images.githubusercontent.com/39655074/121447993-a8ffd200-c94b-11eb-8169-0268e66a0503.png">
