### PR TITLE
fix: add skilljar as an iframe-able domain

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -194,7 +194,7 @@ module.exports = {
       options: {
         allPageHeaders: [
           'Referrer-Policy: no-referrer-when-downgrade',
-          'Content-Security-Policy: frame-ancestors https://*.newrelic.com http://*.newrelic.com',
+          'Content-Security-Policy: frame-ancestors *.newrelic.com *.skilljar.com',
         ],
       },
     },


### PR DESCRIPTION
## Description

Adds `*.skilljar.com` to the list of domains allowed to embed developer site content