### PR TITLE
Switch overview layout to display quickstart content tiles

### DIFF
--- a/src/components/quickstarts/OverviewTile.js
+++ b/src/components/quickstarts/OverviewTile.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/react';
+
+import { Surface, Tag } from '@newrelic/gatsby-theme-newrelic';
+
+const truncateDescription = (description) => {
+  if (description.length > 250) {
+    return `${description.slice(0, 244)} . . .`;
+  }
+
+  return description;
+};
+
+const OverviewTile = ({ key, title, image, description, tag }) => {
+  return (
+    <Surface key={key} base={Surface.BASE.PRIMARY}>
+      <div
+        css={css`
+          padding: 1em;
+        `}
+      >
+        <h3>{title}</h3>
+        <div>
+          {image && (
+            <img
+              src={image}
+              alt="Dashboard"
+              css={css`
+                width: 100%;
+                height: 100px;
+                object-fit: cover;
+              `}
+            />
+          )}
+          {description && !image && (
+            <p
+              css={css`
+                font-size: 0.875rem;
+                color: var(--secondary-text-color);
+              `}
+            >
+              {truncateDescription(description)}
+            </p>
+          )}
+        </div>
+        <div
+          css={css`
+            margin-top: 1rem;
+          `}
+        >
+          <Tag>{tag}</Tag>
+        </div>
+      </div>
+    </Surface>
+  );
+};
+
+OverviewTile.propTypes = {
+  key: PropTypes.number.isRequired,
+  title: PropTypes.string.isRequired,
+  image: PropTypes.string,
+  description: PropTypes.string,
+  tag: PropTypes.string.isRequired,
+};
+
+export default OverviewTile;

--- a/src/components/quickstarts/QuickstartOverview.js
+++ b/src/components/quickstarts/QuickstartOverview.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { css } from '@emotion/react';
+
+import { quickstart } from '../../types';
+import OverviewTile from './OverviewTile';
+
+const QuickstartOverview = ({ quickstart }) => {
+  return (
+    <>
+      <h3> What&apos;s included: </h3>
+      <div
+        css={css`
+          display: grid;
+          grid-gap: 1rem;
+          grid-template-columns: repeat(3, 1fr);
+
+          @media (max-width: 1180px) {
+            grid-template-columns: repeat(1, 1fr);
+          }
+        `}
+      >
+        {quickstart.dashboards.map((dashboard, index) => (
+          <OverviewTile
+            key={index}
+            title={dashboard.name}
+            image={dashboard?.screenshots[0]}
+            description={dashboard.description}
+            tag="Dashboard"
+          />
+        ))}
+        {quickstart.alerts.map((alert, index) => (
+          <OverviewTile
+            key={index}
+            title={alert.name}
+            description={alert.details}
+            tag="Alert"
+          />
+        ))}
+        {quickstart.documentation.map((doc, index) => (
+          <OverviewTile
+            key={index}
+            title={doc.name}
+            description={doc.description}
+            tag="Doc"
+          />
+        ))}
+      </div>
+    </>
+  );
+};
+
+QuickstartOverview.propTypes = {
+  quickstart: quickstart.isRequired,
+};
+
+export default QuickstartOverview;

--- a/src/components/quickstarts/QuickstartOverview.js
+++ b/src/components/quickstarts/QuickstartOverview.js
@@ -23,7 +23,7 @@ const QuickstartOverview = ({ quickstart }) => {
           <OverviewTile
             key={index}
             title={dashboard.name}
-            image={dashboard?.screenshots[0]}
+            image={dashboard.screenshots[0]}
             description={dashboard.description}
             tag="Dashboard"
           />

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -17,7 +17,6 @@ import {
   Icon,
   Link,
 } from '@newrelic/gatsby-theme-newrelic';
-import ImageGallery from '../components/ImageGallery';
 import InstallButton from '../components/InstallButton';
 import Markdown from '../components/Markdown';
 import QuickstartDataSources from '../components/quickstarts/QuickstartDataSources';
@@ -28,22 +27,7 @@ import {
   SIGNUP_LINK,
   LOGIN_LINK,
 } from '../data/constants';
-
-const allowedElements = [
-  'h1',
-  'h2',
-  'h3',
-  'ol',
-  'ul',
-  'li',
-  'p',
-  'blockquote',
-  'code',
-  'a',
-  'strong',
-  'em',
-  'hr',
-];
+import QuickstartOverview from '../components/quickstarts/QuickstartOverview';
 
 const QuickstartDetails = ({ data, location }) => {
   const pack = data.quickstarts;
@@ -110,11 +94,7 @@ const QuickstartDetails = ({ data, location }) => {
           <Layout.Content>
             <Tabs.Pages>
               <Tabs.Page id="overview">
-                <ImageGallery images={[]} />
-                <h3>Description</h3>
-                <Markdown skipHtml allowedElements={allowedElements}>
-                  {pack.description}
-                </Markdown>
+                <QuickstartOverview quickstart={pack} />
               </Tabs.Page>
               <Tabs.Page id="dashboards">
                 {pack.dashboards ? (


### PR DESCRIPTION
## Summary
Changing overview layout to display grid tiles. Each tile is one supplied component from the quickstart (1 dashboard, 1 alert, etc). For dashboards, an image is displayed. For alerts and documentation, the description is displayed & truncated to 250 characters.

### Quickstart to checkout:
Everything: https://build-e45a3b32-2eb0-4594-8c91-6d9e5f1bb56b.gtsb.io/instant-observability/elasticsearch/RWxhc3RpY3NlYXJjaA==

### Screenshots:
Desktop:
![Screen Shot 2021-09-01 at 3 49 36 PM](https://user-images.githubusercontent.com/70179215/131756637-f3e0ba72-bf1a-4243-9a23-f50eec8c10d2.png)

Mobile:
![Screen Shot 2021-09-01 at 3 51 04 PM](https://user-images.githubusercontent.com/70179215/131756638-15c71e31-a836-48b4-9d13-faea432313a4.png)

Closes: #1555 