### PR TITLE
chore: show icon for links in markdown quickstart descriptions (#1751)

### DIFF
--- a/src/components/Markdown.js
+++ b/src/components/Markdown.js
@@ -3,6 +3,26 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import ReactMarkdown from 'react-markdown';
 
+import { Link } from '@newrelic/gatsby-theme-newrelic';
+
+const aTagToLink = ({
+  // eslint-disable-next-line no-unused-vars
+  node,
+  ...props
+}) => {
+  return (
+    <Link
+      to={props.href}
+      css={css`
+        text-decoration: none;
+      `}
+      displayExternalIcon
+    >
+      {props.children}
+    </Link>
+  );
+};
+
 const Markdown = ({ className, ...props }) => (
   <ReactMarkdown
     {...props}
@@ -12,6 +32,9 @@ const Markdown = ({ className, ...props }) => (
         margin-top: 0;
       }
     `}
+    components={{
+      a: aTagToLink,
+    }}
   />
 );
 


### PR DESCRIPTION
## Summary
This PR introduces a change to display external link icons for links in quickstart descriptions.

## Screenshots
![Screen Shot 2021-10-22 at 3 50 16 PM](https://user-images.githubusercontent.com/70179215/138531109-8f868b79-30c5-4bf4-958b-059f2a8d456e.png)
![Screen Shot 2021-10-22 at 3 50 26 PM](https://user-images.githubusercontent.com/70179215/138531111-1f06037e-bcf7-4b29-bff9-c2ac235a9ba3.png)

## Links
Closes: #1751 