### PR TITLE
fix: change required status check

### DIFF
--- a/.github/workflows/fetch-quickstarts.yml
+++ b/.github/workflows/fetch-quickstarts.yml
@@ -90,7 +90,7 @@ jobs:
               required_status_checks: {
                 strict: false,
                 contexts: [
-                  'Gatsby Build'
+                  'Gatsby Build Service - developer-website'
                 ]
               },
               restrictions: null,


### PR DESCRIPTION
## Description

The `fetch-quickstarts` script was applying an incorrect status check to the branch protection on `main`. This updates it to the correct job.