### PR TITLE
chore: fixed feather icons

### DIFF
--- a/src/data/nav.yml
+++ b/src/data/nav.yml
@@ -169,7 +169,7 @@
       url: https://opensource.newrelic.com/nerdpacks/
 
 - title: Contribute to quickstarts
-  icon: zap
+  icon: fe-zap
   url: '/contribute-to-quickstarts'
   pages:
     - title: Build a quickstart
@@ -493,7 +493,7 @@
         - title: All things open
           url: '/all-things-open'
 - title: Instant Observability
-  icon: box
+  icon: fe-box
   url: '/instant-observability'
 - title: Nerd Bytes
   icon: nr-nerd-bytes


### PR DESCRIPTION
This PR fixes the names of the feather icons in the nav.yml file to not trigger the console warnings. 