### PR TITLE
chore: add quickstartbuttontext field to tessen

### DIFF
--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
 import { css } from '@emotion/react';
-import Cookies from 'js-cookie';
 import DevSiteSeo from '../components/DevSiteSeo';
 import PropTypes from 'prop-types';
 import PageLayout from '../components/PageLayout';
@@ -53,26 +52,6 @@ const QuickstartDetails = ({ data, location }) => {
       content: quickstart.title,
     },
   ];
-
-  const writeCookie = () => {
-    const currentEnvironment =
-      process.env.ENV || process.env.NODE_ENV || 'development';
-    const options = { expires: 1 /* days */ };
-    if (currentEnvironment !== 'development') {
-      options.domain = 'newrelic.com';
-    }
-
-    Cookies.set('newrelic-quickstart-id', quickstart.id, options);
-  };
-
-  const handleInstallClick = () => {
-    writeCookie();
-    tessen.track('instantObservability', 'QuickstartInstall', {
-      quickstartName: quickstart.name,
-      quickstartId: quickstart.id,
-      quickstartUrl: quickstart.packUrl,
-    });
-  };
 
   const viewRepoClick = () =>
     tessen.track('instantObservability', 'QuickstartViewRepoClick', {
@@ -175,11 +154,7 @@ const QuickstartDetails = ({ data, location }) => {
                 }
               `}
             >
-              <InstallButton
-                quickstart={quickstart}
-                onClick={handleInstallClick}
-                location={location}
-              />
+              <InstallButton quickstart={quickstart} location={location} />
               <Button
                 as={Link}
                 variant={Button.VARIANT.OUTLINE}


### PR DESCRIPTION
Moved tessen.track for the Install Button into the InstallButton.js. Added  a field to tessen to check the button text when clicked. 

Closes https://github.com/newrelic/developer-website/issues/1733