### PR TITLE
Use latest theme for new cookie mgmt / tessen upgrade

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,6 +21,7 @@ module.exports = {
     {
       resolve: '@newrelic/gatsby-theme-newrelic',
       options: {
+        oneTrustID: '77dd4d78-49db-4057-81ea-4bc325d6ecdd',
         forceTrailingSlashes: true,
         layout: {
           contentPadding: '2rem',
@@ -113,6 +114,7 @@ module.exports = {
           },
         },
         tessen: {
+          tessenVersion: '1.14.0',
           product: 'DEV',
           subproduct: 'TDEV',
           segmentWriteKey: 'Ako0hclX8WGHwl9rm4n5uxLtT4wgEtuU',

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "^1.6.19",
     "@mdx-js/react": "^1.6.19",
-    "@newrelic/gatsby-theme-newrelic": "^2.8.0",
+    "@newrelic/gatsby-theme-newrelic": "^3.0.0",
     "@splitsoftware/splitio-react": "^1.2.0",
     "@xstate/react": "^1.0.2",
     "classnames": "^2.2.6",

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import {
-  CookieConsentDialog,
   GlobalHeader,
   Layout,
   Logo,
@@ -84,7 +83,6 @@ const MainLayout = ({ children, pageContext }) => {
         </SdkContext.Provider>
         <Layout.Footer fileRelativePath={fileRelativePath} />
       </Layout>
-      <CookieConsentDialog />
     </>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2048,10 +2048,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-2.8.0.tgz#127848aafb92aa9988ec74beb7b8804da8cda6ab"
-  integrity sha512-ihmDqPPMrt4SccSpY+vZSf5kJBPK0IFb23si8wweDRczUVLAjHTXNEyKHZKYOUyvxdFMH/Lat8DuXdNROPH/VQ==
+"@newrelic/gatsby-theme-newrelic@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-3.0.0.tgz#e9032e46d0bebef4f74da0ce98da4d058ce1edae"
+  integrity sha512-t7uojgs25wggWmjZghFGih9rHYvQ621v3f0mnQ7C+yduSiHQl2eFFZM+l0W/NwGcJjQ93N6rHwOhnCjnIb6WmQ==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
## Description

Bumps theme to latest version just released to fully switch over to new cookie mgmt / tessen upgrade.

This _should_ enable us to report tessen data from preview builds


