### PR TITLE
Search o11y packs by navigating via query params

### DIFF
--- a/src/pages/observability-packs.js
+++ b/src/pages/observability-packs.js
@@ -274,7 +274,7 @@ const ObservabilityPacksPage = ({ data, location }) => {
             <SearchInput
               ref={searchInputRef}
               value={formState.search || ''}
-              placeholder="Search pack names / descriptions"
+              placeholder="Search pack names / descriptions. Enter to search"
               css={css`
                 ${searchExpanded ? `display: block;` : `display: none;`}
                 @media screen and (max-width: 1180px) {


### PR DESCRIPTION
## Description

Draft PR for now until we figure out if we want submit button OR some other logic on auto searching.

This updates the text input and two filters to update and navigate (using @reach/router) via query params so it's added to browser history and a user can go forward / backward in history.

## Related Issue(s) / Ticket(s)

https://github.com/newrelic/developer-website/issues/1475

## Screenshot(s)

TBD
