### PR TITLE
Move search to filters area

### DIFF
--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -14,7 +14,6 @@ import {
 } from '@newrelic/gatsby-theme-newrelic';
 import { useQueryParam, StringParam } from 'use-query-params';
 import { useDebounce } from 'react-use';
-import { search } from 'core-js/fn/symbol';
 
 const sortOptionValues = ['Alphabetical', 'Reverse', 'Popularity'];
 const packContentsFilterGroups = [
@@ -105,7 +104,7 @@ const ObservabilityPacksPage = ({ data, location }) => {
   }, [view]);
 
   useEffect(() => {
-    let duration = 500;
+    const duration = 500;
     searchOpen
       ? setTimeout(() => searchInputRef.current.focus(), duration)
       : setTimeout(() => searchInputRef.current.blur(), duration);

--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -44,7 +44,7 @@ const ObservabilityPacksPage = ({ data, location }) => {
   const [sortState, setSortState] = useState('Alphabetical');
   const [searchTerm, setSearchTerm] = useState('');
   const [view, setView] = useState(VIEWS.GRID);
-  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchExpanded, setSearchExpanded] = useState(false);
 
   const [querySearch, setQuerySearch] = useQueryParam('search', StringParam);
   const [queryFilter, setQueryFilter] = useQueryParam('filter', StringParam);
@@ -53,7 +53,7 @@ const ObservabilityPacksPage = ({ data, location }) => {
   const searchInputRef = useRef();
 
   useKeyPress('s', () => {
-    setSearchOpen(!searchOpen);
+    setSearchExpanded(!searchExpanded);
   });
 
   useInstrumentedData(
@@ -91,7 +91,7 @@ const ObservabilityPacksPage = ({ data, location }) => {
   useEffect(() => {
     if (querySearch) {
       setSearchTerm(querySearch);
-      setSearchOpen(true);
+      setsearchExpanded(true);
     }
     if (queryFilter) {
       setContainingFilterState(queryFilter);
@@ -107,10 +107,10 @@ const ObservabilityPacksPage = ({ data, location }) => {
 
   useEffect(() => {
     const duration = 500;
-    searchOpen
+    searchExpanded
       ? setTimeout(() => searchInputRef.current.focus(), duration)
       : setTimeout(() => searchInputRef.current.blur(), duration);
-  }, [searchOpen]);
+  }, [searchExpanded]);
 
   useEffect(() => {
     let tempFilteredPacks = o11yPacks.filter(
@@ -137,10 +137,10 @@ const ObservabilityPacksPage = ({ data, location }) => {
 
     if (searchTerm !== '') {
       setQuerySearch(searchTerm);
-      setSearchOpen(true);
+      setSearchExpanded(true);
     } else {
       setQuerySearch(undefined);
-      setSearchOpen(false);
+      setSearchExpanded(false);
     }
     setQueryFilter(containingFilterState);
     setQuerySort(sortState);
@@ -219,11 +219,11 @@ const ObservabilityPacksPage = ({ data, location }) => {
               }
             `}
             style={{
-              width: `${searchOpen ? '300px' : '50px'}`,
+              width: `${searchExpanded ? '300px' : '50px'}`,
               transition: 'all 0.5s ease',
             }}
           >
-            {!searchOpen && (
+            {!searchExpanded && (
               <Button
                 variant={Button.VARIANT.PLAIN}
                 css={css`
@@ -232,7 +232,7 @@ const ObservabilityPacksPage = ({ data, location }) => {
                   color: inherit;
                   cursor: pointer;
                 `}
-                onClick={() => setSearchOpen(true)}
+                onClick={() => setSearchExpanded(true)}
               >
                 <Icon name="fe-search" />
               </Button>
@@ -240,12 +240,13 @@ const ObservabilityPacksPage = ({ data, location }) => {
             <SearchInput
               ref={searchInputRef}
               value={searchTerm}
+              placeholder="Search pack names / descriptions"
               style={{
-                display: `${searchOpen ? 'block' : 'none'}`,
+                display: `${searchExpanded ? 'block' : 'none'}`,
               }}
               onClear={() => {
                 setSearchTerm('');
-                setSearchOpen(false);
+                setSearchExpanded(false);
               }}
               onChange={(e) => {
                 setSearchTerm(e.target.value.toLowerCase());

--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -8,6 +8,7 @@ import SegmentedControl from '../components/SegmentedControl';
 import PackTile from '../components/PackTile';
 import {
   SearchInput,
+  Icon,
   useTessen,
   useInstrumentedData,
   useKeyPress,
@@ -213,28 +214,32 @@ const ObservabilityPacksPage = ({ data, location }) => {
           <div
             css={css`
               input {
-                border: ${searchOpen
-                  ? '1px solid var(--border-color)'
-                  : 'none'};
                 background: inherit;
-                cursor: ${searchOpen ? 'text' : 'pointer'};
               }
             `}
             style={{
-              overflow: 'hidden',
-              cursor: 'pointer',
               width: `${searchOpen ? '300px' : '50px'}`,
               transition: 'all 0.5s ease',
             }}
-            onClick={() => setSearchOpen(true)}
-            role="button"
-            tabIndex={0}
           >
+            {!searchOpen && (
+              <button
+                css={css`
+                  background: none;
+                  border: none;
+                  color: inherit;
+                  cursor: pointer;
+                `}
+                onClick={() => setSearchOpen(true)}
+              >
+                <Icon name="fe-search" />
+              </button>
+            )}
             <SearchInput
               ref={searchInputRef}
               value={searchTerm}
               style={{
-                border: `${searchOpen ? 'auto' : 'none'}`,
+                display: `${searchOpen ? 'block' : 'none'}`,
               }}
               onClear={() => {
                 setSearchTerm('');

--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -235,10 +235,7 @@ const ObservabilityPacksPage = ({ data, location }) => {
               <Button
                 variant={Button.VARIANT.PLAIN}
                 css={css`
-                  background: none;
                   border: none;
-                  color: inherit;
-                  cursor: pointer;
                 `}
                 onClick={handleSearchButtonClick}
               >

--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -71,6 +71,14 @@ const ObservabilityPacksPage = ({ data, location }) => {
     { enabled: Boolean(containingFilterState) }
   );
 
+  const handleSearchButtonClick = () => {
+    setSearchExpanded(true);
+    tessen.track('observabilityPack', `packSearchButtonClick`);
+    if (typeof window !== 'undefined' && window.newrelic) {
+      window.newrelic.addPageAction('packSearchButtonClick');
+    }
+  };
+
   useDebounce(
     () => {
       if (searchTerm && searchTerm !== '') {
@@ -232,7 +240,7 @@ const ObservabilityPacksPage = ({ data, location }) => {
                   color: inherit;
                   cursor: pointer;
                 `}
-                onClick={() => setSearchExpanded(true)}
+                onClick={handleSearchButtonClick}
               >
                 <Icon name="fe-search" />
               </Button>

--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -9,6 +9,7 @@ import PackTile from '../components/PackTile';
 import {
   SearchInput,
   Icon,
+  Button,
   useTessen,
   useInstrumentedData,
   useKeyPress,
@@ -223,7 +224,8 @@ const ObservabilityPacksPage = ({ data, location }) => {
             }}
           >
             {!searchOpen && (
-              <button
+              <Button
+                variant={Button.VARIANT.PLAIN}
                 css={css`
                   background: none;
                   border: none;
@@ -233,7 +235,7 @@ const ObservabilityPacksPage = ({ data, location }) => {
                 onClick={() => setSearchOpen(true)}
               >
                 <Icon name="fe-search" />
-              </button>
+              </Button>
             )}
             <SearchInput
               ref={searchInputRef}

--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -91,7 +91,7 @@ const ObservabilityPacksPage = ({ data, location }) => {
   useEffect(() => {
     if (querySearch) {
       setSearchTerm(querySearch);
-      setsearchExpanded(true);
+      setSearchExpanded(true);
     }
     if (queryFilter) {
       setContainingFilterState(queryFilter);

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -45,7 +45,7 @@ const ObservabilityPackDetails = ({ data, location }) => {
             `}
           >
             <InstallButton
-              title={`Install Pack`}
+              title="Install Pack"
               guid={pack.id}
               onClick={handleInstallClick}
             />


### PR DESCRIPTION
## Description

Moves the search input to the filters area. Animates expanding / collapsing the input on button click.

Adds keyboard shortcut `s` to expand search.

Adds tessen/browser page action tracking for search button clicks.

Wasn't quite sure if I should expand on mobile by default.

## Related Issue(s) / Ticket(s)

* Closes https://github.com/newrelic/developer-website/issues/1459

## Screenshot(s)

https://user-images.githubusercontent.com/2952843/124802491-e20c7180-df0c-11eb-9f86-54f4c1a54498.mp4

### Mobile

![2021-07-07_10-22-42](https://user-images.githubusercontent.com/2952843/124802885-4cbdad00-df0d-11eb-8e23-18ee581ebe0c.png)



