### PR TITLE
Add background for quickstarts in dark mode

### DIFF
--- a/src/components/PackTile.js
+++ b/src/components/PackTile.js
@@ -86,8 +86,7 @@ const PackTile = ({
           margin: 0 auto 10px;
 
           .dark-mode & {
-            background-color: rgb(231 231 231 / 0);
-            background: white;
+            background-color: white;
           }
 
           ${view === VIEWS.LIST &&

--- a/src/components/PackTile.js
+++ b/src/components/PackTile.js
@@ -83,10 +83,11 @@ const PackTile = ({
           object-fit: scale-down;
           width: ${view === VIEWS.GRID ? 100 : 25}%;
           padding: 0 ${view === VIEWS.GRID ? 5 : 1}%;
-          margin: 10px auto;
+          margin: 0 auto 10px;
 
           .dark-mode & {
             background-color: rgb(231 231 231 / 0);
+            background: white;
           }
 
           ${view === VIEWS.LIST &&


### PR DESCRIPTION
## Description

These were looking a little rough in dark-mode (see before / after screenshots in the pull request). This isn't a perfect solution, but I think it looks much better than before.

## Screenshot(s)

**BEFORE**
![Screen Shot 2021-11-05 at 10 45 47](https://user-images.githubusercontent.com/1946433/140556647-8049be07-1e82-4313-9d85-84a9ee975f31.png)


**AFTER**
![Screen Shot 2021-11-05 at 10 52 06](https://user-images.githubusercontent.com/1946433/140556618-d94eb866-95f3-47b8-b831-1d7f16baef69.png)
*
