### PR TITLE
Remove CookieConsentDialog in favor of OneTrust

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,7 +21,7 @@ module.exports = {
     {
       resolve: '@newrelic/gatsby-theme-newrelic',
       options: {
-        oneTrustID: '77dd4d78-49db-4057-81ea-4bc325d6ecdd-test',
+        oneTrustID: '77dd4d78-49db-4057-81ea-4bc325d6ecdd',
         forceTrailingSlashes: true,
         layout: {
           contentPadding: '2rem',

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "^1.6.19",
     "@mdx-js/react": "^1.6.19",
-    "@newrelic/gatsby-theme-newrelic": "^2.10.0",
+    "@newrelic/gatsby-theme-newrelic": "^2.10.1",
     "@splitsoftware/splitio-react": "^1.2.0",
     "@xstate/react": "^1.0.2",
     "classnames": "^2.2.6",

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import {
-  CookieConsentDialog,
   GlobalHeader,
   Layout,
   Logo,
@@ -83,7 +82,6 @@ const MainLayout = ({ children, pageContext }) => {
         </SdkContext.Provider>
         <Layout.Footer fileRelativePath={fileRelativePath} />
       </Layout>
-      <CookieConsentDialog />
     </>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2048,10 +2048,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^2.10.0":
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-2.10.0.tgz#3df9a6c46021c02770f8b1101663cb11fdd3f3ba"
-  integrity sha512-/MYWZyh8iS2rFgDyUPxDkEv1Xvdoq9docSIR6JzGRm2OwM8ChxppHVMpyMW0I/ESGvE8tgQyeac8y+Bd+kVAUQ==
+"@newrelic/gatsby-theme-newrelic@^2.10.1":
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-2.10.1.tgz#b6088a1a0f89f44496adffa001e14e22bb65e26f"
+  integrity sha512-ZtUj0mzPez7NQwgBCs8kVfKX4E29GTIXQgsTZw8yVDhwzOfv9IrX9FdWKJb7+/1uGxYiPq9Krl+LtXc8UKFENw==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
## Description

This removes the `CookieConsentDialog` component from the main layout in favor of OneTrust.

Also bumps theme version for tessen amplitude setting.

We'll likely have to update the theme's tracking code (tessen, ga) to no longer check the cookie set by this component before firing analytics calls.

## Related Issue(s) / Ticket(s)

Related to:
* https://github.com/newrelic/developer-website/pull/1656
* https://github.com/newrelic/gatsby-theme-newrelic/pull/463


