### PR TITLE
fix: k8s operator is not official

### DIFF
--- a/src/markdown-pages/automate-workflows/get-started-kubernetes.mdx
+++ b/src/markdown-pages/automate-workflows/get-started-kubernetes.mdx
@@ -24,7 +24,7 @@ tags:
 
 [Kubernetes](https://kubernetes.io/) is an open-source system for automating deployment, scaling, and management of containerized applications. You can use it to provision all kinds of infrastructure and services, including New Relic entities.
 
-In this guide you'll learn how to set up New Relic for the first time with the official [New Relic Kubernetes operator](https://github.com/newrelic/newrelic-kubernetes-operator). More specifically, you'll provision an alert policy with NRQL conditions in your New Relic account using Kubernetes.
+In this guide you'll learn how to set up New Relic for the first time with the open source [New Relic Kubernetes operator](https://github.com/newrelic/newrelic-kubernetes-operator). More specifically, you'll provision an alert policy with NRQL conditions in your New Relic account using Kubernetes.
 
 </Intro>
 


### PR DESCRIPTION
## Description

We received a support ticket from a customer who interpreted "official" in this guide to mean that the project is supported by New Relic. This change replaces "official" with "open source" to more accurately represent the project.