### PR TITLE
Add section for pack support level and copy

### DIFF
--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -33,6 +33,21 @@ const allowedElements = [
   'hr',
 ];
 
+const SUPPORT_CONTENT = {
+  NEWRELIC: {
+    title: 'Built by New Relic',
+    content: `Need help? [Visit our Support Center](https://support.newrelic.com) or check out our community forum, [the Explorers Hub](https://discuss.newrelic.com).`,
+  },
+  VERIFIED: {
+    title: 'Verified by New Relic',
+    content: `Need help? [Visit our Support Center](https://support.newrelic.com) or check out our community forum, [the Explorers Hub](https://discuss.newrelic.com).`,
+  },
+  COMMUNITY: {
+    title: 'Built by the community',
+    content: `Need help? Visit our community forum, [the Explorers Hub](https://discuss.newrelic.com) to find an answer or post a question.`,
+  },
+};
+
 const ObservabilityPackDetails = ({ data, location }) => {
   const pack = data.observabilityPacks;
   const tessen = useTessen();
@@ -270,6 +285,19 @@ const ObservabilityPackDetails = ({ data, location }) => {
             <PageTools.Section>
               <PageTools.Title>Authors</PageTools.Title>
               <p>{pack.authors.join(', ')}</p>
+            </PageTools.Section>
+            <PageTools.Section>
+              <PageTools.Title>Support</PageTools.Title>
+              <h5
+                css={css`
+                  text-transform: uppercase;
+                `}
+              >
+                {SUPPORT_CONTENT[`${pack.level}`].title}
+              </h5>
+              <p>
+                <Markdown>{SUPPORT_CONTENT[`${pack.level}`].content}</Markdown>
+              </p>
             </PageTools.Section>
           </Layout.PageTools>
         </PageLayout>


### PR DESCRIPTION
## Description

Adds section in `PageTools` for support level and copy.  We can safely assume we will one of the 3 since it's validated via a workflow in the observability packs repo.

For now I thought it made most sense to keep the data (`title` and `content`) in the same file so it's easy to find / update for content contributors.

## Related Issue(s) / Ticket(s)

Closes https://github.com/newrelic/developer-website/issues/1408

## Screenshot(s)

![2021-07-12_13-26-49](https://user-images.githubusercontent.com/2952843/125351341-d4902680-e314-11eb-9b0f-fba8b5963852.png)



