### PR TITLE
feat: add super tile experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ yarn-error.log
 
 # In case npm is accidently used to install deps
 package-lock.json
+
+# VSCode files
+.vscode
+

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -47,6 +47,7 @@ module.exports = {
               features: {
                 'developer-website_global-header-gh-buttons': 'on',
                 'developer-website_right-rail-buttons': 'outline',
+                super_tiles: 'on',
               },
               core: {
                 authorizationKey: process.env.SPLITIO_AUTH_KEY || 'localhost',

--- a/src/components/InstallButton.js
+++ b/src/components/InstallButton.js
@@ -16,6 +16,7 @@ import {
 } from '../data/constants';
 import { quickstart } from '../types';
 import Cookies from 'js-cookie';
+import useTreatment from '../hooks/useTreatment';
 
 /**
  * @param {Object} parameters
@@ -85,6 +86,8 @@ const hasComponent = (quickstart, key) =>
   quickstart[key] && quickstart[key].length > 0;
 
 const InstallButton = ({ quickstart, location, ...props }) => {
+  const { treatment } = useTreatment('super_tiles');
+
   const hasInstallableComponent =
     hasComponent(quickstart, 'installPlans') ||
     quickstart.id === CODESTREAM_QUICKSTART_ID;
@@ -153,6 +156,7 @@ const InstallButton = ({ quickstart, location, ...props }) => {
       quickstartName: quickstart.name,
       quickstartId: quickstart.id,
       quickstartUrl: quickstart.packUrl,
+      super_tiles_treatment: treatment,
       quickstartButtonText: hasInstallableComponent
         ? 'Install quickstart'
         : 'See installation docs',

--- a/src/experiments/super_tiles/components/CodeStreamTile.js
+++ b/src/experiments/super_tiles/components/CodeStreamTile.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import SuperTile from './SuperTile';
+import { Button } from '@newrelic/gatsby-theme-newrelic';
+
+const CodeStreamTile = () => {
+  return (
+    <SuperTile>
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          gap: 40px;
+        `}
+      >
+        <div>
+          <span
+            css={css`
+              color: var(--color-brand-400);
+              font-size: 14px;
+              line-height: 20px;
+            `}
+          >
+            Tools & Communications
+          </span>
+          <h2
+            css={css`
+              font-size: 24px;
+              font-weight: 600;
+              line-height: 30px;
+            `}
+          >
+            Introducing CodeStream
+          </h2>
+          <span
+            css={css`
+              color: var(--primary-text-color);
+            `}
+          >
+            CodeStream supercharges development workflows by putting
+            collaboration tools in your IDE.
+          </span>
+        </div>
+        <div>
+          <Button variant={Button.VARIANT.OUTLINE}>Install CodeStream</Button>
+        </div>
+      </div>
+    </SuperTile>
+  );
+};
+
+export default CodeStreamTile;

--- a/src/experiments/super_tiles/components/CodeStreamTile.js
+++ b/src/experiments/super_tiles/components/CodeStreamTile.js
@@ -35,7 +35,10 @@ const CodeStreamTile = () => {
           </h2>
           <span
             css={css`
-              color: var(--primary-text-color);
+              color: var(--color-neutrals-600);
+              .dark-mode & {
+                color: var(--primary-text-color);
+              }
             `}
           >
             CodeStream supercharges development workflows by putting
@@ -43,7 +46,19 @@ const CodeStreamTile = () => {
           </span>
         </div>
         <div>
-          <Button variant={Button.VARIANT.OUTLINE}>Install CodeStream</Button>
+          <Button
+            css={css`
+              border-color: var(--color-brand-400);
+              color: var(--color-brand-400);
+
+              .dark-mode & {
+                color: var(--color-brand-400);
+              }
+            `}
+            variant={Button.VARIANT.OUTLINE}
+          >
+            Install CodeStream
+          </Button>
         </div>
       </div>
     </SuperTile>

--- a/src/experiments/super_tiles/components/CodeStreamTile.js
+++ b/src/experiments/super_tiles/components/CodeStreamTile.js
@@ -1,9 +1,19 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import SuperTile from './SuperTile';
-import { Button } from '@newrelic/gatsby-theme-newrelic';
+import { Button, useTessen } from '@newrelic/gatsby-theme-newrelic';
+import { Link } from 'gatsby';
 
 const CodeStreamTile = () => {
+  const tessen = useTessen();
+
+  const link =
+    '/instant-observability/codestream/29bd9a4a-1c19-4219-9694-0942f6411ce7/';
+
+  const handleButtonClick = () => {
+    tessen.track('clickSuperTile', 'QuickstartLanding', { tile: 'codestream' });
+  };
+
   return (
     <SuperTile>
       <div
@@ -55,7 +65,10 @@ const CodeStreamTile = () => {
                 color: var(--color-brand-400);
               }
             `}
+            onClick={handleButtonClick}
             variant={Button.VARIANT.OUTLINE}
+            to={link}
+            as={Link}
           >
             Install CodeStream
           </Button>

--- a/src/experiments/super_tiles/components/GuidedInstallTile.js
+++ b/src/experiments/super_tiles/components/GuidedInstallTile.js
@@ -1,9 +1,20 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import SuperTile from './SuperTile';
-import { Button } from '@newrelic/gatsby-theme-newrelic';
+import { Button, useTessen } from '@newrelic/gatsby-theme-newrelic';
+import { navigate } from 'gatsby';
 
 const GuidedInstallTile = () => {
+  const tessen = useTessen();
+
+  const link =
+    'https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/new-relic-guided-install-overview/';
+
+  const handleButtonClick = () => {
+    tessen.track('clickSuperTile', 'QuickstartLanding', { tile: 'guided' });
+    navigate(link);
+  };
+
   return (
     <SuperTile type="primary">
       <div
@@ -52,7 +63,9 @@ const GuidedInstallTile = () => {
           </span>
         </div>
         <div>
-          <Button variant={Button.VARIANT.PRIMARY}>Install New Relic</Button>
+          <Button onClick={handleButtonClick} variant={Button.VARIANT.PRIMARY}>
+            Install New Relic
+          </Button>
         </div>
       </div>
     </SuperTile>

--- a/src/experiments/super_tiles/components/GuidedInstallTile.js
+++ b/src/experiments/super_tiles/components/GuidedInstallTile.js
@@ -52,14 +52,7 @@ const GuidedInstallTile = () => {
           </span>
         </div>
         <div>
-          <Button
-            css={css`
-              background-color: var(--color-brand-500);
-            `}
-            variant={Button.VARIANT.PRIMARY}
-          >
-            Install New Relic
-          </Button>
+          <Button variant={Button.VARIANT.PRIMARY}>Install New Relic</Button>
         </div>
       </div>
     </SuperTile>

--- a/src/experiments/super_tiles/components/GuidedInstallTile.js
+++ b/src/experiments/super_tiles/components/GuidedInstallTile.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import SuperTile from './SuperTile';
+import { Button } from '@newrelic/gatsby-theme-newrelic';
+
+const GuidedInstallTile = () => {
+  return (
+    <SuperTile type="primary">
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          gap: 40px;
+        `}
+      >
+        <div>
+          <span
+            css={css`
+              color: #faa44a;
+              font-size: 14px;
+              line-height: 20px;
+            `}
+          >
+            First Steps
+          </span>
+          <h2
+            css={css`
+              font-size: 24px;
+              font-weight: 600;
+              line-height: 30px;
+              color: var(--color-white);
+
+              .dark-mode & {
+                color: var(--heading-text-color);
+              }
+            `}
+          >
+            Guided Install
+          </h2>
+          <span
+            css={css`
+              color: var(--color-neutrals-300);
+
+              .dark-mode & {
+                color: var(--primary-text-color);
+              }
+            `}
+          >
+            Install the New Relic agent with a single command line and start
+            monitoring your log and infrastructure data in real time.
+          </span>
+        </div>
+        <div>
+          <Button
+            css={css`
+              background-color: var(--color-brand-500);
+            `}
+            variant={Button.VARIANT.PRIMARY}
+          >
+            Install New Relic
+          </Button>
+        </div>
+      </div>
+    </SuperTile>
+  );
+};
+
+export default GuidedInstallTile;

--- a/src/experiments/super_tiles/components/SuperTile.js
+++ b/src/experiments/super_tiles/components/SuperTile.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/react';
+
+const SuperTile = ({ children, className, type }) => {
+  return (
+    <div
+      className={className}
+      css={css`
+        width: 100%;
+        display: flex;
+        border-radius: 8px;
+        padding: 24px;
+        flex-direction: column;
+        align-items: flex-start;
+        ${type === 'primary'
+          ? `background: var(--color-brand-700);`
+          : `background: var(--tertiary-background-color);`}
+      `}
+    >
+      {children}
+    </div>
+  );
+};
+
+SuperTile.propTypes = {
+  type: PropTypes.string,
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+};
+
+export default SuperTile;

--- a/src/experiments/super_tiles/index.js
+++ b/src/experiments/super_tiles/index.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/react';
+import useTreatment from '../../hooks/useTreatment';
+import IOBanner from '../../components/IOBanner';
+import CodeStreamTile from './components/CodeStreamTile';
+import GuidedInstallTile from './components/GuidedInstallTile';
+
+const SuperTilesExperiment = ({ isMobile }) => {
+  const { treatment } = useTreatment('super_tiles');
+
+  if (treatment === 'on') {
+    return (
+      <div
+        css={css`
+          display: flex;
+          flex-direction: row;
+          justify-content: space-between;
+          margin-bottom: 16px;
+          gap: 16px;
+        `}
+      >
+        <GuidedInstallTile />
+        <CodeStreamTile />
+      </div>
+    );
+  }
+
+  return <IOBanner isMobile={isMobile} />;
+};
+
+SuperTilesExperiment.propTypes = {
+  isMobile: PropTypes.bool,
+};
+
+export default SuperTilesExperiment;

--- a/src/pages/instant-observability.js
+++ b/src/pages/instant-observability.js
@@ -7,7 +7,6 @@ import { css } from '@emotion/react';
 import SegmentedControl from '../components/SegmentedControl';
 import Overlay from '../components/Overlay';
 import PackTile from '../components/PackTile';
-import IOBanner from '../components/IOBanner';
 import IOLogo from '../components/IOLogo';
 import QuickstartFilter from '../components/quickstarts/QuickstartFilter';
 import {
@@ -23,6 +22,7 @@ import BUILD_YOUR_OWN from '../images/build-your-own.svg';
 import GUIDED_INSTALL from '../images/guided-install.svg';
 import { useDebounce } from 'react-use';
 import { sortFeaturedQuickstarts } from '../utils/sortFeaturedQuickstarts';
+import SuperTilesExperiment from '../experiments/super_tiles';
 
 import {
   QUICKSTARTS_REPO,
@@ -294,7 +294,7 @@ const QuickstartsPage = ({ data, location }) => {
             }
           `}
         >
-          {isMobile && <IOBanner isMobile />}
+          {isMobile && <SuperTilesExperiment isMobile />}
           <div
             css={css`
               padding: var(--site-content-padding);
@@ -410,7 +410,7 @@ const QuickstartsPage = ({ data, location }) => {
             padding: var(--site-content-padding);
           `}
         >
-          {!isMobile && <IOBanner />}
+          {!isMobile && <SuperTilesExperiment />}
           <div
             css={css`
               background-color: var(--secondary-background-color);


### PR DESCRIPTION
## Description

In collaboration with the Virtuoso team, we would like to run an A/B test with the following: 
- Show the `<IOBanner>` component for 50% of users --- this is the `control/off` treatment
- Show the individual `<SuperTile>` tiles for 50% of users --- this is the `on` treatment

**Code changes**
- Create a shared `src/experiments/` folder where all existing and future experiments can be stored
- Create a `<SuperTile>` component
- Create a `<GuidedInstallTile>` and `<CodeStreamTile>` component
- Create a wrapper component, `<SuperTilesExperiment>` that will either render the `<IOBanner>` or individual super tiles

**Split.io**
A new experiment/split has been added in Split.io, titled `super_tiles` in the GPE workspace.

**Tessen events**
The following Tessen events have been attached to the CTA buttons for the super tiles:
-  `tessen.track('clickSuperTile', 'QuickstartLanding', { tile: 'codestream' });`
-  `tessen.track('clickSuperTile', 'QuickstartLanding', { tile: 'guided' });`


## Reviewer Notes

Simply run `yarn start` when pulling down this branch.

## Related Issue(s) / Ticket(s)

If there are any related [GitHub Issues](https://github.com/newrelic/developer-website/issues) or JIRA tickets, add links to them here.
* [[Public Catalog] A/B Test: Guided Install & Feature Quickstart Tile](https://github.com/newrelic/developer-website/issues/1870)

## Screenshot(s)

### `On` treatment - 50%

**Light mode**

<img width="1684" alt="Screen Shot 2021-11-15 at 1 20 28 PM" src="https://user-images.githubusercontent.com/20836690/141842842-c2279a9f-091b-4762-927b-fbe9f67cde39.png">


**Dark mode**

<img width="1674" alt="Screen Shot 2021-11-15 at 1 20 41 PM" src="https://user-images.githubusercontent.com/20836690/141842947-65136341-3e1c-4202-9fa7-240a83005858.png">

### `Control/off` treatment - 50%

<img width="1679" alt="Screen Shot 2021-11-15 at 1 27 32 PM" src="https://user-images.githubusercontent.com/20836690/141842986-a0c631d5-3e35-4c9c-ad6f-32521e453702.png">

