### PR TITLE
chore: fix signup link on student page

### DIFF
--- a/src/pages/students.js
+++ b/src/pages/students.js
@@ -187,7 +187,7 @@ const StudentsPage = ({ location }) => {
             <Button
               as={ExternalLink}
               className={styles.nominateButton}
-              href="https://forms.gle/Zkdub5e1x4MNqSKW9"
+              href="https://newrelic.com/signup"
               variant={Button.VARIANT.PRIMARY}
             >
               Sign up for a free account{' '}


### PR DESCRIPTION
## Description

There seems to be a wrong registration link on the Student GitHub Education Pack page. I do not know if it should be corrected to the general one I added, but it certainly should not be this form on Google. 

Also recently, I noticed that the broken option that should allow verification with a GitHub account has disappeared from the New Relic One panel. Can you still get the New Relic GitHub Education Pack?

I tried to contact the email provided on GitHub Education Pack page but no one has been writing back for over a month. However, if this promotion is over, it might be better to remove this article.

## Reviewer Notes

If there are links or steps needed to test this work, add them here.

## Related Issue(s) / Ticket(s)

If there are any related [GitHub Issues](https://github.com/newrelic/developer-website/issues) or JIRA tickets, add links to them here.
* [issue]()

## Screenshot(s)

If relevant, add screenshots here.

## Use Conventional Commits

Please help the maintainers by leveraging the following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
standards in your pull request title and commit messages.

## Use `chore`

* for minor changes / additions / corrections to content.
* for minor changes / additions / corrections to images.
* for minor non-functional changes / additions to github actions, github templates, package or config updates, etc

```bash
git commit -m "chore: adjusting config and content"
```

## Use `fix`

* for minor functional corrections to code.

```bash
git commit -m "fix: typo and prop error in the code of conduct"
```

## Use `feat`

* for major functional changes or additions to code.

```bash
git commit -m "feat(media): creating a video landing page"
```
