### PR TITLE
Add temporary test cookie

### DIFF
--- a/src/pages/futurehack-2021.js
+++ b/src/pages/futurehack-2021.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import cx from 'classnames';
+import Cookies from 'js-cookie';
 import PageLayout from '../components/PageLayout';
 import { Button, Icon } from '@newrelic/gatsby-theme-newrelic';
 import DevSiteSeo from '../components/DevSiteSeo';
@@ -29,6 +30,21 @@ const FutureHackPage = ({ location }) => {
     margin-left: -${layout.contentPadding};
     margin-right: -${layout.contentPadding};
   `;
+
+  const writeCookie = () => {
+    const currentEnvironment =
+      process.env.ENV || process.env.NODE_ENV || 'development';
+    const options = { expires: 1 /* days */ };
+    if (currentEnvironment !== 'development') {
+      options.domain = 'newrelic.com';
+    }
+
+    Cookies.set('newrelic-pack-id', 'test', options);
+  };
+
+  useEffect(() => {
+    writeCookie();
+  });
 
   return (
     <>


### PR DESCRIPTION
This (temporarily) adds a cookie on load of the futurehack page. We want to test out the use of a cookie to pass pack information to one.newrelic for installs as outlined here https://github.com/newrelic/newrelic-observability-packs/issues/127