### PR TITLE
Update tessen QuickstartCatalogSearch event property to avoid name conflict

### DIFF
--- a/src/pages/instant-observability.js
+++ b/src/pages/instant-observability.js
@@ -111,7 +111,7 @@ const QuickstartsPage = ({ data, location }) => {
       tessen.track('instantObservability', 'QuickstartCatalogSearch', {
         filter: filterParam,
         search: searchParam,
-        category: categoryParam,
+        quickstartCategory: categoryParam,
       });
     }
   }, [location.search, tessen]);


### PR DESCRIPTION
## Description

Changes the `category` property name to avoid conflicting with the Tessen `category` which overwrites this property when it's sent to segment. In this case, the `category` that's used is `QuickstartCatalogSearch`.


