### PR TITLE
Add data sources tab

### DIFF
--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -226,6 +226,7 @@ const ObservabilityPackDetails = ({ data, location }) => {
             <Tabs.BarItem id="alerts" count={pack.alerts?.length ?? 0}>
               Alerts
             </Tabs.BarItem>
+            <Tabs.BarItem id="data-sources">Data Sources</Tabs.BarItem>
           </Tabs.Bar>
           <Layout.Content>
             <Tabs.Pages>
@@ -245,6 +246,9 @@ const ObservabilityPackDetails = ({ data, location }) => {
                 {pack.alerts
                   ? renderAlerts(pack)
                   : emptyStateContent(pack, 'alerts')}
+              </Tabs.Page>
+              <Tabs.Page id="data-sources">
+                {emptyStateContent(pack, 'data sources')}
               </Tabs.Page>
             </Tabs.Pages>
           </Layout.Content>

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -226,7 +226,7 @@ const ObservabilityPackDetails = ({ data, location }) => {
             <Tabs.BarItem id="alerts" count={pack.alerts?.length ?? 0}>
               Alerts
             </Tabs.BarItem>
-            <Tabs.BarItem id="data-sources">Data Sources</Tabs.BarItem>
+            <Tabs.BarItem id="data-sources">Data sources</Tabs.BarItem>
           </Tabs.Bar>
           <Layout.Content>
             <Tabs.Pages>

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -230,7 +230,7 @@ const ObservabilityPackDetails = ({ data, location }) => {
               id="data-sources"
               count={
                 (pack.instrumentation?.length ?? 0) +
-                (pack.documentation ? 1 : 0)
+                (pack.documentation?.length ?? 0)
               }
             >
               Data sources

--- a/src/templates/ObservabilityPackDetails.js
+++ b/src/templates/ObservabilityPackDetails.js
@@ -226,7 +226,15 @@ const ObservabilityPackDetails = ({ data, location }) => {
             <Tabs.BarItem id="alerts" count={pack.alerts?.length ?? 0}>
               Alerts
             </Tabs.BarItem>
-            <Tabs.BarItem id="data-sources">Data sources</Tabs.BarItem>
+            <Tabs.BarItem
+              id="data-sources"
+              count={
+                (pack.instrumentation?.length ?? 0) +
+                (pack.documentation ? 1 : 0)
+              }
+            >
+              Data sources
+            </Tabs.BarItem>
           </Tabs.Bar>
           <Layout.Content>
             <Tabs.Pages>


### PR DESCRIPTION
Adds a data source tab and page with empty state
Closes https://github.com/newrelic/developer-website/issues/1511

## Screenshot(s)
<img width="958" alt="Screen Shot 2021-08-17 at 3 07 13 PM" src="https://user-images.githubusercontent.com/39655074/129807060-20802086-e859-414d-9108-57fd8310bca6.png">


