### PR TITLE
Connect Install Button to Nerdlet in NR1

### DIFF
--- a/src/components/InstallButton.js
+++ b/src/components/InstallButton.js
@@ -1,17 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Dropdown, Link } from '@newrelic/gatsby-theme-newrelic';
-import { css } from '@emotion/react';
+import { Button, Link } from '@newrelic/gatsby-theme-newrelic';
 import getPackNr1Url from '../utils/get-pack-nr1-url';
 import { NR1_LOGIN_URL } from '../data/constants';
 
-const sampleItems = new Array(10).fill().map((_, i) => i + 1);
-
-const createMenuItems = (items, index) =>
-  items.map((item) => (
-    <Dropdown.MenuItem key={index}>{item}</Dropdown.MenuItem>
-  ));
-
+/** @param {string} packId */
 const createInstallLink = (packId) => {
   const platformUrl = getPackNr1Url(packId, true); // FIXME: remove `true` when deployed
   const url = new URL(
@@ -22,45 +15,19 @@ const createInstallLink = (packId) => {
   return url.href;
 };
 
-const InstallButton = ({ title, ...props }) => {
-  return (
-    <div
-      css={css`
-        display: flex;
-        flex-direction: row;
-      `}
-    >
-      <Button
-        {...props}
-        as={Link}
-        to={createInstallLink()}
-        variant={Button.VARIANT.PRIMARY}
-        css={css`
-          border-bottom-right-radius: 0px;
-          border-top-right-radius: 0px;
-          margin-right: 2px;
-        `}
-      >
-        {title}
-      </Button>
-      <Dropdown align="right">
-        <Dropdown.Toggle
-          variant={Button.VARIANT.PRIMARY}
-          css={css`
-            border-bottom-left-radius: 0px;
-            border-top-left-radius: 0px;
-            padding: 5px;
-          `}
-        />
-        <Dropdown.Menu>{createMenuItems(sampleItems)}</Dropdown.Menu>
-      </Dropdown>
-    </div>
-  );
-};
+const InstallButton = ({ packId, ...props }) => (
+  <Button
+    {...props}
+    as={Link}
+    to={createInstallLink(packId)}
+    variant={Button.VARIANT.PRIMARY}
+  >
+    Install Pack
+  </Button>
+);
 
 InstallButton.propTypes = {
-  title: PropTypes.string.isRequired,
-  guid: PropTypes.string.isRequired,
+  packId: PropTypes.string.isRequired,
 };
 
 export default InstallButton;

--- a/src/components/InstallButton.js
+++ b/src/components/InstallButton.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Dropdown, Link } from '@newrelic/gatsby-theme-newrelic';
 import { css } from '@emotion/react';
+import getPackNr1Url from '../utils/get-pack-nr1-url';
+import { NR1_LOGIN_URL } from '../data/constants';
 
 const sampleItems = new Array(10).fill().map((_, i) => i + 1);
 
@@ -10,8 +12,14 @@ const createMenuItems = (items, index) =>
     <Dropdown.MenuItem key={index}>{item}</Dropdown.MenuItem>
   ));
 
-const createInstallLink = () => {
-  return `https://one.newrelic.com/launcher/nr1-core.explorer`;
+const createInstallLink = (packId) => {
+  const platformUrl = getPackNr1Url(packId, true); // FIXME: remove `true` when deployed
+  const url = new URL(
+    `?return_to=${encodeURIComponent(platformUrl)}`,
+    NR1_LOGIN_URL
+  );
+
+  return url.href;
 };
 
 const InstallButton = ({ title, ...props }) => {

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -10,3 +10,12 @@ export const SPLIT_TRACKING_EVENTS = {
 
 export const SDK_BASE_URL =
   'https://d1zobbh8kytrtv.cloudfront.net/platform/doc-app';
+
+// FIXME: update this to production URL when deployed / launched
+export const NR1_LOGIN_URL = 'https://staging-login.newrelic.com/login';
+
+// FIXME: update this to production URL when deployed / launched
+export const NR1_BASE_URL = 'https://dev-one.newrelic.com';
+
+export const NR1_PACK_DETAILS_NERDLET =
+  'catalog-pack-details.catalog-pack-details';

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -18,4 +18,4 @@ export const NR1_LOGIN_URL = 'https://staging-login.newrelic.com/login';
 export const NR1_BASE_URL = 'https://dev-one.newrelic.com';
 
 export const NR1_PACK_DETAILS_NERDLET =
-  'catalog-pack-details.catalog-pack-details';
+  'catalog-pack-details.catalog-pack-contents';

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -204,11 +204,7 @@ const ObservabilityPackDetails = ({ data, location }) => {
               gap: 1rem;
             `}
           >
-            <InstallButton
-              title="Install Pack"
-              guid={pack.id}
-              onClick={handleInstallClick}
-            />
+            <InstallButton packId={pack.id} onClick={handleInstallClick} />
           </PageLayout.Header>
           <Tabs.Bar
             css={css`

--- a/src/utils/get-pack-nr1-url.js
+++ b/src/utils/get-pack-nr1-url.js
@@ -1,0 +1,30 @@
+import { NR1_BASE_URL, NR1_PACK_DETAILS_NERDLET } from '../data/constants';
+
+const NERDLET_PATH = `nerdlet/${NR1_PACK_DETAILS_NERDLET}`;
+
+/**
+ * @param {string} packId The ID for an observability pack.
+ * @param {boolean} [debug] If set to true, this will add `packages=local`.
+ * @returns {string} The URL for the pack details within the platform.
+ */
+const getPackNr1Url = (packId, debug = false) => {
+  const pane = JSON.stringify({
+    nerdletId: NR1_PACK_DETAILS_NERDLET,
+    packId,
+  });
+
+  // Note: this works differently depending on whether or not we have access
+  // to the window object (and the btoa function).
+  const hash =
+    window && window.btoa
+      ? btoa(pane)
+      : Buffer.from(pane, 'utf-8').toString('base64');
+
+  const local = debug ? 'packages=local&' : '';
+
+  const url = new URL(`${NERDLET_PATH}?${local}pane=${hash}`, NR1_BASE_URL);
+
+  return url.href;
+};
+
+export default getPackNr1Url;


### PR DESCRIPTION
## Description
Connects the `Install Pack` button to the login page so that the user is redirected to our installation nerdlet. The `packId` is included in the URL so that the user will see the details for the right observability pack when they get into the platform.

### Working user flows

The following user flows work:

1. As a user that is logged in, click on `Install Pack` on the details page.
2. You will be taken right to the installation nerdlet.

1. As a user that is logged out, click on `Install Pack` on the details page.
2. Log into New Relic.
3. On successful login, you will be taken to the installation nerdlet.

### Not working user flow

The following user flow currently does _not_ work:

1. As a new user that does not have an account, click on `Install Pack` on the details page.
2. Create a new account.
3. Verify your account email.
4. Login in.
5. On successful login, you will be taken to the installation nerdlet.

This _may_ be because, when signing up for a new account, all users are presented the virtuoso installation flow.

## Related Issue(s)
* Closes https://github.com/newrelic/newrelic-observability-packs/issues/114