### PR TITLE
Use most recently stable version of SDK

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -170,7 +170,7 @@ module.exports = {
     {
       resolve: 'gatsby-source-newrelic-sdk',
       options: {
-        release: 'release-2776',
+        release: 'release-2751',
       },
     },
     'gatsby-plugin-embed-pages',


### PR DESCRIPTION
## Description

There's an issue with the `Transform data` example of the NrqlQueries component in our [sdk docs](https://developer.newrelic.com/components/nrql-queries/), this issue isn't present in the internal sdk docs site so I'm rolling us back to the version of the sdk they currently use