### PR TITLE
chore(docs): add docs for super tiles experiment components

### DIFF
--- a/COMPONENT_GUIDE.md
+++ b/COMPONENT_GUIDE.md
@@ -439,3 +439,64 @@ Other text ...
 You can see the difference in what is displayed below:
 
 ![alt text](readme_images/hidden_vs_normal.png "Hidden vs Normal")
+
+# Experiments
+
+## SuperTilesExperiment
+
+### Usage
+
+The `SuperTilesExperiment` component renders the `IOBanner` (control component) or the `GuidedInstallTile` and `CodeStreamTile` (treatment) components based on a 50%/50% A/B test.
+
+To include it: 
+```md
+<SuperTilesExperiment />
+
+# Render <IOBanner> for mobile devices
+<SuperTilesExperiment isMobile={true} />
+```
+
+## Props
+
+|Component|Prop|Required?|Type|Description|
+|-|-|-|-|-|
+|`SuperTilesExperiment`|`isMobile`|no|boolean|Specifies whether the `IOBanner` child component should be rendered for mobile devices.|
+
+
+## SuperTile
+
+### Usage
+
+The `SuperTile` component is a wrapper component that can display a primary and secondary tile.
+
+```md
+# Primary
+<SuperTile type="primary">
+  My content
+</SuperTile>
+
+# Secondary
+<SuperTile>
+  My content
+</SuperTile>
+```
+
+## GuidedInstallTile
+
+### Usage
+
+The `GuidedInstallTile` component includes custom content relevant to the guided install flow in New Relic.
+
+```md
+<GuidedInstallTile />
+```
+
+## CodeStreamTile
+
+### Usage
+
+The `CodeStreamTile` component includes custom content relevant to New Relic CodeStream.
+
+```md
+<CodeStreamTile />
+```

--- a/COMPONENT_GUIDE.md
+++ b/COMPONENT_GUIDE.md
@@ -40,7 +40,7 @@ If there is a more than plain text and a `<Video />` (such as a code snippet or 
 
 ## Steps
 
-The `<Steps />` is a required container for the individual `<Step />` components and will autonumber from top to bottom.
+The `<Steps />` is a required container for the individual `<Step />` components and will outnumber from top to bottom.
 
 ### Usage
 
@@ -188,7 +188,7 @@ You can use the `Tabs` component, and related sub-components to construct a tabb
 
 ## Usage
 
-```jsx
+```html
 <Tabs>
   <Tabs.Bar>
     <Tabs.BarItem id="tacos">Tacos</Tabs.BarItem>
@@ -207,9 +207,9 @@ You can use the `Tabs` component, and related sub-components to construct a tabb
 
 An example of how it could be use
 
-# Tutorial
+## Tutorial
 
-## Usage
+### Usage
 
 You can use the `Tutorial` component walk a user through changes in code by automatically highlighting the difference between each step.
 
@@ -301,7 +301,7 @@ const evenMoreNewCode = "here is even more new code"
 </Tutorial>
 ````
 
-In the first step's rendered codeblock, the second line (`myNewCode`) in _first-file.js_ will be highlighted. In the second step, the second line (`myNewCode`) in second-file.js_ will be highlighted. In the third step, the third line (`evenMoreNewCode`) iin _first-file.js_ will be highlighted.
+In the first step's rendered codeblock, the second line (`myNewCode`) in _first-file.js_ will be highlighted. In the second step, the second line (`myNewCode`) in _second-file.js_ will be highlighted. In the third step, the third line (`evenMoreNewCode`) in _first-file.js_ will be highlighted.
 
 Even though a single file is highlighted in each step, all files are rendered in tabs for each step on the page. Your reader can then toggle between the files to see what the current state of the whole codebase is.
 
@@ -440,18 +440,18 @@ You can see the difference in what is displayed below:
 
 ![alt text](readme_images/hidden_vs_normal.png "Hidden vs Normal")
 
-# Experiments
+## A/B Experiments
 
-## SuperTilesExperiment
+### SuperTilesExperiment
 
 ### Usage
 
-The `SuperTilesExperiment` component renders the `IOBanner` (control component) or the `GuidedInstallTile` and `CodeStreamTile` (treatment) components based on a 50%/50% A/B test.
+The `SuperTilesExperiment` component renders the `IOBanner` (control component) or the `GuidedInstallTile` and `CodeStreamTile` (treatment) components based on a `50% 50%` A/B test.
 
-To include it: 
-```md
+To include it:
+
+```html
 <SuperTilesExperiment />
-
 # Render <IOBanner> for mobile devices
 <SuperTilesExperiment isMobile={true} />
 ```
@@ -462,41 +462,44 @@ To include it:
 |-|-|-|-|-|
 |`SuperTilesExperiment`|`isMobile`|no|boolean|Specifies whether the `IOBanner` child component should be rendered for mobile devices.|
 
-
-## SuperTile
+### SuperTile
 
 ### Usage
 
 The `SuperTile` component is a wrapper component that can display a primary and secondary tile.
 
-```md
-# Primary
+#### Primary
+
+```html
 <SuperTile type="primary">
   My content
 </SuperTile>
+```
 
-# Secondary
+#### Secondary
+
+```html
 <SuperTile>
   My content
 </SuperTile>
 ```
 
-## GuidedInstallTile
+### GuidedInstallTile
 
 ### Usage
 
 The `GuidedInstallTile` component includes custom content relevant to the guided install flow in New Relic.
 
-```md
+```html
 <GuidedInstallTile />
 ```
 
-## CodeStreamTile
+### CodeStreamTile
 
 ### Usage
 
 The `CodeStreamTile` component includes custom content relevant to New Relic CodeStream.
 
-```md
+```html
 <CodeStreamTile />
 ```


### PR DESCRIPTION
## Description

Add documentation and usage examples for the super tiles experiment (A/B test) that was [merged earlier today](https://github.com/newrelic/developer-website/pull/1887).
There is a new section called _Experiments_ that we might be able to make use of in the future if there will be more.

## Related Issue(s) / Ticket(s)

* [[Dev Site] Document new super tile component](https://github.com/newrelic/developer-website/issues/1890)

