### PR TITLE
newrelic profile add -n > --profile

### DIFF
--- a/src/markdown-pages/automate-workflows/get-started-new-relic-cli.mdx
+++ b/src/markdown-pages/automate-workflows/get-started-new-relic-cli.mdx
@@ -89,9 +89,9 @@ Run the [`profiles add`](https://github.com/newrelic/newrelic-cli/blob/master/do
 
 ```sh lineNumbers=false
 # Create the tutorial account for the US region
-newrelic profiles add -n tutorial --apiKey YOUR_NEW_RELIC_USER_KEY -r YOUR_REGION
+newrelic profiles add --profile tutorial --apiKey YOUR_NEW_RELIC_USER_KEY -r YOUR_REGION
 # Set the profile as defaults
-newrelic profiles default -n tutorial
+newrelic profiles default --profile tutorial
 ```
 
 <Callout variant="important">


### PR DESCRIPTION
`newrelic profile add` no longer recognizes the `-n` shorthand flag. The correct and current syntax should be `newrelic profile add --profile <string>`

## Description

Updating the flags for the current version of newrelic-cli 

## Reviewer Notes

If there are links or steps needed to test this work, add them here.

## Related Issue(s) / Ticket(s)

If there are any related [GitHub Issues](https://github.com/newrelic/developer-website/issues) or JIRA tickets, add links to them here.
* [issue]()

## Screenshot(s)

If relevant, add screenshots here.

## Use Conventional Commits

Please help the maintainers by leveraging the following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
standards in your pull request title and commit messages.

## Use `chore`

* for minor changes / additions / corrections to content.
* for minor changes / additions / corrections to images.
* for minor non-functional changes / additions to github actions, github templates, package or config updates, etc

```bash
git commit -m "chore: adjusting config and content"
```

## Use `fix`

* for minor functional corrections to code.

```bash
git commit -m "fix: typo and prop error in the code of conduct"
```

## Use `feat`

* for major functional changes or additions to code.

```bash
git commit -m "feat(media): creating a video landing page"
```
