### PR TITLE
chore: changed application to nerdpack

### DIFF
--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -21,7 +21,7 @@ const packContentsFilterValues = [
   'Alerts',
   'Visualizations',
   'Synthetics Checks',
-  'Applications',
+  'Nerdpacks',
 ];
 
 const VIEWS = {

--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -20,7 +20,7 @@ const packContentsFilterValues = [
   'Dashboards',
   'Alerts',
   'Visualizations',
-  'Synthetics Checks',
+  'Synthetics',
   'Nerdpacks',
 ];
 

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -75,7 +75,7 @@ const ObservabilityPackDetails = ({ data, location }) => {
                 disabled={!(pack.synthetics?.length ?? 0)}
                 count={pack.synthetics?.length ?? 0}
               >
-                Synthetics checks
+                Synthetics
               </Tabs.BarItem>
               <Tabs.BarItem
                 id="visualizations"


### PR DESCRIPTION
This PR changes applications to nerdpacks in the filter and removes "checks" from Synthetics in the filter and tabs