### PR TITLE
Add animated image slider

### DIFF
--- a/src/@newrelic/gatsby-theme-newrelic/icons/feather.js
+++ b/src/@newrelic/gatsby-theme-newrelic/icons/feather.js
@@ -34,6 +34,11 @@ export default {
       />
     </>
   ),
+  'chevron-right': (
+    <>
+      <polyline points="9 18 15 12 9 6" />
+    </>
+  ),
   clock: (
     <>
       <circle cx="12" cy="12" r="10" />

--- a/src/@newrelic/gatsby-theme-newrelic/icons/feather.js
+++ b/src/@newrelic/gatsby-theme-newrelic/icons/feather.js
@@ -34,6 +34,11 @@ export default {
       />
     </>
   ),
+  'chevron-left': (
+    <>
+      <polyline points="15 18 9 12 15 6" />
+    </>
+  ),
   'chevron-right': (
     <>
       <polyline points="9 18 15 12 9 6" />

--- a/src/@newrelic/gatsby-theme-newrelic/icons/feather.js
+++ b/src/@newrelic/gatsby-theme-newrelic/icons/feather.js
@@ -44,6 +44,11 @@ export default {
       <polyline points="9 18 15 12 9 6" />
     </>
   ),
+  circle: (
+    <>
+      <circle cx="12" cy="12" r="10" />
+    </>
+  ),
   clock: (
     <>
       <circle cx="12" cy="12" r="10" />

--- a/src/components/ImageSlider.js
+++ b/src/components/ImageSlider.js
@@ -32,6 +32,8 @@ const ImageSlider = ({ images, height }) => {
     <div
       css={css`
         position: relative;
+        display: flex;
+        align-items: center;
         height: ${height}px;
         margin-bottom: 2rem;
         overflow: hidden;
@@ -40,12 +42,14 @@ const ImageSlider = ({ images, height }) => {
       {images.length > 1 && (
         <div
           css={css`
-            position: absolute;
             z-index: 200;
-            top: 38%;
             width: 100%;
+            height: 20%;
             display: flex;
             justify-content: space-between;
+            @media screen and (max-width: 400px) {
+              height: 12%;
+            }
           `}
         >
           <Button
@@ -56,6 +60,9 @@ const ImageSlider = ({ images, height }) => {
               opacity: 0.2;
               border: none;
               cursor: pointer;
+              width: 10%;
+              min-width: 3rem;
+              height: 100%;
               &:hover {
                 opacity: 0.5;
                 background: var(--color-neutrals-300);
@@ -67,7 +74,7 @@ const ImageSlider = ({ images, height }) => {
                 color: var(--color-black);
               `}
               name="chevron-left"
-              size="4rem"
+              size="100%"
             />
           </Button>
           <Button
@@ -78,6 +85,9 @@ const ImageSlider = ({ images, height }) => {
               opacity: 0.2;
               border: none;
               cursor: pointer;
+              width: 10%;
+              min-width: 3rem;
+              height: 100%;
               &:hover {
                 opacity: 0.5;
                 background: var(--color-neutrals-300);
@@ -86,7 +96,7 @@ const ImageSlider = ({ images, height }) => {
           >
             <Icon
               name="chevron-right"
-              size="4rem"
+              size="100%"
               css={css`
                 color: var(--color-black);
               `}
@@ -109,29 +119,24 @@ const ImageSlider = ({ images, height }) => {
           config={{ mass: 1, tension: 100, friction: 20 }}
         >
           {(styles, item) => (
-            <animated.div style={{ ...styles, position: 'absolute' }}>
-              <a
-                href={item}
-                target="_blank"
-                rel="noreferrer"
-                css={css`
-                  height: ${height}px;
-                  width: 100%;
-                  margin-right: 1rem;
-                `}
-              >
+            <animated.div
+              css={css`
+                display: flex;
+                height: 100%;
+                align-items: center;
+              `}
+              style={{ ...styles, position: 'absolute' }}
+            >
+              <a href={item} target="_blank" rel="noreferrer" css={css``}>
                 <img
                   src={item}
                   alt={`${item.split('/').slice(-1)}`}
                   css={css`
-                    height: ${height}px;
+                    width: 100%;
                     box-sizing: border-box;
                     box-shadow: inset 0px 0px 0px 4px var(--divider-color);
                     border-radius: 4px;
                     padding: 0.25rem;
-                    @media screen and (min-width: 1240px) {
-                      width: 100%;
-                    }
                     @media screen and (max-width: 760px) {
                       object-fit: contain;
                       width: 100%;

--- a/src/components/ImageSlider.js
+++ b/src/components/ImageSlider.js
@@ -127,7 +127,7 @@ const ImageSlider = ({ images, height }) => {
               `}
               style={{ ...styles, position: 'absolute' }}
             >
-              <a href={item} target="_blank" rel="noreferrer" css={css``}>
+              <a href={item} target="_blank" rel="noreferrer">
                 <img
                   src={item}
                   alt={`${item.split('/').slice(-1)}`}
@@ -137,10 +137,6 @@ const ImageSlider = ({ images, height }) => {
                     box-shadow: inset 0px 0px 0px 4px var(--divider-color);
                     border-radius: 4px;
                     padding: 0.25rem;
-                    @media screen and (max-width: 760px) {
-                      object-fit: contain;
-                      width: 100%;
-                    }
                   `}
                 />
               </a>

--- a/src/components/ImageSlider.js
+++ b/src/components/ImageSlider.js
@@ -133,6 +133,7 @@ const ImageSlider = ({ images, height }) => {
                   alt={`${item.split('/').slice(-1)}`}
                   css={css`
                     width: 100%;
+                    max-height: ${height}px;
                     box-sizing: border-box;
                     box-shadow: inset 0px 0px 0px 4px var(--divider-color);
                     border-radius: 4px;

--- a/src/components/ImageSlider.js
+++ b/src/components/ImageSlider.js
@@ -134,6 +134,7 @@ const ImageSlider = ({ images, height }) => {
                     }
                     @media screen and (max-width: 760px) {
                       object-fit: contain;
+                      width: 100%;
                     }
                   `}
                 />

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
-import { Icon } from '@newrelic/gatsby-theme-newrelic';
+import { Button, Icon } from '@newrelic/gatsby-theme-newrelic';
 
 const ImageSlider = ({ images, height }) => {
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
@@ -29,8 +29,9 @@ const ImageSlider = ({ images, height }) => {
     >
       {images.length > 1 && (
         <>
-          <button
+          <Button
             onClick={handleClickPrev}
+            variant={Button.VARIANT.PLAIN}
             css={css`
               position: absolute;
               top: 38%;
@@ -42,9 +43,10 @@ const ImageSlider = ({ images, height }) => {
             `}
           >
             <Icon name="chevron-left" size="4rem" />
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={handleClickNext}
+            variant={Button.VARIANT.PLAIN}
             css={css`
               position: absolute;
               top: 38%;
@@ -56,7 +58,7 @@ const ImageSlider = ({ images, height }) => {
             `}
           >
             <Icon name="chevron-right" size="4rem" />
-          </button>
+          </Button>
         </>
       )}
       <a

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -62,7 +62,11 @@ const ImageSlider = ({ images, height }) => {
         </>
       )}
       <a
-        href={images && images.length > 0 ? images[selectedImageIndex] : ''}
+        href={
+          images && images.length > 0
+            ? images[selectedImageIndex]
+            : noImagePlaceholder
+        }
         target="_blank"
         rel="noreferrer"
         css={css`

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -122,7 +122,7 @@ const ImageSlider = ({ images, height }) => {
               >
                 <img
                   src={item}
-                  alt="placeholder-text"
+                  alt={`Image ${item.split('/').slice(-1)}`}
                   css={css`
                     height: ${height}px;
                     width: 100%;

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -122,7 +122,7 @@ const ImageSlider = ({ images, height }) => {
               >
                 <img
                   src={item}
-                  alt={`Image ${item.split('/').slice(-1)}`}
+                  alt={`${item.split('/').slice(-1)}`}
                   css={css`
                     height: ${height}px;
                     width: 100%;

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -120,7 +120,4 @@ ImageSlider.propTypes = {
   height: PropTypes.number,
 };
 
-const noImagePlaceholder =
-  'https://socialistmodernism.com/wp-content/uploads/2017/07/placeholder-image.png';
-
 export default ImageSlider;

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -6,10 +6,12 @@ import { Transition, animated, config } from 'react-spring';
 
 const ImageSlider = ({ images, height }) => {
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
+  const [forward, setForward] = useState(true);
 
   const handleClickNext = () => {
     const nextImageIndex = selectedImageIndex + 1;
     setSelectedImageIndex(nextImageIndex % images.length);
+    setForward(true);
   };
 
   const handleClickPrev = () => {
@@ -19,6 +21,11 @@ const ImageSlider = ({ images, height }) => {
     } else {
       setSelectedImageIndex(prevImageIndex % images.length);
     }
+    setForward(false);
+  };
+
+  const handleClickSpecificSlide = (indexValue) => {
+    setSelectedImageIndex(indexValue);
   };
 
   return (
@@ -27,6 +34,7 @@ const ImageSlider = ({ images, height }) => {
         position: relative;
         height: ${height}px;
         margin-bottom: 2rem;
+        overflow: hidden;
       `}
     >
       {images.length > 1 && (
@@ -68,19 +76,19 @@ const ImageSlider = ({ images, height }) => {
       {
         <Transition
           items={images[selectedImageIndex]}
-          from={{ opacity: 0 }}
-          enter={{ opacity: 1 }}
-          leave={{ opacity: 0 }}
+          from={{
+            opacity: 0.5,
+            transform: `translate3d(${forward ? '100%' : '-100%'}, 0px, 0px)`,
+          }}
+          enter={{ opacity: 1, transform: 'translate3d(-0%, 0px, 0px)' }}
+          leave={{
+            transform: `translate3d(${forward ? '-100%' : '100%'}, 0px, 0px)`,
+          }}
           delay={200}
-          config={config.molasses}
+          config={{ mass: 1, tension: 100, friction: 20 }}
         >
           {(styles, item) => (
-            <animated.div
-              css={css`
-                position: absolute;
-              `}
-              style={styles}
-            >
+            <animated.div style={{ ...styles, position: 'absolute' }}>
               <a
                 href={item}
                 target="_blank"
@@ -111,6 +119,40 @@ const ImageSlider = ({ images, height }) => {
           )}
         </Transition>
       }
+      <div
+        css={css`
+          z-index: 200;
+          position: absolute;
+          bottom: 2%;
+          width: 100%;
+        `}
+      >
+        <div
+          css={css`
+            display: flex;
+            justify-content: center;
+            flex-wrap: wrap;
+          `}
+        >
+          {images.map((_, index) => (
+            <Button
+              onClick={() => handleClickSpecificSlide(index)}
+              variant={Button.VARIANT.PLAIN}
+              css={css`
+                border: none;
+                cursor: pointer;
+              `}
+            >
+              <Icon
+                name="circle"
+                css={css`
+                  fill: ${selectedImageIndex === index ? 'white' : 'none'};
+                `}
+              />
+            </Button>
+          ))}
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -38,23 +38,33 @@ const ImageSlider = ({ images, height }) => {
       `}
     >
       {images.length > 1 && (
-        <>
+        <div
+          css={css`
+            position: absolute;
+            z-index: 200;
+            top: 38%;
+            width: 100%;
+            display: flex;
+            justify-content: space-between;
+          `}
+        >
           <Button
             onClick={handleClickPrev}
             variant={Button.VARIANT.PLAIN}
             css={css`
-              position: absolute;
-              z-index: 200;
-              top: 38%;
-              left: 0;
-              background: none;
+              background: var(--color-neutrals-300);
+              opacity: 0.2;
               border: none;
               cursor: pointer;
+              &:hover {
+                opacity: 0.5;
+                background: var(--color-neutrals-300);
+              }
             `}
           >
             <Icon
               css={css`
-                color: var(--color-teal-500);
+                color: var(--color-black);
               `}
               name="chevron-left"
               size="4rem"
@@ -64,24 +74,25 @@ const ImageSlider = ({ images, height }) => {
             onClick={handleClickNext}
             variant={Button.VARIANT.PLAIN}
             css={css`
-              position: absolute;
-              z-index: 200;
-              top: 38%;
-              right: 0;
-              background: none;
+              background: var(--color-neutrals-300);
+              opacity: 0.2;
               border: none;
               cursor: pointer;
+              &:hover {
+                opacity: 0.5;
+                background: var(--color-neutrals-300);
+              }
             `}
           >
             <Icon
               name="chevron-right"
               size="4rem"
               css={css`
-                color: var(--color-teal-500);
+                color: var(--color-black);
               `}
             />
           </Button>
-        </>
+        </div>
       )}
       {
         <Transition
@@ -152,13 +163,23 @@ const ImageSlider = ({ images, height }) => {
               css={css`
                 border: none;
                 cursor: pointer;
-                color: var(--color-teal-500);
+                color: var(--color-neutrals-300);
+                &:hover {
+                  background: none;
+                  border: none;
+                  color: var(--color-neutrals-300);
+                }
               `}
             >
               <Icon
                 name="circle"
                 css={css`
-                  fill: ${selectedImageIndex === index ? 'teal' : 'none'};
+                  fill: ${selectedImageIndex === index
+                    ? `var(--color-neutrals-300)`
+                    : 'none'};
+                  &:hover {
+                    fill: var(--color-neutrals-300);
+                  }
                 `}
               />
             </Button>

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -18,21 +18,48 @@ const ImageSlider = ({ images, height }) => {
         margin-bottom: 2rem;
       `}
     >
-      <button
-        onClick={handleClickNext}
+      {images.length > 1 && (
+        <button
+          onClick={handleClickNext}
+          css={css`
+            position: absolute;
+            top: 38%;
+            right: 0;
+            background: none;
+            color: var(--color-white);
+            border: none;
+            cursor: pointer;
+          `}
+        >
+          <Icon name="chevron-right" size="4rem" />
+        </button>
+      )}
+      <a
+        href={images[selectedImageIndex]}
+        target="_blank"
+        rel="noreferrer"
         css={css`
-          position: absolute;
-          top: 38%;
-          right: 0;
-          background: none;
-          color: var(--color-white);
-          border: none;
-          cursor: pointer;
+          height: ${height}px;
+          width: 100%;
+          margin-right: 1rem;
         `}
       >
-        <Icon name="chevron-right" size="4rem" />
-      </button>
-      {CreateImageBlock(images[selectedImageIndex], height)}
+        <img
+          src={images[selectedImageIndex]}
+          alt="placeholder-text"
+          css={css`
+            height: ${height}px;
+            width: 100%;
+            box-sizing: border-box;
+            box-shadow: inset 0px 0px 0px 4px var(--divider-color);
+            border-radius: 4px;
+            padding: 0.25rem;
+            @media screen and (max-width: 760px) {
+              object-fit: contain;
+            }
+          `}
+        />
+      </a>
     </div>
   );
 };
@@ -40,34 +67,6 @@ const ImageSlider = ({ images, height }) => {
 ImageSlider.propTypes = {
   images: PropTypes.array,
   height: PropTypes.number,
-};
-
-const CreateImageBlock = (image, height) => {
-  return (
-    <a
-      href={image}
-      target="_blank"
-      rel="noreferrer"
-      css={css`
-        height: ${height}px;
-        width: 100%;
-        margin-right: 1rem;
-      `}
-    >
-      <img
-        src={image}
-        alt="placeholder-text"
-        css={css`
-          height: ${height}px;
-          width: 100%;
-          box-sizing: border-box;
-          box-shadow: inset 0px 0px 0px 4px var(--divider-color);
-          border-radius: 4px;
-          padding: 0.25rem;
-        `}
-      />
-    </a>
-  );
 };
 
 const noImagePlaceholder =

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -15,7 +15,6 @@ const ImageSlider = ({ images, height }) => {
     const prevImageIndex = selectedImageIndex - 1;
     if (prevImageIndex < 0) {
       setSelectedImageIndex(images.length - 1);
-      console.log(images.length - 1);
     } else {
       setSelectedImageIndex(prevImageIndex % images.length);
     }

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
 import { Button, Icon } from '@newrelic/gatsby-theme-newrelic';
+import { Transition, animated, config } from 'react-spring';
 
 const ImageSlider = ({ images, height }) => {
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
@@ -24,6 +25,7 @@ const ImageSlider = ({ images, height }) => {
     <div
       css={css`
         position: relative;
+        height: ${height}px;
         margin-bottom: 2rem;
       `}
     >
@@ -34,6 +36,7 @@ const ImageSlider = ({ images, height }) => {
             variant={Button.VARIANT.PLAIN}
             css={css`
               position: absolute;
+              z-index: 200;
               top: 38%;
               left: 0;
               background: none;
@@ -49,6 +52,7 @@ const ImageSlider = ({ images, height }) => {
             variant={Button.VARIANT.PLAIN}
             css={css`
               position: absolute;
+              z-index: 200;
               top: 38%;
               right: 0;
               background: none;
@@ -61,40 +65,52 @@ const ImageSlider = ({ images, height }) => {
           </Button>
         </>
       )}
-      <a
-        href={
-          images && images.length > 0
-            ? images[selectedImageIndex]
-            : noImagePlaceholder
-        }
-        target="_blank"
-        rel="noreferrer"
-        css={css`
-          height: ${height}px;
-          width: 100%;
-          margin-right: 1rem;
-        `}
-      >
-        <img
-          src={
-            images && images.length > 0
-              ? images[selectedImageIndex]
-              : noImagePlaceholder
-          }
-          alt="placeholder-text"
-          css={css`
-            height: ${height}px;
-            width: 100%;
-            box-sizing: border-box;
-            box-shadow: inset 0px 0px 0px 4px var(--divider-color);
-            border-radius: 4px;
-            padding: 0.25rem;
-            @media screen and (max-width: 760px) {
-              object-fit: contain;
-            }
-          `}
-        />
-      </a>
+      {
+        <Transition
+          items={images[selectedImageIndex]}
+          from={{ opacity: 0 }}
+          enter={{ opacity: 1 }}
+          leave={{ opacity: 0 }}
+          delay={200}
+          config={config.molasses}
+        >
+          {(styles, item) => (
+            <animated.div
+              css={css`
+                position: absolute;
+              `}
+              style={styles}
+            >
+              <a
+                href={item}
+                target="_blank"
+                rel="noreferrer"
+                css={css`
+                  height: ${height}px;
+                  width: 100%;
+                  margin-right: 1rem;
+                `}
+              >
+                <img
+                  src={item}
+                  alt="placeholder-text"
+                  css={css`
+                    height: ${height}px;
+                    width: 100%;
+                    box-sizing: border-box;
+                    box-shadow: inset 0px 0px 0px 4px var(--divider-color);
+                    border-radius: 4px;
+                    padding: 0.25rem;
+                    @media screen and (max-width: 760px) {
+                      object-fit: contain;
+                    }
+                  `}
+                />
+              </a>
+            </animated.div>
+          )}
+        </Transition>
+      }
     </div>
   );
 };

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -11,6 +11,16 @@ const ImageSlider = ({ images, height }) => {
     setSelectedImageIndex(nextImageIndex % images.length);
   };
 
+  const handleClickPrev = () => {
+    const prevImageIndex = selectedImageIndex - 1;
+    if (prevImageIndex < 0) {
+      setSelectedImageIndex(images.length - 1);
+      console.log(images.length - 1);
+    } else {
+      setSelectedImageIndex(prevImageIndex % images.length);
+    }
+  };
+
   return (
     <div
       css={css`
@@ -19,20 +29,36 @@ const ImageSlider = ({ images, height }) => {
       `}
     >
       {images.length > 1 && (
-        <button
-          onClick={handleClickNext}
-          css={css`
-            position: absolute;
-            top: 38%;
-            right: 0;
-            background: none;
-            color: var(--color-white);
-            border: none;
-            cursor: pointer;
-          `}
-        >
-          <Icon name="chevron-right" size="4rem" />
-        </button>
+        <>
+          <button
+            onClick={handleClickPrev}
+            css={css`
+              position: absolute;
+              top: 38%;
+              left: 0;
+              background: none;
+              color: var(--color-white);
+              border: none;
+              cursor: pointer;
+            `}
+          >
+            <Icon name="chevron-left" size="4rem" />
+          </button>
+          <button
+            onClick={handleClickNext}
+            css={css`
+              position: absolute;
+              top: 38%;
+              right: 0;
+              background: none;
+              color: var(--color-white);
+              border: none;
+              cursor: pointer;
+            `}
+          >
+            <Icon name="chevron-right" size="4rem" />
+          </button>
+        </>
       )}
       <a
         href={images[selectedImageIndex]}

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
 import { Button, Icon } from '@newrelic/gatsby-theme-newrelic';
-import { Transition, animated, config } from 'react-spring';
+import { Transition, animated } from 'react-spring';
 
 const ImageSlider = ({ images, height }) => {
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
@@ -137,6 +137,7 @@ const ImageSlider = ({ images, height }) => {
           {images.map((_, index) => (
             <Button
               onClick={() => handleClickSpecificSlide(index)}
+              key={`goToSlide${index}`}
               variant={Button.VARIANT.PLAIN}
               css={css`
                 border: none;

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -125,11 +125,13 @@ const ImageSlider = ({ images, height }) => {
                   alt={`${item.split('/').slice(-1)}`}
                   css={css`
                     height: ${height}px;
-                    width: 100%;
                     box-sizing: border-box;
                     box-shadow: inset 0px 0px 0px 4px var(--divider-color);
                     border-radius: 4px;
                     padding: 0.25rem;
+                    @media screen and (min-width: 1240px) {
+                      width: 100%;
+                    }
                     @media screen and (max-width: 760px) {
                       object-fit: contain;
                     }
@@ -191,8 +193,8 @@ const ImageSlider = ({ images, height }) => {
 };
 
 ImageSlider.propTypes = {
-  images: PropTypes.array,
-  height: PropTypes.number,
+  images: PropTypes.array.isRequired,
+  height: PropTypes.number.isRequired,
 };
 
 export default ImageSlider;

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -4,7 +4,11 @@ import { css } from '@emotion/react';
 import { Button, Icon } from '@newrelic/gatsby-theme-newrelic';
 import { Transition, animated } from 'react-spring';
 
-const ImageSlider = ({ images, height }) => {
+const ImageSlider = ({ _, height }) => {
+  const images = [
+    'https://docs.newrelic.com/static/6f1272aa038f79c90a0c07a3d60b16df/109e2/FSO_landing0.png',
+    'https://raw.githubusercontent.com/newrelic/newrelic-observability-packs/v0.8.2/packs/apache/dashboards/apache01.png',
+  ];
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
   const [forward, setForward] = useState(true);
 
@@ -48,12 +52,17 @@ const ImageSlider = ({ images, height }) => {
               top: 38%;
               left: 0;
               background: none;
-              color: var(--color-white);
               border: none;
               cursor: pointer;
             `}
           >
-            <Icon name="chevron-left" size="4rem" />
+            <Icon
+              css={css`
+                color: var(--color-teal-500);
+              `}
+              name="chevron-left"
+              size="4rem"
+            />
           </Button>
           <Button
             onClick={handleClickNext}
@@ -64,12 +73,17 @@ const ImageSlider = ({ images, height }) => {
               top: 38%;
               right: 0;
               background: none;
-              color: var(--color-white);
               border: none;
               cursor: pointer;
             `}
           >
-            <Icon name="chevron-right" size="4rem" />
+            <Icon
+              name="chevron-right"
+              size="4rem"
+              css={css`
+                color: var(--color-teal-500);
+              `}
+            />
           </Button>
         </>
       )}
@@ -142,12 +156,13 @@ const ImageSlider = ({ images, height }) => {
               css={css`
                 border: none;
                 cursor: pointer;
+                color: var(--color-teal-500);
               `}
             >
               <Icon
                 name="circle"
                 css={css`
-                  fill: ${selectedImageIndex === index ? 'white' : 'none'};
+                  fill: ${selectedImageIndex === index ? 'teal' : 'none'};
                 `}
               />
             </Button>

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -4,11 +4,7 @@ import { css } from '@emotion/react';
 import { Button, Icon } from '@newrelic/gatsby-theme-newrelic';
 import { Transition, animated } from 'react-spring';
 
-const ImageSlider = ({ _, height }) => {
-  const images = [
-    'https://docs.newrelic.com/static/6f1272aa038f79c90a0c07a3d60b16df/109e2/FSO_landing0.png',
-    'https://raw.githubusercontent.com/newrelic/newrelic-observability-packs/v0.8.2/packs/apache/dashboards/apache01.png',
-  ];
+const ImageSlider = ({ images, height }) => {
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
   const [forward, setForward] = useState(true);
 

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -60,7 +60,7 @@ const ImageSlider = ({ images, height }) => {
         </>
       )}
       <a
-        href={images[selectedImageIndex]}
+        href={images && images.length > 0 ? images[selectedImageIndex] : ''}
         target="_blank"
         rel="noreferrer"
         css={css`
@@ -70,7 +70,11 @@ const ImageSlider = ({ images, height }) => {
         `}
       >
         <img
-          src={images[selectedImageIndex]}
+          src={
+            images && images.length > 0
+              ? images[selectedImageIndex]
+              : noImagePlaceholder
+          }
           alt="placeholder-text"
           css={css`
             height: ${height}px;

--- a/src/components/ImageSlider/ImageSlider.js
+++ b/src/components/ImageSlider/ImageSlider.js
@@ -1,0 +1,76 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import { css } from '@emotion/react';
+import { Icon } from '@newrelic/gatsby-theme-newrelic';
+
+const ImageSlider = ({ images, height }) => {
+  const [selectedImageIndex, setSelectedImageIndex] = useState(0);
+
+  const handleClickNext = () => {
+    const nextImageIndex = selectedImageIndex + 1;
+    setSelectedImageIndex(nextImageIndex % images.length);
+  };
+
+  return (
+    <div
+      css={css`
+        position: relative;
+        margin-bottom: 2rem;
+      `}
+    >
+      <button
+        onClick={handleClickNext}
+        css={css`
+          position: absolute;
+          top: 38%;
+          right: 0;
+          background: none;
+          color: var(--color-white);
+          border: none;
+          cursor: pointer;
+        `}
+      >
+        <Icon name="chevron-right" size="4rem" />
+      </button>
+      {CreateImageBlock(images[selectedImageIndex], height)}
+    </div>
+  );
+};
+
+ImageSlider.propTypes = {
+  images: PropTypes.array,
+  height: PropTypes.number,
+};
+
+const CreateImageBlock = (image, height) => {
+  return (
+    <a
+      href={image}
+      target="_blank"
+      rel="noreferrer"
+      css={css`
+        height: ${height}px;
+        width: 100%;
+        margin-right: 1rem;
+      `}
+    >
+      <img
+        src={image}
+        alt="placeholder-text"
+        css={css`
+          height: ${height}px;
+          width: 100%;
+          box-sizing: border-box;
+          box-shadow: inset 0px 0px 0px 4px var(--divider-color);
+          border-radius: 4px;
+          padding: 0.25rem;
+        `}
+      />
+    </a>
+  );
+};
+
+const noImagePlaceholder =
+  'https://socialistmodernism.com/wp-content/uploads/2017/07/placeholder-image.png';
+
+export default ImageSlider;

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -14,7 +14,7 @@ import {
 import ImageGallery from '../components/ImageGallery';
 import Intro from '../components/Intro';
 import InstallButton from '../components/InstallButton';
-import ImageSlider from '../components/ImageSlider/ImageSlider';
+import ImageSlider from '../components/ImageSlider';
 
 const ObservabilityPackDetails = ({ data, location }) => {
   const pack = data.observabilityPacks;

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -14,6 +14,7 @@ import {
 import ImageGallery from '../components/ImageGallery';
 import Intro from '../components/Intro';
 import InstallButton from '../components/InstallButton';
+import ImageSlider from '../components/ImageSlider/ImageSlider';
 
 const ObservabilityPackDetails = ({ data, location }) => {
   const pack = data.observabilityPacks;
@@ -134,7 +135,7 @@ const ObservabilityPackDetails = ({ data, location }) => {
                 {pack.dashboards?.map((dashboard) => (
                   <>
                     <h3>{dashboard.name}</h3>
-                    <ImageGallery images={dashboard.screenshots} />
+                    <ImageSlider height={400} images={dashboard.screenshots} />
                     {dashboard.description && (
                       <>
                         <h4>Description</h4>
@@ -267,11 +268,8 @@ export const pageQuery = graphql`
   query($id: String!) {
     observabilityPacks(id: { eq: $id }) {
       name
-      websiteUrl
-      logoUrl
       level
       id
-      iconUrl
       description
       dashboards {
         description


### PR DESCRIPTION
## Description

Adds animated image slider and nav controls to go to next/prev/specific slides. Does not show nav controls if only one image. Assumes for now there will always be at least one image passed  in via props.

Wasn't sure what looked best for images either clipped on smaller screen or scaled down. Went with what I thought was slightly better option and scaled down image so you can see entire thing instead of tiny portion of it ¯\_(ツ)_/¯

Tried to address styling for nav controls being visible but obtrusive on both dark / light screenshots.

## Related Issue(s) / Ticket(s)

Related to:
- https://github.com/newrelic/developer-website/issues/1405
- https://github.com/newrelic/developer-website/issues/1388
- https://github.com/newrelic/developer-website/pull/1415 (incorporated most of @zstix feedback from this PR into this one)

## Screenshot(s)

https://user-images.githubusercontent.com/2952843/122978699-a50c8080-d34b-11eb-809f-b9dee7462a58.mp4




