### PR TITLE
chore: update sdk version

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -212,7 +212,7 @@ module.exports = {
     {
       resolve: 'gatsby-source-newrelic-sdk',
       options: {
-        release: 'release-3366',
+        release: 'release-3439',
       },
     },
     'gatsby-plugin-embed-pages',


### PR DESCRIPTION
## Description

- Updated the SDK version to `release-3439`

- I did not find any new components to add this time. 

- I did a local build and poked around a little on the SDK pages and everything seemed okay. 

Closes https://github.com/newrelic/developer-website/issues/1933