### PR TITLE
Fix url list script

### DIFF
--- a/scripts/list-quickstart-urls.js
+++ b/scripts/list-quickstart-urls.js
@@ -8,7 +8,7 @@ const NR1_GUIDED_INSTALL_NERDLET = 'nr1-install-newrelic.nr1-install-newrelic';
 const csvColumns = ['Quickstart name,url'];
 const urls = quickstarts
   .map((quickstart) => {
-    const hasInstallableComponent = quickstart.installPlans.length === 1;
+    const hasInstallableComponent = quickstart.installPlans.length > 0;
     const hasGuidedInstall =
       hasInstallableComponent &&
       quickstart.installPlans[0].id.includes('guided-install');


### PR DESCRIPTION
The previous check only worked if there was a single install plan, but some packs have multiple. this checks for any packs with any number of install plans