### PR TITLE
Add build your own pack tile

### DIFF
--- a/src/components/PackImg.js
+++ b/src/components/PackImg.js
@@ -46,16 +46,12 @@ const PackImg = ({ className, logoUrl, packName }) => {
         background-repeat: no-repeat;
         background-position: center;
         background-origin: content-box;
+        display: flex;
+        justify-content: center;
+        align-items: center;
       `}
     >
-      <p
-        css={css`
-          text-align: center;
-          line-height: ${packAcronym.length < 4 ? '190%' : '300%'};
-        `}
-      >
-        {packAcronym}
-      </p>
+      <p>{packAcronym}</p>
     </div>
   );
 };

--- a/src/components/PackImg.js
+++ b/src/components/PackImg.js
@@ -1,16 +1,23 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
-import DEFAULT_IMAGE from '../images/new-relic-logo.png';
+import DEFAULT_IMAGE from '../images/default-logo-background.svg';
 
 const PackImg = ({ className, logoUrl, packName }) => {
+  const [packAcronym, setPackAcronym] = useState('');
+
   const getPackNameAcronym = () => {
     let packNameAcronym = '';
     packName.split(' ').forEach((word) => {
       packNameAcronym = packNameAcronym.concat('', word.charAt(0));
     });
-    return packNameAcronym.toUpperCase();
+    setPackAcronym(packNameAcronym.toUpperCase());
   };
+  useEffect(() => {
+    if (!logoUrl) {
+      getPackNameAcronym();
+    }
+  });
 
   if (logoUrl) {
     return (
@@ -34,56 +41,20 @@ const PackImg = ({ className, logoUrl, packName }) => {
       css={css`
         color: var(--color-brand-400);
         font-family: var(--code-font);
-        font-size: 7rem;
+        font-size: ${packAcronym.length < 4 ? '6rem' : '4rem'};
+        background-image: url(${DEFAULT_IMAGE});
+        background-repeat: no-repeat;
+        background-position: center;
+        background-origin: content-box;
       `}
     >
-      <div
-        css={css`
-          border: solid var(--color-brand-400) 2px;
-          height: 1px;
-          width: 60px;
-          position: relative;
-          top: 20%;
-          left: 0;
-        `}
-      />
-      <div
-        css={css`
-          border: solid var(--color-green-200) 2px;
-          height: 1px;
-          width: 30px;
-          position: relative;
-          top: 75%;
-          left: 90%;
-        `}
-      />
-      <div
-        css={css`
-          border: solid var(--color-red-300) 2px;
-          height: 1px;
-          width: 20px;
-          position: relative;
-          top: 50px;
-          left: 0px;
-        `}
-      />
-      <div
-        css={css`
-          border: solid var(--color-brand-300) 2px;
-          height: 1px;
-          width: 50px;
-          position: relative;
-          top: 80%;
-          left: 83%;
-        `}
-      />
       <p
         css={css`
           text-align: center;
-          line-height: 150%;
+          line-height: ${packAcronym.length < 4 ? '190%' : '300%'};
         `}
       >
-        {getPackNameAcronym()}
+        {packAcronym}
       </p>
     </div>
   );

--- a/src/components/PackTile.js
+++ b/src/components/PackTile.js
@@ -20,7 +20,16 @@ const VIEWS = {
   LIST: 'List view',
 };
 
-const PackTile = ({ id, view, name, fields, logoUrl, description, level }) => {
+const PackTile = ({
+  id,
+  view,
+  name,
+  fields,
+  logoUrl,
+  description,
+  level,
+  className,
+}) => {
   const tessen = useTessen();
   const handlePackClick = useInstrumentedHandler(
     () => {
@@ -40,7 +49,7 @@ const PackTile = ({ id, view, name, fields, logoUrl, description, level }) => {
     <Surface
       key={id}
       base={Surface.BASE.PRIMARY}
-      className="pack-tile-instrument"
+      className={className}
       interactive
       css={css`
         overflow: hidden;
@@ -51,7 +60,11 @@ const PackTile = ({ id, view, name, fields, logoUrl, description, level }) => {
           margin-bottom: 1em;
         `}
       `}
-      onClick={handlePackClick}
+      onClick={() => {
+        if (fields.slug) {
+          handlePackClick();
+        }
+      }}
     >
       <PackImg
         logoUrl={logoUrl}
@@ -114,6 +127,7 @@ PackTile.propTypes = {
   logoUrl: PropTypes.string,
   description: PropTypes.string,
   level: PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default PackTile;

--- a/src/components/PackTile.js
+++ b/src/components/PackTile.js
@@ -31,6 +31,7 @@ const PackTile = ({
   className,
 }) => {
   const tessen = useTessen();
+
   const handlePackClick = useInstrumentedHandler(
     () => {
       tessen.track('observabilityPack', 'observabilityPackClick', {
@@ -45,6 +46,21 @@ const PackTile = ({
       packName: name,
     }
   );
+
+  const handleBuildTileClick = useInstrumentedHandler(
+    () => {
+      tessen.track('observabilityPack', 'buildYourOwnObservabilityPackClick', {
+        publicCatalogView: view,
+        packName: name,
+      });
+    },
+    {
+      actionName: 'buildYourOwnObservabilityPackClick',
+      publicCatalogView: view,
+      packName: name,
+    }
+  );
+
   return (
     <Surface
       key={id}
@@ -60,11 +76,7 @@ const PackTile = ({
           margin-bottom: 1em;
         `}
       `}
-      onClick={() => {
-        if (fields.slug) {
-          handlePackClick();
-        }
-      }}
+      onClick={fields ? handlePackClick : handleBuildTileClick}
     >
       <PackImg
         logoUrl={logoUrl}

--- a/src/images/build-your-own.svg
+++ b/src/images/build-your-own.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 95 490 260" xmlns="http://www.w3.org/2000/svg">
+  <line style="stroke-width: 4px; stroke: rgb(0, 179, 195);" x1="0" y1="115" x2="90" y2="115"/>
+  <line style="stroke-width: 4px; stroke: rgb(236, 132, 126);" x1="0" y1="145" x2="55" y2="145"/>
+  <line  style="stroke-width: 4px; stroke: rgb(0, 179, 195);" x1="35" y1="245" x2="35" y2="195"></line>
+  <line  style="stroke-width: 4px; stroke: rgb(0, 179, 195);" x1="10" y1="220" x2="60" y2="220"></line>
+  <text style="font-family: Menlo,Consolas,monospace; font-size: 40px; fill: black" x="90" y="235">Build your own</text>
+  <line style="stroke-width: 4px; stroke: rgb(127, 232, 152);" x1="390" y1="305" x2="490" y2="305"/>
+  <line style="stroke-width: 4px; stroke: rgb(112, 204, 211);" x1="436" y1="335" x2="494" y2="335"/>
+</svg>

--- a/src/images/build-your-own.svg
+++ b/src/images/build-your-own.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg viewBox="0 95 490 260" xmlns="http://www.w3.org/2000/svg">
   <line style="stroke-width: 4px; stroke: rgb(0, 179, 195);" x1="0" y1="115" x2="90" y2="115"/>
-  <line style="stroke-width: 4px; stroke: rgb(236, 132, 126);" x1="0" y1="145" x2="55" y2="145"/>
+  <line style="stroke-width: 4px; stroke: rgb(236, 132, 126);" x1="0" y1="145" x2="50" y2="145"/>
   <line  style="stroke-width: 4px; stroke: rgb(0, 179, 195);" x1="35" y1="245" x2="35" y2="195"></line>
   <line  style="stroke-width: 4px; stroke: rgb(0, 179, 195);" x1="10" y1="220" x2="60" y2="220"></line>
   <text style="font-family: Menlo,Consolas,monospace; font-size: 40px; fill: black" x="90" y="235">Build your own</text>
-  <line style="stroke-width: 4px; stroke: rgb(127, 232, 152);" x1="390" y1="305" x2="490" y2="305"/>
-  <line style="stroke-width: 4px; stroke: rgb(112, 204, 211);" x1="436" y1="335" x2="494" y2="335"/>
+  <line style="stroke-width: 4px; stroke: rgb(127, 232, 152);" x1="400" y1="305" x2="490" y2="305"/>
+  <line style="stroke-width: 4px; stroke: rgb(112, 204, 211);" x1="440" y1="335" x2="490" y2="335"/>
 </svg>

--- a/src/images/default-logo-background.svg
+++ b/src/images/default-logo-background.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 95 490 260" xmlns="http://www.w3.org/2000/svg">
+  <line style="stroke-width: 4px; stroke: rgb(0, 179, 195);" x1="0" y1="115" x2="90" y2="115"/>
+  <line style="stroke-width: 4px; stroke: rgb(236, 132, 126);" x1="0" y1="145" x2="55" y2="145"/>
+  <line style="stroke-width: 4px; stroke: rgb(127, 232, 152);" x1="390" y1="305" x2="490" y2="305"/>
+  <line style="stroke-width: 4px; stroke: rgb(112, 204, 211);" x1="436" y1="335" x2="494" y2="335"/>
+</svg>

--- a/src/images/default-logo-background.svg
+++ b/src/images/default-logo-background.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg viewBox="0 95 490 260" xmlns="http://www.w3.org/2000/svg">
   <line style="stroke-width: 4px; stroke: rgb(0, 179, 195);" x1="0" y1="115" x2="90" y2="115"/>
-  <line style="stroke-width: 4px; stroke: rgb(236, 132, 126);" x1="0" y1="145" x2="55" y2="145"/>
-  <line style="stroke-width: 4px; stroke: rgb(127, 232, 152);" x1="390" y1="305" x2="490" y2="305"/>
-  <line style="stroke-width: 4px; stroke: rgb(112, 204, 211);" x1="436" y1="335" x2="494" y2="335"/>
+  <line style="stroke-width: 4px; stroke: rgb(236, 132, 126);" x1="0" y1="145" x2="50" y2="145"/>
+  <line style="stroke-width: 4px; stroke: rgb(127, 232, 152);" x1="400" y1="305" x2="490" y2="305"/>
+  <line style="stroke-width: 4px; stroke: rgb(112, 204, 211);" x1="440" y1="335" x2="490" y2="335"/>
 </svg>

--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -16,6 +16,7 @@ import {
 } from '@newrelic/gatsby-theme-newrelic';
 import { useQueryParam, StringParam } from 'use-query-params';
 import { useDebounce } from 'react-use';
+import BUILD_YOUR_OWN from '../images/build-your-own.svg';
 
 const sortOptionValues = ['Alphabetical', 'Reverse', 'Popularity'];
 const packContentsFilterGroups = [
@@ -351,6 +352,24 @@ const ObservabilityPacksPage = ({ data, location }) => {
           `}
         `}
       >
+        <a
+          href="https://github.com/newrelic/newrelic-observability-packs"
+          target="_blank"
+          rel="noreferrer"
+          css={css`
+            text-decoration: none;
+          `}
+        >
+          <PackTile
+            css={css`
+              height: 100%;
+            `}
+            view={view}
+            logoUrl={BUILD_YOUR_OWN}
+            name="Build your own Observability Pack"
+            description="Can't find the right pack for your needs? Check out our README and build your own!"
+          />
+        </a>
         {filteredPacks.map((pack) => (
           <PackTile key={pack.id} view={view} {...pack} />
         ))}

--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -13,6 +13,7 @@ import {
   useTessen,
   useInstrumentedData,
   useKeyPress,
+  ExternalLink,
 } from '@newrelic/gatsby-theme-newrelic';
 import { useQueryParam, StringParam } from 'use-query-params';
 import { useDebounce } from 'react-use';
@@ -352,24 +353,25 @@ const ObservabilityPacksPage = ({ data, location }) => {
           `}
         `}
       >
-        <a
+        <ExternalLink
           href="https://github.com/newrelic/newrelic-observability-packs"
-          target="_blank"
-          rel="noreferrer"
           css={css`
             text-decoration: none;
           `}
         >
           <PackTile
-            css={css`
-              height: 100%;
-            `}
+            css={
+              view === VIEWS.GRID &&
+              css`
+                height: 100%;
+              `
+            }
             view={view}
             logoUrl={BUILD_YOUR_OWN}
             name="Build your own Observability Pack"
             description="Can't find the right pack for your needs? Check out our README and build your own!"
           />
-        </a>
+        </ExternalLink>
         {filteredPacks.map((pack) => (
           <PackTile key={pack.id} view={view} {...pack} />
         ))}


### PR DESCRIPTION
## Description

This PR is for adding a tile to the observability pack list that links to the pack repo to encourage folks to build their own

TODO
- [ ] confirm and implement design
- [ ] confirm and implement copy
- [x] adjust instrumentation for `build your own pack` clicks
- [x] decide whether to create a new component or stick with the manipulations to PackTile
      This issue is mainly stemming from the fact that the tile needs to externally link and is currently built for internal links

## Related Issue(s) / Ticket(s)

Closes https://github.com/newrelic/developer-website/issues/1481

## Screenshot(s)

### Current WIP
![Screen Shot 2021-07-14 at 2 43 22 PM](https://user-images.githubusercontent.com/39655074/125697053-6f5ec944-a3a8-4c78-a5d7-184787e80c90.png)


