### PR TITLE
Add breadcrumbs to details pages

### DIFF
--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -8,12 +8,6 @@ const Breadcrumbs = ({ segments, separator }) => {
     <div
       css={css`
         margin: 2em 0;
-        > :first-child {
-          margin-left: 0;
-        }
-        > * {
-          margin-left: 0.5em;
-        }
       `}
       aria-label="breadcrumb"
     >
@@ -27,13 +21,11 @@ const Breadcrumbs = ({ segments, separator }) => {
           <span
             key={`breadcrumb-${segment.name}`}
             css={css`
-              :after {
-                margin-left: 0.5em;
-                content: ' ${separator} ';
-              }
-              :last-child {
+              :not(:last-of-type) {
                 :after {
-                  content: '';
+                  margin: 0 0.5em;
+                  display: inline-block;
+                  content: '${separator}';
                 }
               }
             `}

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -1,0 +1,52 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { css } from '@emotion/react';
+import { Link } from '@newrelic/gatsby-theme-newrelic';
+
+const Breadcrumbs = ({ segments, separator }) => {
+  return (
+    <div
+      css={css`
+        margin: 2em 0;
+        > :first-child {
+          margin-left: 0;
+        }
+        > * {
+          margin-left: 0.5em;
+        }
+      `}
+      aria-label="breadcrumb"
+    >
+      {segments
+        .map((segment) => {
+          const elem = segment.url ? (
+            <Link to={segment.url}>{segment.name}</Link>
+          ) : (
+            segment.name
+          );
+          return <span key={`breadcrumb-${segment.name}`}>{elem}</span>;
+        })
+        .reduce((prev, curr) => [
+          prev,
+          React.createElement('span', {}, separator),
+          curr,
+        ])}
+    </div>
+  );
+};
+
+Breadcrumbs.defaultProps = {
+  separator: '/',
+};
+
+Breadcrumbs.propTypes = {
+  segments: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      url: PropTypes.string,
+    })
+  ),
+  separator: PropTypes.string,
+};
+
+export default Breadcrumbs;

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -56,7 +56,7 @@ Breadcrumbs.propTypes = {
       name: PropTypes.string.isRequired,
       url: PropTypes.string,
     })
-  ),
+  ).isRequired,
   separator: PropTypes.string,
 };
 

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -17,20 +17,31 @@ const Breadcrumbs = ({ segments, separator }) => {
       `}
       aria-label="breadcrumb"
     >
-      {segments
-        .map((segment) => {
-          const elem = segment.url ? (
-            <Link to={segment.url}>{segment.name}</Link>
-          ) : (
-            segment.name
-          );
-          return <span key={`breadcrumb-${segment.name}`}>{elem}</span>;
-        })
-        .reduce((prev, curr) => [
-          prev,
-          React.createElement('span', {}, separator),
-          curr,
-        ])}
+      {segments.map((segment) => {
+        const elem = segment.url ? (
+          <Link to={segment.url}>{segment.name}</Link>
+        ) : (
+          segment.name
+        );
+        return (
+          <span
+            key={`breadcrumb-${segment.name}`}
+            css={css`
+              :after {
+                margin-left: 0.5em;
+                content: ' ${separator} ';
+              }
+              :last-child {
+                :after {
+                  content: '';
+                }
+              }
+            `}
+          >
+            {elem}
+          </span>
+        );
+      })}
     </div>
   );
 };

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -50,14 +50,13 @@ const QuickstartDetails = ({ data, location }) => {
   const pack = data.quickstarts;
   const packUrl = pack.packUrl || QUICKSTARTS_REPO;
   const tessen = useTessen();
-  const breadcrumbSegments = [
+  const breadcrumbs = [
     {
       name: 'Instant Observability (I/O)',
       url: '/instant-observability/',
     },
     {
       name: pack.name,
-      url: null,
     },
   ];
   const handleInstallClick = useInstrumentedHandler(
@@ -77,7 +76,7 @@ const QuickstartDetails = ({ data, location }) => {
   return (
     <>
       <DevSiteSeo title={pack.name} location={location} />
-      <Breadcrumbs segments={breadcrumbSegments} />
+      <Breadcrumbs segments={breadcrumbs} />
       <Tabs>
         <PageLayout type={PageLayout.TYPE.RELATED_CONTENT_TABS}>
           <PageLayout.Header

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -21,6 +21,7 @@ import ImageGallery from '../components/ImageGallery';
 import InstallButton from '../components/InstallButton';
 import Markdown from '../components/Markdown';
 import QuickstartDataSources from '../components/quickstarts/QuickstartDataSources';
+import Breadcrumbs from '../components/Breadcrumbs';
 import { quickstart } from '../types';
 import {
   QUICKSTARTS_REPO,
@@ -49,6 +50,16 @@ const QuickstartDetails = ({ data, location }) => {
   const pack = data.quickstarts;
   const packUrl = pack.packUrl || QUICKSTARTS_REPO;
   const tessen = useTessen();
+  const breadcrumbSegments = [
+    {
+      name: 'Instant Observability (I/O)',
+      url: '/instant-observability/',
+    },
+    {
+      name: pack.name,
+      url: null,
+    },
+  ];
   const handleInstallClick = useInstrumentedHandler(
     () => {
       tessen.track('observabilityPack', 'packInstall', {
@@ -66,6 +77,7 @@ const QuickstartDetails = ({ data, location }) => {
   return (
     <>
       <DevSiteSeo title={pack.name} location={location} />
+      <Breadcrumbs segments={breadcrumbSegments} />
       <Tabs>
         <PageLayout type={PageLayout.TYPE.RELATED_CONTENT_TABS}>
           <PageLayout.Header


### PR DESCRIPTION
## Description

Adds a `Breadcrumbs` component and uses it on the pack details pages above the page title / pack name.

Stopped short of adding to theme for time being, but made it its own component so it's a wee bit easier to port over if/when we want to.

## Related Issue(s) / Ticket(s)

Closes https://github.com/newrelic/developer-website/issues/1559

## Screenshot(s)

![2021-08-31_16-06-09](https://user-images.githubusercontent.com/2952843/131586944-beabb44e-0162-4e9e-bfc8-2f462abb098c.png)
