### PR TITLE
Add simple image slides with navigation

### DIFF
--- a/src/@newrelic/gatsby-theme-newrelic/icons/feather.js
+++ b/src/@newrelic/gatsby-theme-newrelic/icons/feather.js
@@ -34,6 +34,11 @@ export default {
       />
     </>
   ),
+  'chevron-right': (
+    <>
+      <polyline points="9 18 15 12 9 6" />
+    </>
+  ),
   clock: (
     <>
       <circle cx="12" cy="12" r="10" />

--- a/src/@newrelic/gatsby-theme-newrelic/icons/feather.js
+++ b/src/@newrelic/gatsby-theme-newrelic/icons/feather.js
@@ -34,6 +34,11 @@ export default {
       />
     </>
   ),
+  'chevron-left': (
+    <>
+      <polyline points="15 18 9 12 15 6" />
+    </>
+  ),
   'chevron-right': (
     <>
       <polyline points="9 18 15 12 9 6" />

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
-import { Icon } from '@newrelic/gatsby-theme-newrelic';
+import { Button, Icon } from '@newrelic/gatsby-theme-newrelic';
 
 const ImageSlider = ({ images, height }) => {
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
@@ -29,8 +29,9 @@ const ImageSlider = ({ images, height }) => {
     >
       {images.length > 1 && (
         <>
-          <button
+          <Button
             onClick={handleClickPrev}
+            variant={Button.VARIANT.PLAIN}
             css={css`
               position: absolute;
               top: 38%;
@@ -42,9 +43,10 @@ const ImageSlider = ({ images, height }) => {
             `}
           >
             <Icon name="chevron-left" size="4rem" />
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={handleClickNext}
+            variant={Button.VARIANT.PLAIN}
             css={css`
               position: absolute;
               top: 38%;
@@ -56,7 +58,7 @@ const ImageSlider = ({ images, height }) => {
             `}
           >
             <Icon name="chevron-right" size="4rem" />
-          </button>
+          </Button>
         </>
       )}
       <a

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -62,7 +62,11 @@ const ImageSlider = ({ images, height }) => {
         </>
       )}
       <a
-        href={images && images.length > 0 ? images[selectedImageIndex] : ''}
+        href={
+          images && images.length > 0
+            ? images[selectedImageIndex]
+            : noImagePlaceholder
+        }
         target="_blank"
         rel="noreferrer"
         css={css`

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -18,21 +18,48 @@ const ImageSlider = ({ images, height }) => {
         margin-bottom: 2rem;
       `}
     >
-      <button
-        onClick={handleClickNext}
+      {images.length > 1 && (
+        <button
+          onClick={handleClickNext}
+          css={css`
+            position: absolute;
+            top: 38%;
+            right: 0;
+            background: none;
+            color: var(--color-white);
+            border: none;
+            cursor: pointer;
+          `}
+        >
+          <Icon name="chevron-right" size="4rem" />
+        </button>
+      )}
+      <a
+        href={images[selectedImageIndex]}
+        target="_blank"
+        rel="noreferrer"
         css={css`
-          position: absolute;
-          top: 38%;
-          right: 0;
-          background: none;
-          color: var(--color-white);
-          border: none;
-          cursor: pointer;
+          height: ${height}px;
+          width: 100%;
+          margin-right: 1rem;
         `}
       >
-        <Icon name="chevron-right" size="4rem" />
-      </button>
-      {CreateImageBlock(images[selectedImageIndex], height)}
+        <img
+          src={images[selectedImageIndex]}
+          alt="placeholder-text"
+          css={css`
+            height: ${height}px;
+            width: 100%;
+            box-sizing: border-box;
+            box-shadow: inset 0px 0px 0px 4px var(--divider-color);
+            border-radius: 4px;
+            padding: 0.25rem;
+            @media screen and (max-width: 760px) {
+              object-fit: contain;
+            }
+          `}
+        />
+      </a>
     </div>
   );
 };
@@ -40,34 +67,6 @@ const ImageSlider = ({ images, height }) => {
 ImageSlider.propTypes = {
   images: PropTypes.array,
   height: PropTypes.number,
-};
-
-const CreateImageBlock = (image, height) => {
-  return (
-    <a
-      href={image}
-      target="_blank"
-      rel="noreferrer"
-      css={css`
-        height: ${height}px;
-        width: 100%;
-        margin-right: 1rem;
-      `}
-    >
-      <img
-        src={image}
-        alt="placeholder-text"
-        css={css`
-          height: ${height}px;
-          width: 100%;
-          box-sizing: border-box;
-          box-shadow: inset 0px 0px 0px 4px var(--divider-color);
-          border-radius: 4px;
-          padding: 0.25rem;
-        `}
-      />
-    </a>
-  );
 };
 
 const noImagePlaceholder =

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -15,7 +15,6 @@ const ImageSlider = ({ images, height }) => {
     const prevImageIndex = selectedImageIndex - 1;
     if (prevImageIndex < 0) {
       setSelectedImageIndex(images.length - 1);
-      console.log(images.length - 1);
     } else {
       setSelectedImageIndex(prevImageIndex % images.length);
     }

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -11,6 +11,16 @@ const ImageSlider = ({ images, height }) => {
     setSelectedImageIndex(nextImageIndex % images.length);
   };
 
+  const handleClickPrev = () => {
+    const prevImageIndex = selectedImageIndex - 1;
+    if (prevImageIndex < 0) {
+      setSelectedImageIndex(images.length - 1);
+      console.log(images.length - 1);
+    } else {
+      setSelectedImageIndex(prevImageIndex % images.length);
+    }
+  };
+
   return (
     <div
       css={css`
@@ -19,20 +29,36 @@ const ImageSlider = ({ images, height }) => {
       `}
     >
       {images.length > 1 && (
-        <button
-          onClick={handleClickNext}
-          css={css`
-            position: absolute;
-            top: 38%;
-            right: 0;
-            background: none;
-            color: var(--color-white);
-            border: none;
-            cursor: pointer;
-          `}
-        >
-          <Icon name="chevron-right" size="4rem" />
-        </button>
+        <>
+          <button
+            onClick={handleClickPrev}
+            css={css`
+              position: absolute;
+              top: 38%;
+              left: 0;
+              background: none;
+              color: var(--color-white);
+              border: none;
+              cursor: pointer;
+            `}
+          >
+            <Icon name="chevron-left" size="4rem" />
+          </button>
+          <button
+            onClick={handleClickNext}
+            css={css`
+              position: absolute;
+              top: 38%;
+              right: 0;
+              background: none;
+              color: var(--color-white);
+              border: none;
+              cursor: pointer;
+            `}
+          >
+            <Icon name="chevron-right" size="4rem" />
+          </button>
+        </>
       )}
       <a
         href={images[selectedImageIndex]}

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -60,7 +60,7 @@ const ImageSlider = ({ images, height }) => {
         </>
       )}
       <a
-        href={images[selectedImageIndex]}
+        href={images && images.length > 0 ? images[selectedImageIndex] : ''}
         target="_blank"
         rel="noreferrer"
         css={css`
@@ -70,7 +70,11 @@ const ImageSlider = ({ images, height }) => {
         `}
       >
         <img
-          src={images[selectedImageIndex]}
+          src={
+            images && images.length > 0
+              ? images[selectedImageIndex]
+              : noImagePlaceholder
+          }
           alt="placeholder-text"
           css={css`
             height: ${height}px;

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -1,0 +1,76 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import { css } from '@emotion/react';
+import { Icon } from '@newrelic/gatsby-theme-newrelic';
+
+const ImageSlider = ({ images, height }) => {
+  const [selectedImageIndex, setSelectedImageIndex] = useState(0);
+
+  const handleClickNext = () => {
+    const nextImageIndex = selectedImageIndex + 1;
+    setSelectedImageIndex(nextImageIndex % images.length);
+  };
+
+  return (
+    <div
+      css={css`
+        position: relative;
+        margin-bottom: 2rem;
+      `}
+    >
+      <button
+        onClick={handleClickNext}
+        css={css`
+          position: absolute;
+          top: 38%;
+          right: 0;
+          background: none;
+          color: var(--color-white);
+          border: none;
+          cursor: pointer;
+        `}
+      >
+        <Icon name="chevron-right" size="4rem" />
+      </button>
+      {CreateImageBlock(images[selectedImageIndex], height)}
+    </div>
+  );
+};
+
+ImageSlider.propTypes = {
+  images: PropTypes.array,
+  height: PropTypes.number,
+};
+
+const CreateImageBlock = (image, height) => {
+  return (
+    <a
+      href={image}
+      target="_blank"
+      rel="noreferrer"
+      css={css`
+        height: ${height}px;
+        width: 100%;
+        margin-right: 1rem;
+      `}
+    >
+      <img
+        src={image}
+        alt="placeholder-text"
+        css={css`
+          height: ${height}px;
+          width: 100%;
+          box-sizing: border-box;
+          box-shadow: inset 0px 0px 0px 4px var(--divider-color);
+          border-radius: 4px;
+          padding: 0.25rem;
+        `}
+      />
+    </a>
+  );
+};
+
+const noImagePlaceholder =
+  'https://socialistmodernism.com/wp-content/uploads/2017/07/placeholder-image.png';
+
+export default ImageSlider;

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -14,6 +14,7 @@ import {
 import ImageGallery from '../components/ImageGallery';
 import Intro from '../components/Intro';
 import InstallButton from '../components/InstallButton';
+import ImageSlider from '../components/ImageSlider/ImageSlider';
 
 const ObservabilityPackDetails = ({ data, location }) => {
   const pack = data.observabilityPacks;
@@ -134,7 +135,7 @@ const ObservabilityPackDetails = ({ data, location }) => {
                 {pack.dashboards?.map((dashboard) => (
                   <>
                     <h3>{dashboard.name}</h3>
-                    <ImageGallery images={dashboard.screenshots} />
+                    <ImageSlider height={400} images={dashboard.screenshots} />
                     {dashboard.description && (
                       <>
                         <h4>Description</h4>
@@ -267,11 +268,8 @@ export const pageQuery = graphql`
   query($id: String!) {
     observabilityPacks(id: { eq: $id }) {
       name
-      websiteUrl
-      logoUrl
       level
       id
-      iconUrl
       description
       dashboards {
         description


### PR DESCRIPTION
## Description

Adds simple image slider (without the sliding animation for now) and arrows to navigate to next / prev image.

Does not show nav arrows if only one image

## Reviewer Notes

Wasn't sure what looked best for images either clipped on smaller screen or scaled down.

## Related Issue(s) / Ticket(s)

Related to:
- https://github.com/newrelic/developer-website/issues/1405
- https://github.com/newrelic/developer-website/issues/1388

## Screenshot(s)

https://user-images.githubusercontent.com/2952843/122829771-46d49480-d29c-11eb-98ce-c6d5450641e0.mp4

