### PR TITLE
Rename packId to quickstartId in install url

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -17,6 +17,8 @@ export const NR1_LOGIN_URL = 'https://staging-login.newrelic.com/login';
 // FIXME: update this to production URL when deployed / launched
 export const NR1_BASE_URL = 'https://staging-one.newrelic.com';
 
+export const NR1_BASE_URL_LOCAL = 'https://dev-one.newrelic.com';
+
 export const NR1_PACK_DETAILS_NERDLET =
   'catalog-pack-details.catalog-pack-contents';
 

--- a/src/utils/get-pack-nr1-url.js
+++ b/src/utils/get-pack-nr1-url.js
@@ -1,4 +1,8 @@
-import { NR1_BASE_URL, NR1_PACK_DETAILS_NERDLET } from '../data/constants';
+import {
+  NR1_BASE_URL,
+  NR1_BASE_URL_LOCAL,
+  NR1_PACK_DETAILS_NERDLET,
+} from '../data/constants';
 
 const NERDLET_PATH = `nerdlet/${NR1_PACK_DETAILS_NERDLET}`;
 
@@ -7,10 +11,10 @@ const NERDLET_PATH = `nerdlet/${NR1_PACK_DETAILS_NERDLET}`;
  * @param {boolean} [debug] If set to true, this will add `packages=local`.
  * @returns {string} The URL for the pack details within the platform.
  */
-const getPackNr1Url = (packId, debug = false) => {
+const getPackNr1Url = (quickstartId, debug = false) => {
   const pane = JSON.stringify({
     nerdletId: NR1_PACK_DETAILS_NERDLET,
-    packId,
+    quickstartId,
   });
 
   // Note: this works differently depending on whether or not we have access
@@ -21,8 +25,9 @@ const getPackNr1Url = (packId, debug = false) => {
       : Buffer.from(pane, 'utf-8').toString('base64');
 
   const local = debug ? 'packages=local&' : '';
+  const NR1_URL = debug ? NR1_BASE_URL_LOCAL : NR1_BASE_URL;
 
-  const url = new URL(`${NERDLET_PATH}?${local}pane=${hash}`, NR1_BASE_URL);
+  const url = new URL(`${NERDLET_PATH}?${local}pane=${hash}`, NR1_URL);
 
   return url.href;
 };


### PR DESCRIPTION
This PR works in tandem with the refactor PR of the nerdlet. Changing the packId provided in the nr1 url to quickstartId in the dev site and consuming quickstartId in the nerdlet