### PR TITLE
Fix `logger` API page

### DIFF
--- a/src/components/DevSiteSeo.js
+++ b/src/components/DevSiteSeo.js
@@ -78,8 +78,8 @@ function DevSiteSeo({ description, meta, title, tags, location }) {
 
   return (
     <SEO location={location} title={title}>
-      {validMetadata.map((data) => (
-        <meta key={data.name} {...data} />
+      {validMetadata.map((data, index) => (
+        <meta key={`${data.name}-${index}`} {...data} />
       ))}
       <script src={withPrefix('tessen.min-1.3.0.js')} type="text/javascript" />
     </SEO>

--- a/src/components/FunctionDefinition.js
+++ b/src/components/FunctionDefinition.js
@@ -4,7 +4,12 @@ import CodeDef from './CodeDef';
 import { graphql } from 'gatsby';
 
 const FunctionDefinition = ({ className, arguments: params, returnValue }) => {
-  if (!params.length && !returnValue && !returnValue.length) {
+  const hasParams = params.length;
+  const isReturnArray = Array.isArray(returnValue);
+  const hasReturn =
+    (isReturnArray && returnValue.length) || (!isReturnArray && returnValue);
+
+  if (!hasParams && !hasReturn) {
     return null;
   }
 

--- a/src/components/FunctionDefinition.js
+++ b/src/components/FunctionDefinition.js
@@ -4,8 +4,12 @@ import CodeDef from './CodeDef';
 import { graphql } from 'gatsby';
 
 const FunctionDefinition = ({ className, arguments: params, returnValue }) => {
-  if (!params.length && !returnValue.length) {
+  if (!params.length && !returnValue && !returnValue.length) {
     return null;
+  }
+
+  if (!Array.isArray(returnValue)) {
+    returnValue = [returnValue];
   }
 
   return (
@@ -30,13 +34,18 @@ const FunctionDefinition = ({ className, arguments: params, returnValue }) => {
       {params.length > 0 && <CodeDef.Bracket>)</CodeDef.Bracket>}
       {returnValue.length > 0 && (
         <>
-          <CodeDef.Operator> => </CodeDef.Operator>
+          <CodeDef.Operator> =&gt; </CodeDef.Operator>
           <CodeDef.Type>{returnValue[0].type}</CodeDef.Type>
         </>
       )}
     </CodeDef>
   );
 };
+
+const ReturnValueType = PropTypes.shape({
+  type: PropTypes.string,
+  description: PropTypes.string,
+});
 
 FunctionDefinition.propTypes = {
   className: PropTypes.string,
@@ -47,12 +56,10 @@ FunctionDefinition.propTypes = {
       description: PropTypes.string,
     })
   ).isRequired,
-  returnValue: PropTypes.arrayOf(
-    PropTypes.shape({
-      type: PropTypes.string,
-      description: PropTypes.string,
-    })
-  ).isRequired,
+  returnValue: PropTypes.oneOfType([
+    ReturnValueType,
+    PropTypes.arrayOf(ReturnValueType),
+  ]).isRequired,
 };
 
 export const query = graphql`

--- a/src/components/MethodReference.js
+++ b/src/components/MethodReference.js
@@ -16,12 +16,14 @@ const MethodReference = ({ className, method }) => {
       <h3>
         <code>{method.name}</code>
       </h3>
-      <Markdown
-        source={method.description}
-        css={css`
-          margin-bottom: 1rem;
-        `}
-      />
+      {method.description && method.description !== 'undefined' && (
+        <Markdown
+          source={method.description}
+          css={css`
+            margin-bottom: 1rem;
+          `}
+        />
+      )}
       <FunctionDefinition
         arguments={method.arguments}
         returnValue={method.returnValue}


### PR DESCRIPTION
## Description
This PR adds a few fixes to reduce the number of errors on the developer site. More specifically, this removes:

* The warning that we needed a unique `key` for the `<meta>` tags coming from our SEO component
* The warning coming from the `logger` API page (due to the SDK being in a weird state - see screenshots)

## Screenshot(s)
It looks like the SDK for the `logger` API is mostly incomplete. A number of the adjustments in the PR were defensive adjustments to get the page to render without errors. That said, it's still pretty incomplete:

![Screen Shot 2021-09-01 at 16 19 31](https://user-images.githubusercontent.com/1946433/131758006-42d29e5a-e1d9-4712-86a3-5796ca480a4b.png)
