### PR TITLE
Add a default logo for packs without an image

### DIFF
--- a/plugins/gatsby-source-newrelic-sdk/gatsby-ssr.js
+++ b/plugins/gatsby-source-newrelic-sdk/gatsby-ssr.js
@@ -6,11 +6,6 @@ export const onPreRenderHTML = ({
 }) => {
   replaceHeadComponents([
     ...getHeadComponents(),
-    <link
-      key="space-mono"
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Space+Mono&display=swap"
-    />,
     <script
       key="react-router"
       defer

--- a/plugins/gatsby-source-newrelic-sdk/gatsby-ssr.js
+++ b/plugins/gatsby-source-newrelic-sdk/gatsby-ssr.js
@@ -6,6 +6,11 @@ export const onPreRenderHTML = ({
 }) => {
   replaceHeadComponents([
     ...getHeadComponents(),
+    <link
+      key="space-mono"
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Space+Mono&display=swap"
+    />,
     <script
       key="react-router"
       defer

--- a/src/components/PackImg.js
+++ b/src/components/PackImg.js
@@ -4,6 +4,14 @@ import { css } from '@emotion/react';
 import DEFAULT_IMAGE from '../images/new-relic-logo.png';
 
 const PackImg = ({ className, logoUrl, packName }) => {
+  const getPackNameAcronym = () => {
+    let packNameAcronym = '';
+    packName.split(' ').forEach((word) => {
+      packNameAcronym = packNameAcronym.concat('', word.charAt(0));
+    });
+    return packNameAcronym.toUpperCase();
+  };
+
   if (logoUrl) {
     return (
       <img
@@ -25,7 +33,7 @@ const PackImg = ({ className, logoUrl, packName }) => {
       className={className}
       css={css`
         color: var(--color-brand-400);
-        font-family: 'Space Mono', monospace;
+        font-family: var(--code-font);
         font-size: 7rem;
       `}
     >
@@ -75,7 +83,7 @@ const PackImg = ({ className, logoUrl, packName }) => {
           line-height: 150%;
         `}
       >
-        {packName.charAt(0)}
+        {getPackNameAcronym()}
       </p>
     </div>
   );

--- a/src/components/PackImg.js
+++ b/src/components/PackImg.js
@@ -24,7 +24,7 @@ const PackImg = ({ className, logoUrl, packName }) => {
     <div
       className={className}
       css={css`
-        color: dodgerblue;
+        color: var(--color-brand-400);
         font-family: 'Space Mono', monospace;
         font-size: 7rem;
       `}

--- a/src/components/PackImg.js
+++ b/src/components/PackImg.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/react';
+import DEFAULT_IMAGE from '../images/new-relic-logo.png';
+
+const PackImg = ({ className, logoUrl, packName }) => {
+  if (logoUrl) {
+    return (
+      <img
+        css={css`
+          display: block;
+        `}
+        src={logoUrl}
+        alt={packName}
+        onError={(e) => {
+          e.preventDefault();
+          e.target.src = DEFAULT_IMAGE;
+        }}
+        className={className}
+      />
+    );
+  }
+  return (
+    <div
+      className={className}
+      css={css`
+        color: dodgerblue;
+        font-family: 'Space Mono', monospace;
+        font-size: 7rem;
+      `}
+    >
+      <div
+        css={css`
+          border: solid var(--color-brand-400) 2px;
+          height: 1px;
+          width: 60px;
+          position: relative;
+          top: 20%;
+          left: 0;
+        `}
+      />
+      <div
+        css={css`
+          border: solid var(--color-green-200) 2px;
+          height: 1px;
+          width: 30px;
+          position: relative;
+          top: 75%;
+          left: 90%;
+        `}
+      />
+      <div
+        css={css`
+          border: solid var(--color-red-300) 2px;
+          height: 1px;
+          width: 20px;
+          position: relative;
+          top: 50px;
+          left: 0px;
+        `}
+      />
+      <div
+        css={css`
+          border: solid var(--color-brand-300) 2px;
+          height: 1px;
+          width: 50px;
+          position: relative;
+          top: 80%;
+          left: 83%;
+        `}
+      />
+      <p
+        css={css`
+          text-align: center;
+          line-height: 150%;
+        `}
+      >
+        {packName.charAt(0)}
+      </p>
+    </div>
+  );
+};
+
+PackImg.propTypes = {
+  packName: PropTypes.string.isRequired,
+  logoUrl: PropTypes.string,
+  className: PropTypes.string,
+};
+
+export default PackImg;

--- a/src/components/PackTile.js
+++ b/src/components/PackTile.js
@@ -9,7 +9,7 @@ import {
   useTessen,
   useInstrumentedHandler,
 } from '@newrelic/gatsby-theme-newrelic';
-import DEFAULT_IMAGE from '../images/new-relic-logo.png';
+import PackImg from './PackImg';
 
 const LEVELS = {
   NEWRELIC: 'NEWRELIC',
@@ -19,6 +19,7 @@ const VIEWS = {
   GRID: 'Grid view',
   LIST: 'List view',
 };
+
 const PackTile = ({ id, view, name, fields, logoUrl, description, level }) => {
   const tessen = useTessen();
   const handlePackClick = useInstrumentedHandler(
@@ -52,15 +53,10 @@ const PackTile = ({ id, view, name, fields, logoUrl, description, level }) => {
       `}
       onClick={handlePackClick}
     >
-      <img
-        src={logoUrl || DEFAULT_IMAGE}
-        alt={name}
-        onError={(e) => {
-          e.preventDefault();
-          e.target.src = DEFAULT_IMAGE;
-        }}
+      <PackImg
+        logoUrl={logoUrl}
+        packName={name}
         css={css`
-          display: block;
           height: 200px;
           background-color: var(--color-white);
           object-fit: scale-down;

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -45,7 +45,7 @@ const ObservabilityPackDetails = ({ data, location }) => {
             `}
           >
             <InstallButton
-              title={`Install Pack`}
+              title="Install Pack"
               guid={pack.id}
               onClick={handleInstallClick}
             />


### PR DESCRIPTION
## Description

This adds an image component which will conditionally render a supplied logo image or a placeholder.

I took some creative liberty and referenced the stripes from the site logo but am open to any design!

TODO:
- [ ] confirm icon or pack acronym style

## Related Issue(s) / Ticket(s)

Closes https://github.com/newrelic/developer-website/issues/1428

## Screenshot(s)

## with an icon

<img width="1692" alt="Screen Shot 2021-07-07 at 2 57 16 PM" src="https://user-images.githubusercontent.com/39655074/124833909-b8b30c00-df33-11eb-95ec-a85188e284c7.png">
<img width="700" alt="Screen Shot 2021-07-07 at 2 57 26 PM" src="https://user-images.githubusercontent.com/39655074/124833925-bf418380-df33-11eb-9b6a-84d24b05cd97.png">

## with pack name acronym

<img width="1055" alt="Screen Shot 2021-07-08 at 12 42 21 PM" src="https://user-images.githubusercontent.com/39655074/124981454-71d41d80-dfea-11eb-9fcd-47e8efdcd136.png">
<img width="1060" alt="Screen Shot 2021-07-08 at 12 42 37 PM" src="https://user-images.githubusercontent.com/39655074/124981461-739de100-dfea-11eb-98e3-998fa6d3c695.png">




