### PR TITLE
chore: remove right fade on right when scrolled to end of gallery

### DIFF
--- a/src/components/ImageGallery/ImageGallery.js
+++ b/src/components/ImageGallery/ImageGallery.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 
@@ -38,6 +38,17 @@ const CreateImageBlock = (image) => {
  * @param {String} props.className
  */
 const ImageGallery = ({ images, className }) => {
+  const gallery = useRef();
+  const [isGalleryScrolledToEnd, setIsGalleryScrolledToEnd] = useState(false);
+
+  const onScroll = () => {
+    const scrollLeft = Math.round(gallery.current.scrollLeft);
+    const scrollWidth = gallery.current.scrollWidth;
+    const offsetWidth = gallery.current.offsetWidth;
+    const isScrolledToEnd = scrollWidth - offsetWidth === scrollLeft;
+    setIsGalleryScrolledToEnd(isScrolledToEnd);
+  };
+
   return (
     <div
       css={css`
@@ -47,6 +58,8 @@ const ImageGallery = ({ images, className }) => {
     >
       <div
         className={className}
+        ref={gallery}
+        onScroll={onScroll}
         css={css`
           display: flex;
           white-space: nowrap;
@@ -55,11 +68,13 @@ const ImageGallery = ({ images, className }) => {
             pointer-events: none;
             content: '';
             position: absolute;
-            background: linear-gradient(
+            background: ${!isGalleryScrolledToEnd
+              ? `linear-gradient(
               to right,
               transparent 87%,
               var(--primary-background-color)
-            );
+            )`
+              : `none`};
             width: 100%;
             height: 100%;
           }


### PR DESCRIPTION
## Description

Removes the gradient fade on the right of image gallery when gallery is scrolled all the way to the end.

## Related Issue(s) / Ticket(s)

Addresses part of https://github.com/newrelic/developer-website/issues/1405

## Screenshot(s)

https://user-images.githubusercontent.com/2952843/122313040-56359580-ceca-11eb-9cbc-d6db794ea0bb.mp4


https://user-images.githubusercontent.com/2952843/122313179-97c64080-ceca-11eb-858d-0fd4628fcb21.mp4






