### PR TITLE
Change tab select styling on ios browsers

### DIFF
--- a/src/components/Tabs/Bar.js
+++ b/src/components/Tabs/Bar.js
@@ -4,7 +4,7 @@ import useMobileDetect from 'use-mobile-detect-hook';
 import { css } from '@emotion/react';
 import useTabs from './useTabs';
 
-const MobileTabControl = ({ children }) => {
+const MobileTabControl = ({ children, isIos }) => {
   const [currentTab, setCurrentTab] = useTabs();
   // eslint gets angry about using props from React.Children.map
   /* eslint-disable react/prop-types */
@@ -20,7 +20,7 @@ const MobileTabControl = ({ children }) => {
         border-radius: 4px;
         border-color: var(--secondary-background-color);
         background-color: var(--primary-background-color);
-        color: var(--primary-text-color);
+        color: ${isIos ? `var(--color-black)` : `var(--primary-text-color)`};
       `}
     >
       {React.Children.map(children, ({ props }) => (
@@ -41,14 +41,16 @@ const MobileTabControl = ({ children }) => {
 
 MobileTabControl.propTypes = {
   children: PropTypes.node.isRequired,
+  isIos: PropTypes.bool,
 };
 
 const Bar = ({ children, className }) => {
   const detectMobile = useMobileDetect();
   const isMobile = detectMobile.isMobile();
+  const isIos = detectMobile.isIos();
 
   if (isMobile) {
-    return <MobileTabControl>{children}</MobileTabControl>;
+    return <MobileTabControl isIos={isIos}>{children}</MobileTabControl>;
   }
 
   return (


### PR DESCRIPTION
## Description

Checks if mobile device is iOS and if so adjusts to text color in the select to be more readable on the gray background

## Related Issue(s) / Ticket(s)

Closes https://github.com/newrelic/developer-website/issues/1421

## Screenshot(s)

![IMG_CEB0044F5DB1-1](https://user-images.githubusercontent.com/2952843/124986832-f45fdb80-dff0-11eb-977d-13baa679e578.jpeg)



