### PR TITLE
fix banner text breaking out of image

### DIFF
--- a/src/components/IOBanner.js
+++ b/src/components/IOBanner.js
@@ -46,7 +46,7 @@ const IOBanner = ({ isMobile }) => {
         </h1>
         <p
           css={css`
-            font-size: max(12px, 0.75vw);
+            font-size: 0.75rem;
             @media screen and (max-width: 1303px) {
               margin-bottom: 0.3rem;
             }


### PR DESCRIPTION
## Description

The banner text was expanding on larger screen to break out of the background image. This adjusts the text to a fixed size to prevent this from happening.

* Closes #1701 