### PR TITLE
Remove /nerdlet from nr1 url

### DIFF
--- a/src/utils/get-pack-nr1-url.js
+++ b/src/utils/get-pack-nr1-url.js
@@ -4,8 +4,6 @@ import {
   NR1_PACK_DETAILS_NERDLET,
 } from '../data/constants';
 
-const NERDLET_PATH = `nerdlet/${NR1_PACK_DETAILS_NERDLET}`;
-
 /**
  * @param {string} packId The ID for an observability pack.
  * @param {boolean} [debug] If set to true, this will add `packages=local`.
@@ -27,7 +25,7 @@ const getPackNr1Url = (quickstartId, debug = false) => {
   const local = debug ? 'packages=local&' : '';
   const NR1_URL = debug ? NR1_BASE_URL_LOCAL : NR1_BASE_URL;
 
-  const url = new URL(`${NERDLET_PATH}?${local}pane=${hash}`, NR1_URL);
+  const url = new URL(`?${local}pane=${hash}`, NR1_URL);
 
   return url.href;
 };

--- a/src/utils/get-pack-nr1-url.js
+++ b/src/utils/get-pack-nr1-url.js
@@ -4,6 +4,8 @@ import {
   NR1_PACK_DETAILS_NERDLET,
 } from '../data/constants';
 
+const NERDLET_PATH = `launcher/nr1-core.explorer/`;
+
 /**
  * @param {string} packId The ID for an observability pack.
  * @param {boolean} [debug] If set to true, this will add `packages=local`.
@@ -25,7 +27,7 @@ const getPackNr1Url = (quickstartId, debug = false) => {
   const local = debug ? 'packages=local&' : '';
   const NR1_URL = debug ? NR1_BASE_URL_LOCAL : NR1_BASE_URL;
 
-  const url = new URL(`?${local}pane=${hash}`, NR1_URL);
+  const url = new URL(`${NERDLET_PATH}?${local}pane=${hash}`, NR1_URL);
 
   return url.href;
 };


### PR DESCRIPTION
We were adding `/nerdlet/catalog-pack-details.catalog-pack-contents` to the nr1 url when installing a pack. i don't think it's possible to load a nerdlet this way and it seems it redirects for some users and not others. This removes that part of the url (but maintains the nerdlet ID passed in the pane param) which uses the platform to launch our nerdlet. if we don't want to see the platform tabs at the top (explorer, alerts, etc) we can make our own launcher, but in the meantime this will at least render things functional