### PR TITLE
feat: add redirects for embed pages

### DIFF
--- a/plugins/gatsby-plugin-embed-pages/gatsby-node.js
+++ b/plugins/gatsby-plugin-embed-pages/gatsby-node.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 exports.createPages = async ({ actions, graphql, reporter }) => {
-  const { createPage } = actions;
+  const { createPage, createRedirect } = actions;
 
   const { data } = await graphql(`
     query MyQuery {
@@ -14,8 +14,8 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
           frontmatter {
             title
             path
+            redirects
           }
-          body
         }
       }
     }
@@ -25,8 +25,8 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     const {
       frontmatter,
       fields: { fileRelativePath, slug },
-      body,
     } = node;
+    const { redirects } = frontmatter;
     const nodePath = frontmatter.path || slug;
     const pagePath = path.join(nodePath, 'embed', '/');
     const contentSourcePath = nodePath;
@@ -41,5 +41,23 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         layout: 'EmbedLayout',
       },
     });
+
+    if (redirects) {
+      redirects.forEach((fromPath) => {
+        reporter.info(
+          `Creating redirect for embed page: ${path.join(
+            fromPath,
+            'embed',
+            '/'
+          )}`
+        );
+        createRedirect({
+          fromPath: path.join(fromPath, 'embed', '/'),
+          toPath: pagePath,
+          isPermanent: true,
+          redirectInBrowser: true,
+        });
+      });
+    }
   });
 };


### PR DESCRIPTION
## Description

Adds redirects for embed pages if an MDX file has redirects in frontmatter. Not 100% sure how this works in an `iframe` but we can create redirects to see if it works.

Came in as hero request. this page:
https://developer.newrelic.com/build-apps/build-visualization/embed/ 

Moved to:
https://developer.newrelic.com/explore-docs/custom-viz/build-visualization/embed/