### PR TITLE
fix: tessen event not triggered on click for guided install tile

### DIFF
--- a/src/experiments/super_tiles/components/GuidedInstallTile.js
+++ b/src/experiments/super_tiles/components/GuidedInstallTile.js
@@ -10,7 +10,7 @@ import { SIGNUP_LINK } from '../../../data/constants';
 
 const GuidedInstallTile = () => {
   const handleButtonClick = useInstrumentedHandler(
-    () => navigate(SIGNUP_LINK),
+    navigate(SIGNUP_LINK),
     {
       tessenEventName: 'clickSuperTile',
       tessenCategoryName: 'QuickstartLanding',

--- a/src/experiments/super_tiles/components/GuidedInstallTile.js
+++ b/src/experiments/super_tiles/components/GuidedInstallTile.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@emotion/react';
 import SuperTile from './SuperTile';
 import { Button, useTessen } from '@newrelic/gatsby-theme-newrelic';
-import { Link } from 'gatsby';
+import { navigate } from 'gatsby';
 import { SIGNUP_LINK } from '../../../data/constants';
 
 const GuidedInstallTile = () => {
@@ -10,6 +10,9 @@ const GuidedInstallTile = () => {
 
   const handleButtonClick = () => {
     tessen.track('clickSuperTile', 'QuickstartLanding', { tile: 'guided' });
+    setTimeout(() => {
+      navigate(SIGNUP_LINK);
+    }, 500);
   };
 
   return (
@@ -60,12 +63,7 @@ const GuidedInstallTile = () => {
           </span>
         </div>
         <div>
-          <Button
-            onClick={handleButtonClick}
-            as={Link}
-            to={SIGNUP_LINK}
-            variant={Button.VARIANT.PRIMARY}
-          >
+          <Button onClick={handleButtonClick} variant={Button.VARIANT.PRIMARY}>
             Install New Relic
           </Button>
         </div>

--- a/src/experiments/super_tiles/components/GuidedInstallTile.js
+++ b/src/experiments/super_tiles/components/GuidedInstallTile.js
@@ -10,7 +10,7 @@ import { SIGNUP_LINK } from '../../../data/constants';
 
 const GuidedInstallTile = () => {
   const handleButtonClick = useInstrumentedHandler(
-    navigate(SIGNUP_LINK),
+    () => navigate(SIGNUP_LINK),
     {
       tessenEventName: 'clickSuperTile',
       tessenCategoryName: 'QuickstartLanding',

--- a/src/experiments/super_tiles/components/GuidedInstallTile.js
+++ b/src/experiments/super_tiles/components/GuidedInstallTile.js
@@ -1,19 +1,23 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import SuperTile from './SuperTile';
-import { Button, useTessen } from '@newrelic/gatsby-theme-newrelic';
+import {
+  Button,
+  useInstrumentedHandler,
+} from '@newrelic/gatsby-theme-newrelic';
 import { navigate } from 'gatsby';
 import { SIGNUP_LINK } from '../../../data/constants';
 
 const GuidedInstallTile = () => {
-  const tessen = useTessen();
-
-  const handleButtonClick = () => {
-    tessen.track('clickSuperTile', 'QuickstartLanding', { tile: 'guided' });
-    setTimeout(() => {
-      navigate(SIGNUP_LINK);
-    }, 500);
-  };
+  const handleButtonClick = useInstrumentedHandler(
+    () => navigate(SIGNUP_LINK),
+    {
+      tessenEventName: 'clickSuperTile',
+      tessenCategoryName: 'QuickstartLanding',
+      tile: 'guided',
+    },
+    'tessen'
+  );
 
   return (
     <SuperTile type="primary">

--- a/src/experiments/super_tiles/components/GuidedInstallTile.js
+++ b/src/experiments/super_tiles/components/GuidedInstallTile.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@emotion/react';
 import SuperTile from './SuperTile';
 import { Button, useTessen } from '@newrelic/gatsby-theme-newrelic';
-import { navigate } from 'gatsby';
+import { Link } from 'gatsby';
 import { SIGNUP_LINK } from '../../../data/constants';
 
 const GuidedInstallTile = () => {
@@ -10,7 +10,6 @@ const GuidedInstallTile = () => {
 
   const handleButtonClick = () => {
     tessen.track('clickSuperTile', 'QuickstartLanding', { tile: 'guided' });
-    navigate(SIGNUP_LINK);
   };
 
   return (
@@ -61,7 +60,12 @@ const GuidedInstallTile = () => {
           </span>
         </div>
         <div>
-          <Button onClick={handleButtonClick} variant={Button.VARIANT.PRIMARY}>
+          <Button
+            onClick={handleButtonClick}
+            as={Link}
+            to={SIGNUP_LINK}
+            variant={Button.VARIANT.PRIMARY}
+          >
             Install New Relic
           </Button>
         </div>


### PR DESCRIPTION
## Description

Looks like `navigate()` prevents Tessen from registering that event if it happens at the same time as `tessen.track`. Using `useInstrumentHandler` is a better approach compared to using timeouts.