### PR TITLE
Add back dashboards id to tab item

### DIFF
--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -206,6 +206,7 @@ const QuickstartDetails = ({ data, location }) => {
           >
             <Tabs.BarItem id="overview">Overview</Tabs.BarItem>
             <Tabs.BarItem
+              id="dashboards"
               count={quickstart.dashboards?.length ?? 0}
               onClick={tessenTabTrack(`QuickstartTabToggle`, quickstart)}
             >


### PR DESCRIPTION
Noticed a little bug in develop, we lost the ID on a quickstart tab item and it resulted in the tab showing the overview instead of dashboard info