### PR TITLE
chore: update filename for module instructions

### DIFF
--- a/src/markdown-pages/terraform/terrform-modules.mdx
+++ b/src/markdown-pages/terraform/terrform-modules.mdx
@@ -319,9 +319,9 @@ After you have created a module, if you want to store the module somewhere other
 
 ### Create a new Github repo
 
-First, inside of your HostModules directory, initialize a new Github repo. Add your __module.tf__ and __provider.tf__ to the stage for commit:
+First, inside of your HostModules directory, initialize a new Github repo. Add your __main.tf__ and __provider.tf__ to the stage for commit:
 ```bash
-git add module.tf provider.tf
+git add main.tf provider.tf
 git commit -m "init"
 ```
 


### PR DESCRIPTION
## Description

Current instructions provide incorrect filenames

> First, inside of your HostModules directory, initialize a new Github repo. Add your module.tf and provider.tf to the stage for commit:
> 
> ```bash
> git add module.tf provider.tf
> git commit -m "init"
> ```

The file names in the directory should be `main.tf` and `provider.tf`
