### PR TITLE
chore: aligns tags

### DIFF
--- a/src/components/quickstarts/QuickstartDataSources.js
+++ b/src/components/quickstarts/QuickstartDataSources.js
@@ -41,6 +41,7 @@ const QuickstartDataSources = ({ quickstart }) => (
           interactive
         >
           <h3>{doc.name}</h3>
+          {doc.description && <p>{doc.description}</p>}
           <Tag
             css={css`
               display: inline-block;
@@ -49,8 +50,6 @@ const QuickstartDataSources = ({ quickstart }) => (
           >
             Docs
           </Tag>
-
-          {doc.description && <p>{doc.description}</p>}
         </Surface>
       ))}
     </div>

--- a/src/components/quickstarts/QuickstartOverview.js
+++ b/src/components/quickstarts/QuickstartOverview.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { css } from '@emotion/react';
-
 import { quickstart } from '../../types';
 import OverviewTile from './OverviewTile';
 import Markdown from '../Markdown';


### PR DESCRIPTION
- moves the doc tag down under the description on the datsource tab
- removes an empty line from the overview file