### PR TITLE
Create quickstart url csv script

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "build:staging": "GATSBY_NEWRELIC_ENV=staging gatsby build",
     "build:related-content": "BUILD_RELATED_CONTENT=true yarn run build:production",
     "fetch-quickstarts": "node ./scripts/actions/fetch-quickstarts.js",
+    "list-quickstart-urls": "node ./scripts/list-quickstart-urls.js",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "yarn run develop",

--- a/scripts/list-quickstart-urls.js
+++ b/scripts/list-quickstart-urls.js
@@ -1,0 +1,33 @@
+const getPackNr1Url = require('../src/utils/get-pack-nr1-url');
+const quickstarts = require('../src/data/quickstarts.json');
+const fs = require('fs');
+
+const NR1_PACK_DETAILS_NERDLET = 'catalog-pack-details.catalog-pack-contents';
+const NR1_GUIDED_INSTALL_NERDLET = 'nr1-install-newrelic.nr1-install-newrelic';
+
+const csvColumns = ['Quickstart name,url'];
+const urls = quickstarts
+  .map((quickstart) => {
+    const hasInstallableComponent = quickstart.installPlans.length === 1;
+    const hasGuidedInstall =
+      hasInstallableComponent &&
+      quickstart.installPlans[0].id.includes('guided-install');
+    if (hasInstallableComponent) {
+      if (hasGuidedInstall) {
+        return `${quickstart.title},${getPackNr1Url(
+          quickstart.id,
+          NR1_GUIDED_INSTALL_NERDLET
+        )}`;
+      } else {
+        return `${quickstart.title},${getPackNr1Url(
+          quickstart.id,
+          NR1_PACK_DETAILS_NERDLET
+        )}`;
+      }
+    }
+  })
+  .filter(Boolean);
+
+const urlOutputCsv = csvColumns.concat(urls).join('\n');
+
+fs.writeFileSync('quickstart_urls.csv', urlOutputCsv);

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -14,11 +14,6 @@ export const SDK_BASE_URL =
 // FIXME: update this to production URL when deployed / launched
 export const NR1_LOGIN_URL = 'https://staging-login.newrelic.com/login';
 
-// FIXME: update this to production URL when deployed / launched
-export const NR1_BASE_URL = 'https://staging-one.newrelic.com';
-
-export const NR1_BASE_URL_LOCAL = 'https://dev-one.newrelic.com';
-
 export const NR1_PACK_DETAILS_NERDLET =
   'catalog-pack-details.catalog-pack-contents';
 

--- a/src/utils/get-pack-nr1-url.js
+++ b/src/utils/get-pack-nr1-url.js
@@ -1,5 +1,6 @@
-import { NR1_BASE_URL, NR1_BASE_URL_LOCAL } from '../data/constants';
-
+// FIXME: update this to production URL when deployed / launched
+const NR1_BASE_URL = 'https://staging-one.newrelic.com';
+const NR1_BASE_URL_LOCAL = 'https://dev-one.newrelic.com';
 const NERDLET_PATH = `launcher/nr1-core.explorer/`;
 
 /**
@@ -16,7 +17,7 @@ const getPackNr1Url = (quickstartId, nerdletId, debug = false) => {
   // Note: this works differently depending on whether or not we have access
   // to the window object (and the btoa function).
   const hash =
-    window && window.btoa
+    typeof window !== 'undefined' && window.btoa
       ? btoa(pane)
       : Buffer.from(pane, 'utf-8').toString('base64');
 
@@ -28,4 +29,4 @@ const getPackNr1Url = (quickstartId, nerdletId, debug = false) => {
   return url.href;
 };
 
-export default getPackNr1Url;
+module.exports = getPackNr1Url;


### PR DESCRIPTION
Adds a script for generating a csv file that contains the urls to all installable quickstarts (this includes both guided installs and regular)

Closes https://github.com/newrelic/developer-website/issues/1637