### PR TITLE
refactor: redirect to login instead of sign up if cookie exists

### DIFF
--- a/src/experiments/super_tiles/components/GuidedInstallTile.js
+++ b/src/experiments/super_tiles/components/GuidedInstallTile.js
@@ -6,11 +6,14 @@ import {
   useInstrumentedHandler,
 } from '@newrelic/gatsby-theme-newrelic';
 import { navigate } from 'gatsby';
-import { SIGNUP_LINK } from '../../../data/constants';
+import Cookies from 'js-cookie';
+import { SIGNUP_LINK, LOGIN_LINK } from '../../../data/constants';
 
 const GuidedInstallTile = () => {
+  const isReturningUser = Boolean(Cookies.get('ajs_user_id'));
+
   const handleButtonClick = useInstrumentedHandler(
-    () => navigate(SIGNUP_LINK),
+    () => navigate(isReturningUser ? LOGIN_LINK : SIGNUP_LINK),
     {
       tessenEventName: 'clickSuperTile',
       tessenCategoryName: 'QuickstartLanding',


### PR DESCRIPTION
## Description

Let's redirect to the login page instead of always going to sign up for the guided install super tile A/B test if there is a 🍪  present.


