### PR TITLE
chore: remove iconUrl from query

### DIFF
--- a/src/pages/instant-observability.js
+++ b/src/pages/instant-observability.js
@@ -798,7 +798,6 @@ export const pageQuery = graphql`
         }
         authors
         description
-        iconUrl
         summary
         installPlans {
           id


### PR DESCRIPTION
Resolves gatsby cloud build error

<img width="1318" alt="Screen Shot 2021-11-18 at 4 50 14 PM" src="https://user-images.githubusercontent.com/1395158/142518709-6bc66f77-a762-4a59-8dc3-6e500737dc43.png">


