### PR TITLE
fix: Update cookie to match original spec

### DIFF
--- a/src/components/InstallButton.js
+++ b/src/components/InstallButton.js
@@ -137,10 +137,12 @@ const InstallButton = ({ quickstart, location, ...props }) => {
       options.domain = 'newrelic.com';
     }
 
-    const startTarget = btoa(JSON.stringify({
-      source: "nrio",
-      target: quickstart.id
-    }));
+    const startTarget = btoa(
+      JSON.stringify({
+        source: 'nrio',
+        target: quickstart.id,
+      })
+    );
     Cookies.set('start_target', startTarget, options);
     Cookies.set('newrelic-quickstart-id', quickstart.id, options);
   };

--- a/src/components/InstallButton.js
+++ b/src/components/InstallButton.js
@@ -140,7 +140,7 @@ const InstallButton = ({ quickstart, location, ...props }) => {
     const startTarget = btoa(
       JSON.stringify({
         source: 'nrio',
-        target: quickstart.id,
+        id: quickstart.id,
       })
     );
     Cookies.set('start_target', startTarget, options);

--- a/src/components/InstallButton.js
+++ b/src/components/InstallButton.js
@@ -137,6 +137,11 @@ const InstallButton = ({ quickstart, location, ...props }) => {
       options.domain = 'newrelic.com';
     }
 
+    const startTarget = btoa(JSON.stringify({
+      source: "nrio",
+      target: quickstart.id
+    }));
+    Cookies.set('start_target', startTarget, options);
     Cookies.set('newrelic-quickstart-id', quickstart.id, options);
   };
 


### PR DESCRIPTION
## Description

The original spec for the cookie was generic and not specific to NRIO or Quickstarts. We need to move towards the generic approach to move in line with architectural guidance, remove special cases in repositories, and improve analytics.

This is the first of multiple steps to move us towards that generic cookie `start_target`.

I'm going to go step-wise:
1. Update here
2. Update in guided-install's router which reads the cookie and sends you to the appropriate location
3. Return here and remove `newrelic-quickstart-id` unless it's being used elsewhere

## Reviewer Notes

Reviewer should only need verify writing the cookie succeeds

## Related Issue(s) / Ticket(s)

If there are any related [GitHub Issues](https://github.com/newrelic/developer-website/issues) or JIRA tickets, add links to them here.
* [issue]()

## Screenshot(s)

If relevant, add screenshots here.

## Use Conventional Commits

Please help the maintainers by leveraging the following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
standards in your pull request title and commit messages.

## Use `chore`

* for minor changes / additions / corrections to content.
* for minor changes / additions / corrections to images.
* for minor non-functional changes / additions to github actions, github templates, package or config updates, etc

```bash
git commit -m "chore: adjusting config and content"
```

## Use `fix`

* for minor functional corrections to code.

```bash
git commit -m "fix: typo and prop error in the code of conduct"
```

## Use `feat`

* for major functional changes or additions to code.

```bash
git commit -m "feat(media): creating a video landing page"
```
