### PR TITLE
Design Tweaks

### DIFF
--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -7,13 +7,23 @@ const Breadcrumbs = ({ segments, separator }) => {
   return (
     <div
       css={css`
-        margin: 2em 0;
+        margin: 1rem 0 0;
+        padding: 1rem 2rem;
+
+        background-color: var(--secondary-background-color); ;
       `}
       aria-label="breadcrumb"
     >
       {segments.map((segment) => {
         const elem = segment.url ? (
-          <Link to={segment.url}>{segment.name}</Link>
+          <Link
+            to={segment.url}
+            css={css`
+              text-decoration: none;
+            `}
+          >
+            {segment.name}
+          </Link>
         ) : (
           segment.name
         );
@@ -21,12 +31,12 @@ const Breadcrumbs = ({ segments, separator }) => {
           <span
             key={`breadcrumb-${segment.name}`}
             css={css`
-              :not(:last-of-type) {
-                :after {
-                  margin: 0 0.5em;
-                  display: inline-block;
-                  content: '${separator}';
-                }
+              font-size: 0.85rem;
+
+              :not(:last-of-type):after {
+                margin: 0 0.5em;
+                display: inline-block;
+                content: '${separator}';
               }
             `}
           >

--- a/src/components/Tabs/Page.js
+++ b/src/components/Tabs/Page.js
@@ -9,8 +9,6 @@ const Page = ({ index, children, id }) => {
   const isSelected =
     id === currentTab || (currentTab === undefined && index === 0);
 
-  // if (!isSelected) return null;
-
   return (
     <div role="tabpanel" aria-labelledby={id} hidden={!isSelected}>
       {children}

--- a/src/components/Tabs/Page.js
+++ b/src/components/Tabs/Page.js
@@ -9,10 +9,10 @@ const Page = ({ index, children, id }) => {
   const isSelected =
     id === currentTab || (currentTab === undefined && index === 0);
 
-  if (!isSelected) return null;
+  // if (!isSelected) return null;
 
   return (
-    <div role="tabpanel" aria-labelledby={id}>
+    <div role="tabpanel" aria-labelledby={id} hidden={!isSelected}>
       {children}
     </div>
   );

--- a/src/layouts/QuickStartLayout.js
+++ b/src/layouts/QuickStartLayout.js
@@ -16,6 +16,11 @@ const QuickStartLayout = ({ children }) => {
         <Layout.Main
           css={css`
             min-height: 100vh;
+            padding: 0;
+
+            > * {
+              margin: var(--site-content-padding);
+            }
           `}
         >
           {children}

--- a/src/pages/instant-observability.js
+++ b/src/pages/instant-observability.js
@@ -302,90 +302,82 @@ const QuickstartsPage = ({ data, location }) => {
         >
           <div
             css={css`
-              background-color: var(--color-neutrals-100);
-              margin: 15px 0;
+              background-color: var(--secondary-background-color);
+              border-radius: 4px;
               padding: 1rem;
               display: flex;
               justify-content: space-between;
               align-items: center;
-              flex-wrap: wrap;
-              .dark-mode & {
-                background-color: var(--color-dark-100);
+
+              input {
+                font-size: 1.15em;
+                padding: 0.5rem;
+                padding-left: 3.75rem;
+                border-radius: 4px;
+
+                &::placeholder {
+                  color: var(--border-color);
+                }
               }
+
+              .dark-mode & {
+                background-color: var(--tertiary-background-color);
+              }
+
               @media screen and (max-width: 1180px) {
                 flex-direction: column;
                 align-items: normal;
+
                 > * {
                   margin: 0.5rem 0;
                 }
               }
             `}
           >
+            <SearchInput
+              ref={searchInputRef}
+              size={SearchInput.SIZE.LARGE}
+              value={formState.search || ''}
+              placeholder="Search for any quickstart (e.g. Node, AWS, LAMP, etc.)"
+              onClear={() => {
+                setFormState((state) => ({
+                  ...state,
+                  search: null,
+                }));
+              }}
+              onChange={(e) => {
+                setFormState((state) => ({
+                  ...state,
+                  search: e.target.value.toLowerCase(),
+                }));
+              }}
+            />
             <div
               css={css`
-                display: flex;
-                align-items: center;
-                width: 100%;
-
-                > * {
-                  margin: 0 0.1rem;
-                }
+                min-width: 155px;
+                margin-left: 20px;
               `}
             >
-              <div
-                css={css`
-                  width: 100%;
-                  margin-left: 20px;
-                  input {
-                    background: inherit;
-                  }
-                `}
-              >
-                <SearchInput
-                  ref={searchInputRef}
-                  size={SearchInput.SIZE.LARGE}
-                  value={formState.search || ''}
-                  placeholder="Search pack names / descriptions. Enter to search"
-                  onClear={() => {
-                    setFormState((state) => ({
-                      ...state,
-                      search: null,
-                    }));
-                  }}
-                  onChange={(e) => {
-                    setFormState((state) => ({
-                      ...state,
-                      search: e.target.value.toLowerCase(),
-                    }));
-                  }}
-                />
-              </div>
-              <div
-                css={css`
-                  display: inline-block;
-                  min-width: 155px;
-                  margin-left: 20px;
-                `}
-              >
-                <SegmentedControl
-                  items={Object.values(VIEWS)}
-                  onChange={(_e, view) => {
-                    setView(view);
+              <SegmentedControl
+                items={Object.values(VIEWS)}
+                onChange={(_e, view) => {
+                  setView(view);
 
-                    tessen.track('observabilityPack', `packViewToggle`, {
-                      packViewState: view,
-                    });
-                  }}
-                />
-              </div>
+                  tessen.track('observabilityPack', `packViewToggle`, {
+                    packViewState: view,
+                  });
+                }}
+              />
             </div>
           </div>
           <div
             css={css`
-              margin: 2em 0;
+              padding: 1.25rem 0;
+              font-size: 0.9rem;
+              color: var(--secondary-text-color);
             `}
           >
-            <span>Showing {filteredPacks.length} results</span>
+            Showing {filteredPacks.length} results
           </div>
           <div
             css={css`

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -79,15 +79,53 @@ const QuickstartDetails = ({ data, location }) => {
           type={PageLayout.TYPE.RELATED_CONTENT_TABS}
           css={css`
             grid-template-columns: minmax(0, 1fr) 360px;
+            margin-top: 1rem;
           `}
         >
           <PageLayout.Header
             title={pack.name}
             css={css`
               border-bottom: none;
-              gap: 1rem;
+              display: grid;
+              padding-bottom: 0;
+              grid-template-areas: 'title logo' 'desc logo';
+              grid-column-gap: 1rem;
+
+              h1 {
+                font-weight: normal;
+                grid-area: title;
+              }
             `}
-          />
+          >
+            {pack.logoUrl && (
+              <img
+                src={pack.logoUrl}
+                alt={pack.title}
+                css={css`
+                  max-height: 5rem;
+                  grid-area: logo;
+                  align-self: center;
+
+                  .dark-mode & {
+                    background-color: white;
+                  }
+
+                  @media (max-width: 760px) {
+                    display: none;
+                  }
+                `}
+              />
+            )}
+            {pack.description && (
+              <p
+                css={css`
+                  grid-area: desc;
+                `}
+              >
+                {pack.description}
+              </p>
+            )}
+          </PageLayout.Header>
           <Tabs.Bar
             css={css`
               grid-column: 1/3;


### PR DESCRIPTION
## Description
I noticed a few design inconsistencies when compared to the designs and the in-product experience. I wanted to start addressing those as we get closer to GA. Some of the changes include:

* Adding the description below the quickstart title (like the in-product catalot)
* Adding the logo on the quickstart detail page (like the in-product catalog)
* Adding a background to the breadcrumb bar (like the designs)
* Tweaks to spacing / fonts to match the designs
* Simplifying some of the DOM (we had a few extra `<div>`s that were unnecessary)

## Screenshots
### Catalog Page - Before
![Screen Shot 2021-09-03 at 16 27 18](https://user-images.githubusercontent.com/1946433/132074337-9881b1ee-808c-4c1b-a385-5b369abbe49b.png)
### Catalog Page - After
![Screen Shot 2021-09-03 at 16 27 09](https://user-images.githubusercontent.com/1946433/132074347-6bdf0e73-fb82-4f6c-ae66-98a0ba1ca975.png)

### Details Page - Before
![Screen Shot 2021-09-03 at 16 26 35](https://user-images.githubusercontent.com/1946433/132074356-38ce561a-cb7b-4356-b676-be12dda75469.png)
### Details Page - After
![Screen Shot 2021-09-03 at 16 25 51](https://user-images.githubusercontent.com/1946433/132074369-c0fcbbd2-2316-4367-8dad-95cae116c718.png)
