### PR TITLE
chore: remove extra `the` article in docs sentence

### DIFF
--- a/src/markdown-pages/collect-data/collect-data-from-any-source.mdx
+++ b/src/markdown-pages/collect-data/collect-data-from-any-source.mdx
@@ -32,7 +32,7 @@ But you may want to bring data into New Relic that isn't collected by default. M
 
 ## Agent APIs
 
-If you use our APM, Browser, or Mobile agents to report data, you can use their associated APIs to report custom data. For example, if you monitor your application with the our APM Python agent, you can use the [Python agent API](https://docs.newrelic.com/docs/agents/python-agent/api-guides/guide-using-python-agent-api) to set up custom instrumentation.
+If you use our APM, Browser, or Mobile agents to report data, you can use their associated APIs to report custom data. For example, if you monitor your application with our APM Python agent, you can use the [Python agent API](https://docs.newrelic.com/docs/agents/python-agent/api-guides/guide-using-python-agent-api) to set up custom instrumentation.
 
 See the [agent APIs](https://docs.newrelic.com/docs/agents).
 </Step>


### PR DESCRIPTION
## Description

This PR deletes an unnecessary `the` article in a sentence.