### PR TITLE
chore: run fetch quickstarts to align with in product

### DIFF
--- a/.github/workflows/fetch-quickstarts.yml
+++ b/.github/workflows/fetch-quickstarts.yml
@@ -3,7 +3,7 @@ name: Fetch Quickstarts
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *' # midnight
+    - cron: '0 1,5,9,13,17,21 * * *' # Every 4 hours staggered by 1 hour
 
 env:
   BOT_NAME: nr-opensource-bot


### PR DESCRIPTION
This tells the fetch-quickstarts workflow to run at 4 hour intervals starting at `01:00am`. In-product currently runs at 4 hour intervals starting at `12:00am`