### PR TITLE
Clark/bubble codestream tile

### DIFF
--- a/src/pages/instant-observability.js
+++ b/src/pages/instant-observability.js
@@ -166,7 +166,21 @@ const QuickstartsPage = ({ data, location }) => {
   const quickstarts = data.allQuickstarts.nodes;
 
   const alphaSort = quickstarts.sort((a, b) => a.title.localeCompare(b.title));
-  const sortedQuickstarts = sortFeaturedQuickstarts(alphaSort);
+  let sortedQuickstarts = sortFeaturedQuickstarts(alphaSort);
+
+
+  // Hard-code for moving codestream object to front of sortedQuickstarts array - CM
+  if (!category && !filter && !search || 
+        category === 'featured' && !filter && !search ) {
+    // uuid is codestream id specifically - CM
+    const codestreamIndex = sortedQuickstarts.findIndex(({ id }) => id === '29bd9a4a-1c19-4219-9694-0942f6411ce7');
+    const codestreamObject = sortedQuickstarts[codestreamIndex];
+    sortedQuickstarts = [
+      codestreamObject, 
+      ...sortedQuickstarts.slice(0, codestreamIndex), 
+      ...sortedQuickstarts.slice(codestreamIndex + 1)
+    ];
+  };
 
   const filteredQuickstarts = sortedQuickstarts
     .filter(filterBySearch(search))

--- a/src/pages/instant-observability.js
+++ b/src/pages/instant-observability.js
@@ -177,12 +177,15 @@ const QuickstartsPage = ({ data, location }) => {
     const codestreamIndex = sortedQuickstarts.findIndex(
       ({ id }) => id === '29bd9a4a-1c19-4219-9694-0942f6411ce7'
     );
-    const codestreamObject = sortedQuickstarts[codestreamIndex];
-    sortedQuickstarts = [
-      codestreamObject,
-      ...sortedQuickstarts.slice(0, codestreamIndex),
-      ...sortedQuickstarts.slice(codestreamIndex + 1),
-    ];
+
+    if (codestreamIndex > -1) {
+      const codestreamObject = sortedQuickstarts[codestreamIndex];
+      sortedQuickstarts = [
+        codestreamObject,
+        ...sortedQuickstarts.slice(0, codestreamIndex),
+        ...sortedQuickstarts.slice(codestreamIndex + 1),
+      ];
+    }
   }
 
   const filteredQuickstarts = sortedQuickstarts

--- a/src/pages/instant-observability.js
+++ b/src/pages/instant-observability.js
@@ -168,19 +168,22 @@ const QuickstartsPage = ({ data, location }) => {
   const alphaSort = quickstarts.sort((a, b) => a.title.localeCompare(b.title));
   let sortedQuickstarts = sortFeaturedQuickstarts(alphaSort);
 
-
   // Hard-code for moving codestream object to front of sortedQuickstarts array - CM
-  if (!category && !filter && !search || 
-        category === 'featured' && !filter && !search ) {
+  if (
+    (!category && !filter && !search) ||
+    (category === 'featured' && !filter && !search)
+  ) {
     // uuid is codestream id specifically - CM
-    const codestreamIndex = sortedQuickstarts.findIndex(({ id }) => id === '29bd9a4a-1c19-4219-9694-0942f6411ce7');
+    const codestreamIndex = sortedQuickstarts.findIndex(
+      ({ id }) => id === '29bd9a4a-1c19-4219-9694-0942f6411ce7'
+    );
     const codestreamObject = sortedQuickstarts[codestreamIndex];
     sortedQuickstarts = [
-      codestreamObject, 
-      ...sortedQuickstarts.slice(0, codestreamIndex), 
-      ...sortedQuickstarts.slice(codestreamIndex + 1)
+      codestreamObject,
+      ...sortedQuickstarts.slice(0, codestreamIndex),
+      ...sortedQuickstarts.slice(codestreamIndex + 1),
     ];
-  };
+  }
 
   const filteredQuickstarts = sortedQuickstarts
     .filter(filterBySearch(search))


### PR DESCRIPTION
## Description

logic block to move the codestream data object to the front of the `sortedQuickstarts` array in the marketplace page.

closes - #1796