### PR TITLE
Support markdown for pack descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0",
     "react-live": "^2.2.2",
-    "react-markdown": "^5.0.3",
+    "react-markdown": "^6.0.0",
     "react-middle-ellipsis": "^1.1.0",
     "react-shadow": "^18.6.1",
     "react-simple-code-editor": "^0.11.0",

--- a/src/components/CodeDef/Comment.js
+++ b/src/components/CodeDef/Comment.js
@@ -33,7 +33,9 @@ const renderers = {
   root: Content,
 };
 
-const Comment = ({ text }) => <Markdown source={text} renderers={renderers} />;
+const Comment = ({ text }) => (
+  <Markdown children={text} components={renderers} />
+);
 
 Content.propTypes = {
   children: PropTypes.node,

--- a/src/components/CodeDef/Comment.js
+++ b/src/components/CodeDef/Comment.js
@@ -34,7 +34,7 @@ const renderers = {
 };
 
 const Comment = ({ text }) => (
-  <Markdown children={text} components={renderers} />
+  <Markdown components={renderers}>{text}</Markdown>
 );
 
 Content.propTypes = {

--- a/src/components/MethodReference.js
+++ b/src/components/MethodReference.js
@@ -17,11 +17,12 @@ const MethodReference = ({ className, method }) => {
         <code>{method.name}</code>
       </h3>
       <Markdown
-        children={method.description}
         css={css`
           margin-bottom: 1rem;
         `}
-      />
+      >
+        {method.description}
+      </Markdown>
       <FunctionDefinition
         arguments={method.arguments}
         returnValue={method.returnValue}

--- a/src/components/MethodReference.js
+++ b/src/components/MethodReference.js
@@ -17,7 +17,7 @@ const MethodReference = ({ className, method }) => {
         <code>{method.name}</code>
       </h3>
       <Markdown
-        source={method.description}
+        children={method.description}
         css={css`
           margin-bottom: 1rem;
         `}

--- a/src/components/PropList.js
+++ b/src/components/PropList.js
@@ -213,13 +213,13 @@ const PropList = ({ className, propTypes }) => {
               <div>
                 {deprecation && (
                   <Callout variant="caution" title={`Due ${deprecation.date}`}>
-                    <Markdown source={deprecation.description} />
+                    <Markdown children={deprecation.description} />
                   </Callout>
                 )}
                 {description && (
                   <Markdown
                     className={cx(styles.section)}
-                    source={description}
+                    children={description}
                   />
                 )}
                 <div className={styles.section}>

--- a/src/components/PropList.js
+++ b/src/components/PropList.js
@@ -213,14 +213,13 @@ const PropList = ({ className, propTypes }) => {
               <div>
                 {deprecation && (
                   <Callout variant="caution" title={`Due ${deprecation.date}`}>
-                    <Markdown children={deprecation.description} />
+                    <Markdown>{deprecation.description}</Markdown>
                   </Callout>
                 )}
                 {description && (
-                  <Markdown
-                    className={cx(styles.section)}
-                    children={description}
-                  />
+                  <Markdown className={cx(styles.section)}>
+                    {description}
+                  </Markdown>
                 )}
                 <div className={styles.section}>
                   <PropTypeInfo type={type} />

--- a/src/templates/ApiReferenceTemplate.js
+++ b/src/templates/ApiReferenceTemplate.js
@@ -37,7 +37,7 @@ const ApiReferenceTemplate = ({ data, location }) => {
         <PageLayout.Content>
           {description && (
             <Section className="intro-text">
-              <Markdown children={description} />
+              <Markdown>{description}</Markdown>
             </Section>
           )}
 

--- a/src/templates/ApiReferenceTemplate.js
+++ b/src/templates/ApiReferenceTemplate.js
@@ -37,7 +37,7 @@ const ApiReferenceTemplate = ({ data, location }) => {
         <PageLayout.Content>
           {description && (
             <Section className="intro-text">
-              <Markdown source={description} />
+              <Markdown children={description} />
             </Section>
           )}
 

--- a/src/templates/ComponentReferenceTemplate.js
+++ b/src/templates/ComponentReferenceTemplate.js
@@ -61,7 +61,7 @@ const ComponentReferenceTemplate = ({ data, location }) => {
         <PageLayout.Header title={name} />
         <PageLayout.Content>
           <Section className="intro-text">
-            <Markdown source={componentDescription} />
+            <Markdown children={componentDescription} />
           </Section>
 
           <Section>

--- a/src/templates/ComponentReferenceTemplate.js
+++ b/src/templates/ComponentReferenceTemplate.js
@@ -61,7 +61,7 @@ const ComponentReferenceTemplate = ({ data, location }) => {
         <PageLayout.Header title={name} />
         <PageLayout.Content>
           <Section className="intro-text">
-            <Markdown children={componentDescription} />
+            <Markdown>{componentDescription}</Markdown>
           </Section>
 
           <Section>

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -15,6 +15,22 @@ import ImageGallery from '../components/ImageGallery';
 import Intro from '../components/Intro';
 import InstallButton from '../components/InstallButton';
 import ImageSlider from '../components/ImageSlider';
+import Markdown from '../components/Markdown';
+
+const allowedElements = [
+  'h1',
+  'h2',
+  'h3',
+  'ol',
+  'ul',
+  'li',
+  'p',
+  'code',
+  'a',
+  'strong',
+  'em',
+  'hr',
+];
 
 const ObservabilityPackDetails = ({ data, location }) => {
   const pack = data.observabilityPacks;
@@ -99,7 +115,9 @@ const ObservabilityPackDetails = ({ data, location }) => {
               <Tabs.Page id="overview">
                 <ImageGallery images={[]} />
                 <h3>Description</h3>
-                <p>{pack.description}</p>
+                <Markdown skipHtml allowedElements={allowedElements}>
+                  {pack.description}
+                </Markdown>
               </Tabs.Page>
               <Tabs.Page id="requirements">
                 <Intro

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -25,6 +25,7 @@ const allowedElements = [
   'ul',
   'li',
   'p',
+  'blockquote',
   'code',
   'a',
   'strong',

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -62,7 +62,7 @@ const ObservabilityPackDetails = ({ data, location }) => {
             `}
           >
             <InstallButton
-              title={`Install Pack`}
+              title="Install Pack"
               guid={pack.id}
               onClick={handleInstallClick}
             />

--- a/yarn.lock
+++ b/yarn.lock
@@ -6445,7 +6445,7 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domhandler@^3.0.0, domhandler@^3.3.0:
+domhandler@^3.0.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz"
   integrity sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==
@@ -6475,7 +6475,7 @@ domutils@^1.5.1, domutils@^1.7.0:
     dom-serializer "0"
     domelementtype "1"
 
-domutils@^2.0.0, domutils@^2.4.2, domutils@^2.4.3, domutils@^2.4.4, domutils@^2.5.2, domutils@^2.6.0:
+domutils@^2.0.0, domutils@^2.4.3, domutils@^2.4.4, domutils@^2.5.2, domutils@^2.6.0:
   version "2.6.0"
   resolved "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz"
   integrity sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==
@@ -9606,16 +9606,6 @@ html-react-parser@^1.2.5:
     react-property "1.0.1"
     style-to-js "1.1.0"
 
-html-to-react@^1.3.4:
-  version "1.4.5"
-  resolved "https://registry.npmjs.org/html-to-react/-/html-to-react-1.4.5.tgz"
-  integrity sha512-KONZUDFPg5OodWaQu2ymfkDmU0JA7zB1iPfvyHehTmMUZnk0DS7/TyCMTzsLH6b4BvxX15g88qZCXFhJWktsmA==
-  dependencies:
-    domhandler "^3.3.0"
-    htmlparser2 "^5.0"
-    lodash.camelcase "^4.3.0"
-    ramda "^0.27.1"
-
 html-void-elements@^1.0.0:
   version "1.0.5"
   resolved "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz"
@@ -9651,16 +9641,6 @@ htmlparser2@^4.1.0:
     domelementtype "^2.0.1"
     domhandler "^3.0.0"
     domutils "^2.0.0"
-    entities "^2.0.0"
-
-htmlparser2@^5.0:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz"
-  integrity sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==
-  dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^3.3.0"
-    domutils "^2.4.2"
     entities "^2.0.0"
 
 htmlparser2@^6.1.0:
@@ -12166,13 +12146,6 @@ md5-file@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/md5-file/-/md5-file-5.0.0.tgz"
   integrity sha512-xbEFXCYVWrSx/gEKS1VPlg84h/4L20znVIulKw6kMfmBUAZNAnF00eczz9ICMl+/hjQGo5KSXRxbL/47X3rmMw==
-
-mdast-add-list-metadata@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz"
-  integrity sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==
-  dependencies:
-    unist-util-visit-parents "1.1.2"
 
 mdast-squeeze-paragraphs@^4.0.0:
   version "4.0.0"
@@ -14887,11 +14860,6 @@ rafz@^0.1.14:
   resolved "https://registry.npmjs.org/rafz/-/rafz-0.1.14.tgz"
   integrity sha512-YiQkedSt1urYtYbvHhTQR3l67M8SZbUvga5eJFM/v4vx/GmDdtXlE2hjJIyRjhhO/PjcdGC+CXCYOUA4onit8w==
 
-ramda@^0.27.1:
-  version "0.27.1"
-  resolved "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz"
-  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
-
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz"
@@ -15014,9 +14982,9 @@ react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^17.0.1:
+react-is@^17.0.0, react-is@^17.0.1:
   version "17.0.2"
-  resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-lifecycles-compat@^3.0.4:
@@ -15037,21 +15005,24 @@ react-live@^2.2.2, react-live@^2.2.3:
     react-simple-code-editor "^0.10.0"
     unescape "^1.0.1"
 
-react-markdown@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.npmjs.org/react-markdown/-/react-markdown-5.0.3.tgz"
-  integrity sha512-jDWOc1AvWn0WahpjW6NK64mtx6cwjM4iSsLHJPNBqoAgGOVoIdJMqaKX4++plhOtdd4JksdqzlDibgPx6B/M2w==
+react-markdown@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-6.0.2.tgz#d89be45c278b1e5f0196f851fffb11e30c69f027"
+  integrity sha512-Et2AjXAsbmPP1nLQQRqmVgcqzfwcz8uQJ8VAdADs8Nk/aaUA0YeU9RDLuCtD+GwajCnm/+Iiu2KPmXzmD/M3vA==
   dependencies:
-    "@types/mdast" "^3.0.3"
+    "@types/hast" "^2.0.0"
     "@types/unist" "^2.0.3"
-    html-to-react "^1.3.4"
-    mdast-add-list-metadata "1.0.1"
+    comma-separated-tokens "^1.0.0"
     prop-types "^15.7.2"
-    react-is "^16.8.6"
+    property-information "^5.0.0"
+    react-is "^17.0.0"
     remark-parse "^9.0.0"
+    remark-rehype "^8.0.0"
+    space-separated-tokens "^1.1.0"
+    style-to-object "^0.3.0"
     unified "^9.0.0"
     unist-util-visit "^2.0.0"
-    xtend "^4.0.1"
+    vfile "^4.0.0"
 
 react-middle-ellipsis@^1.1.0:
   version "1.1.0"
@@ -15554,6 +15525,13 @@ remark-parse@^9.0.0:
   integrity sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==
   dependencies:
     mdast-util-from-markdown "^0.8.0"
+
+remark-rehype@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-8.1.0.tgz#610509a043484c1e697437fa5eb3fd992617c945"
+  integrity sha512-EbCu9kHgAxKmW1yEYjx3QafMyGY3q8noUbNUI5xyKbaFP89wbhDrKxyIQNukNYthzjNHZu6J7hwFg7hRm1svYA==
+  dependencies:
+    mdast-util-to-hast "^10.2.0"
 
 remark-retext@^3.1.3:
   version "3.1.3"
@@ -16979,7 +16957,7 @@ sourcemap-codec@^1.4.4, sourcemap-codec@^1.4.8:
   resolved "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
-space-separated-tokens@^1.0.0:
+space-separated-tokens@^1.0.0, space-separated-tokens@^1.1.0:
   version "1.1.5"
   resolved "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz"
   integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
@@ -18506,11 +18484,6 @@ unist-util-visit-children@^1.0.0:
   version "1.1.4"
   resolved "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-1.1.4.tgz"
   integrity sha512-sA/nXwYRCQVRwZU2/tQWUqJ9JSFM1X3x7JIOsIgSzrFHcfVt6NkzDtKzyxg2cZWkCwGF9CO8x4QNZRJRMK8FeQ==
-
-unist-util-visit-parents@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz"
-  integrity sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q==
 
 unist-util-visit-parents@^2.0.0:
   version "2.1.2"


### PR DESCRIPTION
## Description

Adds markdown support for pack description content on the pack details page.

Includes updating to latest version of `react-markdown` and some small updates for breaking changes. Far as I could tell rest of site looked okay (esp the SDK area of the site) but would love second set of 👀 

### Sample markdown description
I used [this sample markdown string](https://gist.githubusercontent.com/roadlittledawn/26fb5b622a4b49167838e0793b3d4269/raw/3f091437f33188db9b252a0545ead5b019a55be2/sample-description.md) to test rendering and what was allowed / disallowed by adding it to a pack `description` field in `src/data/observability-packs.json`.

## Related Issue(s) / Ticket(s)

Closes https://github.com/newrelic/developer-website/issues/1462

## Screenshot(s)

![2021-07-07_14-51-32](https://user-images.githubusercontent.com/2952843/124833853-9de09780-df33-11eb-9eb7-df1e838255ea.png)



