### PR TITLE
Send user to guided install nerdlet

### DIFF
--- a/src/components/InstallButton.js
+++ b/src/components/InstallButton.js
@@ -3,15 +3,19 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { Button, Link, Icon } from '@newrelic/gatsby-theme-newrelic';
 import getPackNr1Url from '../utils/get-pack-nr1-url';
-import { NR1_LOGIN_URL } from '../data/constants';
+import {
+  NR1_LOGIN_URL,
+  NR1_GUIDED_INSTALL_NERDLET,
+  NR1_PACK_DETAILS_NERDLET,
+} from '../data/constants';
 import { quickstart } from '../types';
 
 /**
  * @param {String} id
  * @returns {String}
  */
-const createInstallLink = (id) => {
-  const platformUrl = getPackNr1Url(id);
+const createInstallLink = (id, nerdletId) => {
+  const platformUrl = getPackNr1Url(id, nerdletId);
   const url = new URL(
     `?return_to=${encodeURIComponent(platformUrl)}`,
     NR1_LOGIN_URL
@@ -31,15 +35,24 @@ const hasComponent = (quickstart, key) =>
 const InstallButton = ({ quickstart, ...props }) => {
   const hasInstallableComponent = hasComponent(quickstart, 'installPlans');
 
+  const hasGuidedInstall =
+    hasInstallableComponent &&
+    quickstart.installPlans.length === 1 &&
+    quickstart.installPlans[0].id.includes('guided-install');
+
   // If there is nothing to install AND no documentation, don't show this button.
   if (!hasInstallableComponent && !hasComponent(quickstart, 'documentation')) {
     return null;
   }
 
+  const destinationNerdletId = hasGuidedInstall
+    ? NR1_GUIDED_INSTALL_NERDLET
+    : NR1_PACK_DETAILS_NERDLET;
+
   // If we have an install-able component, generate a URL. Otherwise, link to the
   // first documentation supplied.
   const url = hasInstallableComponent
-    ? createInstallLink(quickstart.id)
+    ? createInstallLink(quickstart.id, destinationNerdletId)
     : quickstart.documentation[0].url;
 
   return (

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -22,6 +22,9 @@ export const NR1_BASE_URL_LOCAL = 'https://dev-one.newrelic.com';
 export const NR1_PACK_DETAILS_NERDLET =
   'catalog-pack-details.catalog-pack-contents';
 
+export const NR1_GUIDED_INSTALL_NERDLET =
+  'nr1-install-newrelic.nr1-install-newrelic';
+
 export const QUICKSTART_SUPPORT_LEVELS = {
   NEWRELIC: 'NEWRELIC',
   VERIFIED: 'VERIFIED',

--- a/src/utils/get-pack-nr1-url.js
+++ b/src/utils/get-pack-nr1-url.js
@@ -1,8 +1,4 @@
-import {
-  NR1_BASE_URL,
-  NR1_BASE_URL_LOCAL,
-  NR1_PACK_DETAILS_NERDLET,
-} from '../data/constants';
+import { NR1_BASE_URL, NR1_BASE_URL_LOCAL } from '../data/constants';
 
 const NERDLET_PATH = `launcher/nr1-core.explorer/`;
 
@@ -11,9 +7,9 @@ const NERDLET_PATH = `launcher/nr1-core.explorer/`;
  * @param {boolean} [debug] If set to true, this will add `packages=local`.
  * @returns {string} The URL for the pack details within the platform.
  */
-const getPackNr1Url = (quickstartId, debug = false) => {
+const getPackNr1Url = (quickstartId, nerdletId, debug = false) => {
   const pane = JSON.stringify({
-    nerdletId: NR1_PACK_DETAILS_NERDLET,
+    nerdletId,
     quickstartId,
   });
 


### PR DESCRIPTION
## Description

This PR sends the user to the guided install flow if the quickstart has a guided-install installPack only. Else the user is sent to the catalog-pack-contents nerdlet as before.

## Reviewer Notes

If there are links or steps needed to test this work, add them here.

## Related Issue(s) / Ticket(s)

If there are any related [GitHub Issues](https://github.com/newrelic/developer-website/issues) or JIRA tickets, add links to them here.
* [issue]()

## Screenshot(s)

If relevant, add screenshots here.

## Use Conventional Commits

Please help the maintainers by leveraging the following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
standards in your pull request title and commit messages.

## Use `chore`

* for minor changes / additions / corrections to content.
* for minor changes / additions / corrections to images.
* for minor non-functional changes / additions to github actions, github templates, package or config updates, etc

```bash
git commit -m "chore: adjusting config and content"
```

## Use `fix`

* for minor functional corrections to code.

```bash
git commit -m "fix: typo and prop error in the code of conduct"
```

## Use `feat`

* for major functional changes or additions to code.

```bash
git commit -m "feat(media): creating a video landing page"
```
