### PR TITLE
Update quickstarts type name in related resources config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -76,7 +76,7 @@ module.exports = {
                 },
                 filters: {
                   page: {
-                    type: ['docs', 'developer', 'opensource', 'quick_starts'],
+                    type: ['docs', 'developer', 'opensource', 'quickstarts'],
                     document_type: [
                       '!views_page_menu',
                       '!term_page_api_menu',


### PR DESCRIPTION
We had originally put `quick_starts` as the type name in our related resources config but it needs to be `quickstarts` to match the meta tags