### PR TITLE
Reduce number of tabs in observability pack details

### DIFF
--- a/src/components/PageLayout/PageLayout.js
+++ b/src/components/PageLayout/PageLayout.js
@@ -9,6 +9,7 @@ import { Layout, useLayout } from '@newrelic/gatsby-theme-newrelic';
 const TYPES = {
   SINGLE_COLUMN: 'SINGLE_COLUMN',
   RELATED_CONTENT: 'RELATED_CONTENT',
+  RELATED_CONTENT_TABS: 'RELATED_CONTENT_TABS',
 };
 
 const LAYOUTS = {

--- a/src/components/PageLayout/PageLayout.js
+++ b/src/components/PageLayout/PageLayout.js
@@ -27,6 +27,23 @@ const LAYOUTS = {
       grid-template-columns: minmax(0, 1fr);
     }
   `,
+  [TYPES.RELATED_CONTENT_TABS]: css`
+    grid-template-areas:
+      'page-header page-header'
+      'tabs tabs'
+      'content page-tools';
+    grid-template-columns: minmax(0, 1fr) 320px;
+    grid-gap: 2rem;
+
+    @media (max-width: 1240px) {
+      grid-template-areas:
+        'page-header'
+        'tabs'
+        'content'
+        'page-tools';
+      grid-template-columns: minmax(0, 1fr);
+    }
+  `,
   [TYPES.SINGLE_COLUMN]: css`
     grid-template-areas:
       'page-header'
@@ -35,11 +52,12 @@ const LAYOUTS = {
   `,
 };
 
-const PageLayout = ({ children, type }) => {
+const PageLayout = ({ children, type, className }) => {
   const { contentPadding } = useLayout();
 
   return (
     <div
+      className={className}
       css={css`
         display: grid;
         grid-gap: ${contentPadding};
@@ -54,6 +72,7 @@ const PageLayout = ({ children, type }) => {
 
 PageLayout.propTypes = {
   children: PropTypes.node,
+  className: PropTypes.string,
   type: PropTypes.oneOf(Object.values(TYPES)).isRequired,
 };
 

--- a/src/components/Tabs/Bar.js
+++ b/src/components/Tabs/Bar.js
@@ -58,6 +58,7 @@ const Bar = ({ children, className }) => {
       css={css`
         display: flex;
         width: 100%;
+        border-bottom: 1px solid var(--color-neutrals-300);
         margin-bottom: 1em;
         overflow: auto;
       `}

--- a/src/components/Tabs/Bar.js
+++ b/src/components/Tabs/Bar.js
@@ -58,7 +58,7 @@ const Bar = ({ children, className }) => {
       css={css`
         display: flex;
         width: 100%;
-        border-bottom: 1px solid var(--color-neutrals-300);
+        border-bottom: 1px solid var(--divider-color);
         margin-bottom: 1em;
         overflow: auto;
       `}

--- a/src/components/Tabs/BarItem.js
+++ b/src/components/Tabs/BarItem.js
@@ -37,17 +37,12 @@ const BarItem = ({ index, children, id, count, disabled }) => {
         border: 0;
         background: none;
         color: var(--primary-text-color);
-
         flex-grow: 1;
         text-align: center;
         padding: 0.5em;
         cursor: pointer;
         user-select: none;
         white-space: nowrap;
-
-        .dark-mode & {
-          border-bottom-color: var(--color-dark-300);
-        }
 
         &:hover {
           color: var(--color-brand-500);
@@ -90,12 +85,11 @@ const BarItem = ({ index, children, id, count, disabled }) => {
         ${isSelected &&
         css`
           color: var(--color-brand-500);
-          border-bottom-width: 3px;
-          border-bottom-color: var(--color-brand-500);
+          border-bottom: var(--color-brand-500) solid 3px;
 
           .dark-mode & {
             color: var(--color-brand-400);
-            border-bottom-color: var(--color-brand-400);
+            border-bottom: var(--color-brand-400) solid 3px;
           }
         `}
       `}

--- a/src/components/Tabs/BarItem.js
+++ b/src/components/Tabs/BarItem.js
@@ -41,7 +41,6 @@ const BarItem = ({ index, children, id, count, disabled }) => {
         flex-grow: 1;
         text-align: center;
         padding: 0.5em;
-        border-bottom: 1px solid var(--color-neutrals-300);
         cursor: pointer;
         user-select: none;
         white-space: nowrap;

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -36,7 +36,7 @@ const ObservabilityPackDetails = ({ data, location }) => {
     <>
       <DevSiteSeo title={pack.name} location={location} />
       <Tabs>
-        <PageLayout type={PageLayout.TYPE.RELATED_CONTENT}>
+        <PageLayout type={PageLayout.TYPE.RELATED_CONTENT_TABS}>
           <PageLayout.Header
             title={pack.name}
             css={css`
@@ -45,55 +45,54 @@ const ObservabilityPackDetails = ({ data, location }) => {
             `}
           >
             <InstallButton
-              title={`Install Pack`}
+              title="Install Pack"
               guid={pack.id}
               onClick={handleInstallClick}
             />
-            <Tabs.Bar
-              css={css`
-                margin-top: 1rem;
-              `}
-            >
-              <Tabs.BarItem id="overview">Overview</Tabs.BarItem>
-              <Tabs.BarItem id="requirements">Requirements</Tabs.BarItem>
-              <Tabs.BarItem
-                id="dashboards"
-                disabled={!(pack.dashboards?.length ?? 0)}
-                count={pack.dashboards?.length ?? 0}
-              >
-                Dashboards
-              </Tabs.BarItem>
-              <Tabs.BarItem
-                id="alerts"
-                disabled={!(pack.alerts?.length ?? 0)}
-                count={pack.alerts?.length ?? 0}
-              >
-                Alerts
-              </Tabs.BarItem>
-              <Tabs.BarItem
-                id="synthetics"
-                disabled={!(pack.synthetics?.length ?? 0)}
-                count={pack.synthetics?.length ?? 0}
-              >
-                Synthetics
-              </Tabs.BarItem>
-              <Tabs.BarItem
-                id="visualizations"
-                disabled={!(pack.visualizations?.length ?? 0)}
-                count={pack.visualizations?.length ?? 0}
-              >
-                Visualizations
-              </Tabs.BarItem>
-              <Tabs.BarItem
-                id="nerdpacks"
-                disabled={!(pack.nerdpacks?.length ?? 0)}
-                count={pack.nerdpacks?.length ?? 0}
-              >
-                Nerdpacks
-              </Tabs.BarItem>
-            </Tabs.Bar>
           </PageLayout.Header>
-
+          <Tabs.Bar
+            css={css`
+              grid-column: 1/3;
+              box-sizing: border-box;
+              padding-right: 30%;
+              @media (max-width: 1240px) {
+                padding: 0;
+              }
+              @media (max-width: 760px) {
+                flex-wrap: wrap;
+              }
+            `}
+          >
+            <Tabs.BarItem id="overview">Overview</Tabs.BarItem>
+            <Tabs.BarItem
+              id="dashboards"
+              disabled={!(pack.dashboards?.length ?? 0)}
+              count={pack.dashboards?.length ?? 0}
+            >
+              Dashboards
+            </Tabs.BarItem>
+            <Tabs.BarItem
+              id="alerts"
+              disabled={!(pack.alerts?.length ?? 0)}
+              count={pack.alerts?.length ?? 0}
+            >
+              Alerts
+            </Tabs.BarItem>
+            <Tabs.BarItem
+              id="synthetics"
+              disabled={!(pack.synthetics?.length ?? 0)}
+              count={pack.synthetics?.length ?? 0}
+            >
+              Synthetics
+            </Tabs.BarItem>
+            <Tabs.BarItem
+              id="visualizations"
+              disabled={!(pack.visualizations?.length ?? 0)}
+              count={pack.visualizations?.length ?? 0}
+            >
+              Visualizations
+            </Tabs.BarItem>
+          </Tabs.Bar>
           <Layout.Content>
             <Tabs.Pages>
               <Tabs.Page id="overview">

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -251,6 +251,13 @@ const ObservabilityPackDetails = ({ data, location }) => {
               <PageTools.Title>Authors</PageTools.Title>
               <p>{pack.authors.join(', ')}</p>
             </PageTools.Section>
+            <PageTools.Section>
+              <PageTools.Title>Requirements</PageTools.Title>
+              <ul>
+                <li>Lorem ipsum dolor sit amet</li>
+                <li>Lorem ipsum dolor sit amet</li>
+              </ul>
+            </PageTools.Section>
           </Layout.PageTools>
         </PageLayout>
       </Tabs>


### PR DESCRIPTION
## Description

This removes the requirements and nerdpacks tabs from the observability pack details page, and mocks the requirements info in the right rail. I also adjusted some mobile styles to avoid a scroll bar on the tabs as much as possible

## Related Issue(s) / Ticket(s)

Closes https://github.com/newrelic/developer-website/issues/1434

## Screenshot(s)
<img width="1397" alt="Screen Shot 2021-07-08 at 2 19 43 PM" src="https://user-images.githubusercontent.com/39655074/124992281-9a164900-dff7-11eb-940d-09751291e5f7.png">
<img width="1389" alt="Screen Shot 2021-07-08 at 2 19 31 PM" src="https://user-images.githubusercontent.com/39655074/124992288-9be00c80-dff7-11eb-9784-732f24e2f4db.png">