### PR TITLE
make quickstart header sticky

### DIFF
--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -128,19 +128,18 @@ const QuickstartDetails = ({ data, location }) => {
 
               @media (min-width: 760px) {
                 background: var(--primary-background-color);
-                border: 1px solid var(--border-color);
+                border-bottom: 1px solid var(--border-color);
                 border-radius: 0.25rem;
-                box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
                 grid-template-areas:
                   'logo title cta'
                   'logo summ cta';
-                padding: 8px 0;
+                padding: 16px 0 24px;
                 position: sticky;
                 top: var(--global-header-height);
                 z-index: 80;
               }
 
-              .dark-mode & {
+              .dark-mode {
                 box-shadow: none;
               }
             `}

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -107,10 +107,8 @@ const QuickstartDetails = ({ data, location }) => {
               )
             }
             css={css`
-              background: var(--primary-background-color);
               border-bottom: none;
               display: grid;
-              padding-bottom: 0;
               grid-template-areas:
                 'logo title cta'
                 'logo summ cta';
@@ -118,16 +116,22 @@ const QuickstartDetails = ({ data, location }) => {
               grid-row-gap: 1rem;
               justify-content: normal;
               justify-self: center;
-              position: sticky;
+              padding-bottom: 8px;
+              padding-top: 8px;
               row-gap: 1rem;
-              top: var(--global-header-height);
               width: 101%;
-              z-index: 80;
 
               h1 {
                 font-weight: normal;
                 grid-area: title;
                 padding-bottom: 1rem;
+              }
+
+              @media (min-width: 760px) {
+                background: var(--primary-background-color);
+                position: sticky;
+                top: var(--global-header-height);
+                z-index: 80;
               }
             `}
           >

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -107,13 +107,22 @@ const QuickstartDetails = ({ data, location }) => {
               )
             }
             css={css`
+              background: var(--primary-background-color);
               border-bottom: none;
               display: grid;
               padding-bottom: 0;
-              grid-template-areas: 'title logo' 'summ logo' 'cta logo';
+              grid-template-areas:
+                'logo title cta'
+                'logo summ cta';
               grid-column-gap: 1rem;
               grid-row-gap: 1rem;
+              justify-content: normal;
+              justify-self: center;
+              position: sticky;
               row-gap: 1rem;
+              top: var(--global-header-height);
+              width: 101%;
+              z-index: 80;
 
               h1 {
                 font-weight: normal;
@@ -130,6 +139,7 @@ const QuickstartDetails = ({ data, location }) => {
                   max-height: 5rem;
                   grid-area: logo;
                   align-self: center;
+                  justify-self: center;
 
                   .dark-mode & {
                     background-color: white;
@@ -145,8 +155,7 @@ const QuickstartDetails = ({ data, location }) => {
               <div
                 css={css`
                   grid-area: summ;
-                  margin-bottom: 1em;
-                  max-width: 40vw;
+                  max-width: 50vw;
 
                   @media (max-width: 760px) {
                     max-width: 100%;
@@ -160,7 +169,8 @@ const QuickstartDetails = ({ data, location }) => {
               css={css`
                 grid-area: cta;
                 display: flex;
-                justify-content: flex-start;
+                justify-content: center;
+                align-self: center;
                 @media (max-width: 760px) {
                   flex-direction: column;
                   align-items: stretch;

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -109,15 +109,14 @@ const QuickstartDetails = ({ data, location }) => {
             css={css`
               border-bottom: none;
               display: grid;
-              grid-template-areas:
-                'logo title cta'
-                'logo summ cta';
               grid-column-gap: 1rem;
               grid-row-gap: 1rem;
+              grid-template-areas:
+                'title logo'
+                'summ logo'
+                'cta logo';
               justify-content: normal;
               justify-self: center;
-              padding-bottom: 8px;
-              padding-top: 8px;
               row-gap: 1rem;
               width: 101%;
 
@@ -129,9 +128,20 @@ const QuickstartDetails = ({ data, location }) => {
 
               @media (min-width: 760px) {
                 background: var(--primary-background-color);
+                border: 1px solid var(--border-color);
+                border-radius: 0.25rem;
+                box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+                grid-template-areas:
+                  'logo title cta'
+                  'logo summ cta';
+                padding: 8px 0;
                 position: sticky;
                 top: var(--global-header-height);
                 z-index: 80;
+              }
+
+              .dark-mode & {
+                box-shadow: none;
               }
             `}
           >


### PR DESCRIPTION
## Summary

* reorganized the header to have logo on the left, title & summary in
the middle, and CTA buttons on the right
* header is sticky and will remain on page when a user scrolls. it
will 'stack' up  with the global header which is also sticky

## Screenshots
![Screen Shot 2021-10-29 at 2 26 06 PM](https://user-images.githubusercontent.com/70179215/139503610-2889ebfe-bc95-4589-9dfa-163877417fe6.png)
![Screen Shot 2021-10-29 at 2 26 15 PM](https://user-images.githubusercontent.com/70179215/139503613-9a53f2a2-d81f-4f9e-a9f8-e76e59910ae0.png)
![Screen Shot 2021-10-29 at 2 26 27 PM](https://user-images.githubusercontent.com/70179215/139503615-3c89ce41-f86e-4ccc-a099-bb406631cd43.png)

## Links
Resolves: #1800 