### PR TITLE
fix: swap CI env variable for require.main

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "build:production": "GATSBY_NEWRELIC_ENV=production gatsby build",
     "build:staging": "GATSBY_NEWRELIC_ENV=staging gatsby build",
     "build:related-content": "BUILD_RELATED_CONTENT=true yarn run build:production",
-    "fetch-observability-packs": "CI=true node ./scripts/actions/fetch-observability-packs.js",
+    "fetch-observability-packs": "node ./scripts/actions/fetch-observability-packs.js",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "yarn run develop",

--- a/scripts/actions/fetch-observability-packs.js
+++ b/scripts/actions/fetch-observability-packs.js
@@ -112,13 +112,13 @@ const main = async (query, url, token) => {
     console.log(
       'No packs were returned from the api, check the logs for errors.'
     );
-    if (process.env.CI) {
+    if (require.main === module) {
       process.exit(1);
     }
   }
 };
 
-if (process.env.CI) {
+if (require.main === module) {
   validateEnvVars();
   main(packQuery, NR_API_URL, NR_API_TOKEN);
 }


### PR DESCRIPTION
## Description
We were using the environment variable `CI` to determine if a script was executed directly or imported for tests. However, Github Actions force sets that variable to `true`, so it will also be true when we're trying to run unit tests in a job. 
This PR removes that environment variable and transfers to using `require.main === module` to determine how the file is being accessed. [Node docs on `require.main`](https://nodejs.org/docs/latest/api/modules.html#modules_accessing_the_main_module)