### PR TITLE
updates to use only tessen

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,5 +4,6 @@ module.exports = {
   tabWidth: 2,
   semi: true,
   singleQuote: true,
+  jsxSingleQuote: false,
   arrowParens: 'always',
 };

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -136,7 +136,7 @@ module.exports = {
           segmentWriteKey: 'Ako0hclX8WGHwl9rm4n5uxLtT4wgEtuU',
           trackPageViews: true,
           pageView: {
-            name: 'pageView',
+            eventName: 'pageView',
             category: 'DocPageView',
             getProperties: ({ location, env }) => ({
               path: location.pathname,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "^1.6.19",
     "@mdx-js/react": "^1.6.19",
-    "@newrelic/gatsby-theme-newrelic": "^3.3.6",
+    "@newrelic/gatsby-theme-newrelic": "^4.0.1",
     "@splitsoftware/splitio-react": "^1.2.0",
     "@xstate/react": "^1.0.2",
     "classnames": "^2.2.6",

--- a/src/components/IOBanner.js
+++ b/src/components/IOBanner.js
@@ -8,7 +8,10 @@ const IOBanner = ({ isMobile }) => {
   const tessen = useTessen();
 
   const handleBannerButtonClick = () => {
-    tessen.track('instantObservability', 'BannerButtonClick');
+    tessen.track({
+      eventName: 'instantObservability',
+      category: 'BannerButtonClick',
+    });
   };
 
   return (

--- a/src/components/InstallButton.js
+++ b/src/components/InstallButton.js
@@ -149,7 +149,9 @@ const InstallButton = ({ quickstart, location, ...props }) => {
 
   const handleInstallClick = () => {
     writeCookie();
-    tessen.track('instantObservability', 'QuickstartInstall', {
+    tessen.track({
+      eventName: 'instantObservability',
+      category: 'QuickstartInstall',
       quickstartName: quickstart.name,
       quickstartId: quickstart.id,
       quickstartUrl: quickstart.packUrl,

--- a/src/components/PackTile.js
+++ b/src/components/PackTile.js
@@ -35,19 +35,25 @@ const PackTile = ({
   const handlePackClick = (quickstartId) => {
     switch (true) {
       case quickstartId === RESERVED_QUICKSTART_IDS.GUIDED_INSTALL:
-        tessen.track('instantObservability', 'GuidedInstallClick', {
+        tessen.track({
+          eventName: 'instantObservability',
+          category: 'GuidedInstallClick',
           publicCatalogView: view,
           quickstartName: name,
         });
         break;
       case quickstartId === RESERVED_QUICKSTART_IDS.BUILD_YOUR_OWN_QUICKSTART:
-        tessen.track('instantObservability', 'BuildYourOwnQuickstartClick', {
+        tessen.track({
+          eventName: 'instantObservability',
+          category: 'BuildYourOwnQuickstartClick',
           publicCatalogView: view,
           quickstartName: name,
         });
         break;
       default:
-        tessen.track('instantObservability', 'QuickstartClick', {
+        tessen.track({
+          eventName: 'instantObservability',
+          category: 'QuickstartClick',
           publicCatalogView: view,
           quickstartName: name,
         });

--- a/src/components/quickstarts/QuickstartDataSources.js
+++ b/src/components/quickstarts/QuickstartDataSources.js
@@ -9,7 +9,9 @@ const QuickstartDataSources = ({ quickstart }) => {
   const tessen = useTessen();
 
   const handleDocsTileClick = () => {
-    tessen.track('instantObservability', 'DocsTileClick', {
+    tessen.track({
+      eventName: 'instantObservability',
+      category: 'DocsTileClick',
       quickstartName: quickstart.name,
       quickstartId: quickstart.id,
     });

--- a/src/pages/instant-observability.js
+++ b/src/pages/instant-observability.js
@@ -124,7 +124,9 @@ const QuickstartsPage = ({ data, location }) => {
     );
     setCategory(categoryParam || '');
     if (searchParam || filterParam || categoryParam) {
-      tessen.track('instantObservability', 'QuickstartCatalogSearch', {
+      tessen.track({
+        eventName: 'instantObservability',
+        category: 'QuickstartCatalogSearch',
         filter: filterParam,
         search: searchParam,
         quickstartCategory: categoryParam,
@@ -681,7 +683,9 @@ const QuickstartsPage = ({ data, location }) => {
                 onChange={(_e, view) => {
                   setView(view);
 
-                  tessen.track('instantObservability', `QuickstartViewToggle`, {
+                  tessen.track({
+                    eventName: 'instantObservability',
+                    category: 'QuickstartViewToggle',
                     quickstartViewState: view,
                   });
                 }}

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -53,14 +53,18 @@ const QuickstartDetails = ({ data, location }) => {
   ];
 
   const trackQuickstart = (action, quickstart) => () =>
-    tessen.track('instantObservability', action, {
+    tessen.track({
+      eventName: 'instantObservability',
+      category: action,
       quickstartName: quickstart.name,
       quickstartId: quickstart.id,
       quickstartUrl: quickstart.packUrl,
     });
 
   const tessenTabTrack = (action, quickstart) => (id, count) => {
-    tessen.track('instantObservability', action, {
+    tessen.track({
+      eventName: 'instantObservability',
+      category: action,
       QuickstartTabState: id,
       QuickstartTabCount: count,
       quickstartName: quickstart.name,
@@ -68,7 +72,9 @@ const QuickstartDetails = ({ data, location }) => {
     });
   };
   const tessenSupportTrack = (quickstart) => (action) => {
-    tessen.track('instantObservability', action, {
+    tessen.track({
+      eventName: 'instantObservability',
+      category: action,
       quickstartName: quickstart.name,
       quickstartId: quickstart.id,
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2057,10 +2057,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@^3.3.6":
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-3.3.6.tgz#f5b83ee9576ac136477ed0692dbaa83dad5068e5"
-  integrity sha512-H/LRO7mfIEy/5192UirnoPXtkhz4fpJrZIGvoR4NyaIjGMRR4fVkyt36r8QuUiWhipPtPMcCCXbWAZsCKpCV0A==
+"@newrelic/gatsby-theme-newrelic@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-4.0.1.tgz#804d93d134b605aeb3c05603e8810c8c416c3fb4"
+  integrity sha512-/i5igS2U+FVXIVQbMmDr179EaS3NIvEaZm7gjRSvHJwdXJStaMvu5GHmqT+CA217vKkVxhBrxwm1rqj0jLtCSg==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
## Summary
* Bring in latest version of the theme
* Update usage of instrumentation to only use tessen -- no longer use pageAction
* Update usage of tessen since latest version of theme has function signature changes
* Additionally, bringing in latest of theme also brings in anonymousId tracking to each tessen call

## Links
Relates to: #1885 