### PR TITLE
fix: failure on no docs and no install plan

### DIFF
--- a/src/components/InstallButton.js
+++ b/src/components/InstallButton.js
@@ -106,6 +106,18 @@ const InstallButton = ({ quickstart, location, ...props }) => {
     quickstart.installPlans.length === 1 &&
     quickstart.installPlans[0].id.includes('guided-install');
 
+  const [installUrl, setInstallUrl] = useState(SIGNUP_LINK);
+  useEffect(() => {
+    setInstallUrl(url);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // If there is nothing to install AND no documentation, don't show this button.
+  if (!hasInstallableComponent && !hasComponent(quickstart, 'documentation')) {
+    return null;
+  }
+
   let nerdletId = hasGuidedInstall
     ? NR1_GUIDED_INSTALL_NERDLET
     : NR1_PACK_DETAILS_NERDLET;
@@ -126,18 +138,6 @@ const InstallButton = ({ quickstart, location, ...props }) => {
         parameters
       )
     : quickstart.documentation[0].url;
-
-  const [installUrl, setInstallUrl] = useState(SIGNUP_LINK);
-  useEffect(() => {
-    setInstallUrl(url);
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // If there is nothing to install AND no documentation, don't show this button.
-  if (!hasInstallableComponent && !hasComponent(quickstart, 'documentation')) {
-    return null;
-  }
 
   const writeCookie = () => {
     const currentEnvironment =


### PR DESCRIPTION
We have functionality to not display the `install`/`See documentation` button if the quickstart has neither an installable component or any other component (dashboard/alert/documentation), but because of where it was in the component it wasn't being returned in time. We were defaulting to `quickstarts.documentation[0].url` for the URL of the install button before verifying that the quickstart had a documentation reference