### PR TITLE
Remove link within link

### DIFF
--- a/src/components/PackTile.js
+++ b/src/components/PackTile.js
@@ -28,6 +28,7 @@ const PackTile = ({
   level,
   className,
   summary,
+  href,
 }) => {
   const tessen = useTessen();
 
@@ -56,7 +57,7 @@ const PackTile = ({
   return (
     <Surface
       as={Link}
-      to={fields?.slug || '/'}
+      to={href || fields?.slug || '/'}
       key={id}
       base={Surface.BASE.PRIMARY}
       className={className}
@@ -168,6 +169,7 @@ PackTile.propTypes = {
   level: PropTypes.string,
   className: PropTypes.string,
   featured: PropTypes.bool,
+  href: PropTypes.string,
 };
 
 export default PackTile;

--- a/src/pages/instant-observability.js
+++ b/src/pages/instant-observability.js
@@ -13,7 +13,6 @@ import QuickstartFilter from '../components/quickstarts/QuickstartFilter';
 import {
   SearchInput,
   useTessen,
-  ExternalLink,
   Button,
   Link,
   Icon,
@@ -706,44 +705,34 @@ const QuickstartsPage = ({ data, location }) => {
           >
             {filters?.length === 1 && filters[0] === 'documentation' ? (
               // if data source filter is selected, display guided install
-              <ExternalLink
-                href={getGuidedInstallStackedNr1Url(NR1_GUIDED_INSTALL_NERDLET)}
+
+              <PackTile
+                id={RESERVED_QUICKSTART_IDS.GUIDED_INSTALL}
                 css={css`
-                  text-decoration: none;
+                  ${view === VIEWS.GRID && `height: 100%;`}
+                  background-color: var(--tertiary-background-color);
                 `}
-              >
-                <PackTile
-                  id={RESERVED_QUICKSTART_IDS.GUIDED_INSTALL}
-                  css={css`
-                    ${view === VIEWS.GRID && `height: 100%;`}
-                    background-color: var(--tertiary-background-color);
-                  `}
-                  view={view}
-                  logoUrl={GUIDED_INSTALL}
-                  title="Guided Install"
-                  summary="Not sure how to get started? We'll walk you through the process of instrumenting your environment so that you can monitor it."
-                />
-              </ExternalLink>
+                href={getGuidedInstallStackedNr1Url(NR1_GUIDED_INSTALL_NERDLET)}
+                view={view}
+                logoUrl={GUIDED_INSTALL}
+                title="Guided Install"
+                summary="Not sure how to get started? We'll walk you through the process of instrumenting your environment so that you can monitor it."
+              />
             ) : (
               // else, display build your own quickstart
-              <ExternalLink
-                href={QUICKSTARTS_REPO}
+
+              <PackTile
+                id={RESERVED_QUICKSTART_IDS.BUILD_YOUR_OWN_QUICKSTART}
                 css={css`
-                  text-decoration: none;
+                  ${view === VIEWS.GRID && `height: 100%;`}
+                  background-color: var(--tertiary-background-color);
                 `}
-              >
-                <PackTile
-                  id={RESERVED_QUICKSTART_IDS.BUILD_YOUR_OWN_QUICKSTART}
-                  css={css`
-                    ${view === VIEWS.GRID && `height: 100%;`}
-                    background-color: var(--tertiary-background-color);
-                  `}
-                  view={view}
-                  logoUrl={BUILD_YOUR_OWN}
-                  title="Build your own quickstart"
-                  summary="Can't find a quickstart with what you need? Check out our README and build your own."
-                />
-              </ExternalLink>
+                href={QUICKSTARTS_REPO}
+                view={view}
+                logoUrl={BUILD_YOUR_OWN}
+                title="Build your own quickstart"
+                summary="Can't find a quickstart with what you need? Check out our README and build your own."
+              />
             )}
             {filteredQuickstarts.map((pack) => (
               <PackTile


### PR DESCRIPTION
When changing our pack tiles into link components i forgot that we also wrap pack tiles in a link component on two occasions: for the build your own tile and the guided install tile. something about these nested link components made the logos crazy, still not sure why... but this should clean things up