### PR TITLE
Center images, fade on sliding out

### DIFF
--- a/src/components/ImageSlider.js
+++ b/src/components/ImageSlider.js
@@ -35,6 +35,7 @@ const ImageSlider = ({ images, height }) => {
           position: relative;
           display: flex;
           align-items: center;
+          justify-content: center;
           height: ${height}px;
           overflow: hidden;
           ${images.length === 1 && 'margin-bottom: 2rem;'}
@@ -114,6 +115,7 @@ const ImageSlider = ({ images, height }) => {
             }}
             enter={{ opacity: 1, transform: 'translate3d(-0%, 0px, 0px)' }}
             leave={{
+              opacity: 0,
               transform: `translate3d(${forward ? '-100%' : '100%'}, 0px, 0px)`,
             }}
             delay={200}


### PR DESCRIPTION
## Description

Centers images in the image gallery and when image slides out, makes it fade.

## Screenshot(s)

https://user-images.githubusercontent.com/2952843/134990752-622a4df2-a709-4e0c-8c56-ef580744c6cb.mp4


https://user-images.githubusercontent.com/2952843/134990758-e086d140-d031-424f-ac3d-71ef61618d62.mp4