### PR TITLE
Update tessen naming for required format, consistency

### DIFF
--- a/src/components/PackTile.js
+++ b/src/components/PackTile.js
@@ -36,7 +36,7 @@ const PackTile = ({
 
   const handlePackClick = useInstrumentedHandler(
     () => {
-      tessen.track('quickstart', 'QuickstartClick', {
+      tessen.track('instantObservability', 'QuickstartClick', {
         publicCatalogView: view,
         quickstartName: name,
       });
@@ -51,7 +51,7 @@ const PackTile = ({
 
   const handleBuildTileClick = useInstrumentedHandler(
     () => {
-      tessen.track('quickstart', 'BuildYourOwnQuickstartClick', {
+      tessen.track('instantObservability', 'BuildYourOwnQuickstartClick', {
         publicCatalogView: view,
         quickstartName: name,
       });

--- a/src/components/Tabs/BarItem.js
+++ b/src/components/Tabs/BarItem.js
@@ -28,7 +28,7 @@ const BarItem = ({ index, children, id, count, disabled }) => {
       type="button"
       onClick={() => {
         !disabled && setCurrentTab(id);
-        tessen.track('quickstart', `QuickstartTabToggle`, {
+        tessen.track('instantObservability', `QuickstartTabToggle`, {
           QuickstartTabState: id,
           QuickstartTabCount: count,
         });

--- a/src/pages/instant-observability.js
+++ b/src/pages/instant-observability.js
@@ -92,7 +92,7 @@ const QuickstartsPage = ({ data, location }) => {
     setCategory(categoryParam);
 
     if (searchParam || filterParam || categoryParam) {
-      tessen.track('InstantObservability', 'QuickstartsCatalog', {
+      tessen.track('instantObservability', 'CatalogSearch', {
         filter: filterParam,
         search: searchParam,
         category: categoryParam,
@@ -393,7 +393,7 @@ const QuickstartsPage = ({ data, location }) => {
                 onChange={(_e, view) => {
                   setView(view);
 
-                  tessen.track('InstantObservability', `QuickstartViewToggle`, {
+                  tessen.track('instantObservability', `QuickstartViewToggle`, {
                     quickstartViewState: view,
                   });
                 }}

--- a/src/pages/instant-observability.js
+++ b/src/pages/instant-observability.js
@@ -92,7 +92,7 @@ const QuickstartsPage = ({ data, location }) => {
     setCategory(categoryParam);
 
     if (searchParam || filterParam || categoryParam) {
-      tessen.track('instantObservability', 'CatalogSearch', {
+      tessen.track('instantObservability', 'QuickstartCatalogSearch', {
         filter: filterParam,
         search: searchParam,
         category: categoryParam,

--- a/src/pages/instant-observability.js
+++ b/src/pages/instant-observability.js
@@ -235,7 +235,7 @@ const QuickstartsPage = ({ data, location }) => {
             />
             <FormControl>
               <Label htmlFor="quickstartCategoryByType">Categories</Label>
-              {detectMobile.isMobile() ? (
+              {isMobile ? (
                 <Select
                   id="quickstartCategoryByType"
                   value={category}

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -65,7 +65,7 @@ const QuickstartDetails = ({ data, location }) => {
 
   const handleInstallClick = () => {
     writeCookie();
-    tessen.track('quickstart', 'QuickstartInstall', {
+    tessen.track('instantObservability', 'QuickstartInstall', {
       quickstartName: quickstart.name,
       quickstartId: quickstart.id,
       quickstartUrl: quickstart.packUrl,
@@ -73,7 +73,7 @@ const QuickstartDetails = ({ data, location }) => {
   };
 
   const viewRepoClick = () =>
-    tessen.track('quickstart', 'QuickstartViewRepoClick', {
+    tessen.track('instantObservability', 'QuickstartViewRepoClick', {
       quickstartName: quickstart.name,
       quickstartId: quickstart.id,
       quickstartUrl: quickstart.packUrl,


### PR DESCRIPTION
## Description

Tessen requires that event names be `camelCase` and category to be `TitleCase`. If they're not, events do not report / fail silently. Some of these events were not sending until I changed the format. I confirmed that all instrumented events sent when running locally.

I also updated the event names to use one standard name. That makes it easier to query downstream when Tessen packages up events for segment and NR1.

## Related issues / PRs
Partially addresses https://github.com/newrelic/developer-website/issues/1603

## Additional context
We don't quite seem to stick to a standard for tessen event naming. But generally, it seems `eventName` is the more broad of the two and `category` is a specific type of said event.

Our tessen wrapper uses this signature:

```
Tessen.track("eventName", "CategoryOfThing", {…})
```

Which packages that into this format in segment:

```
TDEV_CategoryOfThing_eventName
```

