### PR TITLE
chore: add crazyegg script to i/o

### DIFF
--- a/src/components/DevSiteSeo.js
+++ b/src/components/DevSiteSeo.js
@@ -18,6 +18,18 @@ function DevSiteSeo({ description, meta, title, tags, location, type }) {
     `
   );
 
+  const crazyEgg = (location) => {
+    if (location.pathname === '/instant-observability/') {
+      return (
+        <script
+          type="text/javascript"
+          src="//script.crazyegg.com/pages/scripts/0045/9836.js"
+          async="async"
+        />
+      );
+    }
+  };
+
   const metaDescription = description || site.siteMetadata.description;
 
   const globalMetadata = [
@@ -78,6 +90,7 @@ function DevSiteSeo({ description, meta, title, tags, location, type }) {
 
   return (
     <SEO location={location} title={title} type={type}>
+      {crazyEgg(location)}
       {validMetadata.map((data, index) => (
         <meta key={`${data.name}-${index}`} {...data} />
       ))}


### PR DESCRIPTION
## Description

Add the crazyegg script when on the Instant-observability page.

## Reviewer Notes

When running locally, you can see the `9836.js` script being called in the network tab.

I ran 3 Lighthouse reports on local builds in an attempt to compare the impact

- `tabatha/io-crazyegg` branch got an average score of `80`

- `develop` branch had an average score of `82`

Performance tests could also be run against the hosted site vs the pr preview if that would be more accurate. 



## Related Issue

Closes https://github.com/newrelic/developer-website/issues/1818

