### PR TITLE
chore: minor terms.mdx formatting adjustments

### DIFF
--- a/src/markdown-pages/terms.mdx
+++ b/src/markdown-pages/terms.mdx
@@ -248,13 +248,13 @@ Resources, you agree to be bound by these Terms.
     Requirements](https://newrelic.github.io/nr1-catalog/) and
     provide:
 
-    i. Your App meeting the [Listing
+        i. Your App meeting the [Listing
     Requirements](https://newrelic.github.io/nr1-catalog/),
     including regarding security and coding practices,
 
-        - ii. Listing information, trademarks and documentation ("**Listing Materials**"),
-        - iii. End User Terms for your App, and
-        - iv. Other related materials that we reasonably request.
+        ii. Listing information, trademarks and documentation ("**Listing Materials**"),
+        iii. End User Terms for your App, and
+        iv. Other related materials that we reasonably request.
 
     b. **Approval.** New Relic may approve or reject any submitted App in its
     sole discretion and reserves the right to test Apps against the
@@ -265,16 +265,16 @@ Resources, you agree to be bound by these Terms.
     c. **New Relic Rights.** If New Relic approves your submitted App, you
     hereby grant New Relic a license to:
 
-        - i. List your App in the New Relic Catalog;
+        i. List your App in the New Relic Catalog;
 
-        - ii. Copy, distribute, publicly perform and display, and create
+        ii. Copy, distribute, publicly perform and display, and create
     derivative works of your Listing Materials, and screenshots of
     your App's use with the New Relic Service, in order to market and
     promote your App, the New Relic Catalog and the New Relic Service
     (but we will not change your trademarks except for sizing and
     formatting); and
 
-        - iii. Use, host, copy, distribute, publicly perform and display your
+        iii. Use, host, copy, distribute, publicly perform and display your
     App to permit your App to operate with the New Relic Service,
     including by permitting End Users to enable and deploy your App
     with their New Relic Service accounts.

--- a/src/markdown-pages/terms.mdx
+++ b/src/markdown-pages/terms.mdx
@@ -248,7 +248,7 @@ Resources, you agree to be bound by these Terms.
     Requirements](https://newrelic.github.io/nr1-catalog/) and
     provide:
 
-    i. Your App meeting the [Listing
+    - i. Your App meeting the [Listing
     Requirements](https://newrelic.github.io/nr1-catalog/),
     including regarding security and coding practices,
 

--- a/src/markdown-pages/terms.mdx
+++ b/src/markdown-pages/terms.mdx
@@ -42,11 +42,11 @@ Resources, you agree to be bound by these Terms.
     you configure usage or retrieve your data) remains subject to the
     New Relic Terms of Service, not these Terms.
 
-3.  **Registration**. To access or use the Developer Resources, you need to
+3.  **Registration.** To access or use the Developer Resources, you need to
     complete any registration or credentialing requirements
     established by New Relic.
 
-4.  **Use of Developer Resources**. Subject to these Terms, you may use the
+4.  **Use of Developer Resources.** Subject to these Terms, you may use the
     Developer Resources to enable your Apps to interface with the New
     Relic Service. Your use is subject to the developer documentation
     currently available on the [Developer
@@ -58,7 +58,7 @@ Resources, you agree to be bound by these Terms.
     behalf, provided you remain responsible for their compliance with
     these Terms.
 
-5.  **Developer Account**. New Relic may offer test or sandbox accounts as
+5.  **Developer Account.** New Relic may offer test or sandbox accounts as
     part of the Developer Program ("**Developer Accounts**"), which you
     may use only for internal development or testing of your Apps as
     part of your rights in Section 4 (Use of Developer Resources).
@@ -72,7 +72,7 @@ Resources, you agree to be bound by these Terms.
     subject to additional usage restrictions as set forth from time to
     time in the Developer Documentation.
 
-6.  **Access Limits; Compliance**. New Relic may (but is not required to)
+6.  **Access Limits; Compliance.** New Relic may (but is not required to)
     monitor your use of the Developer Resources and how your Apps
     interact with the New Relic Service, including to ensure your
     compliance with these Terms. You agree to cooperate with our
@@ -81,7 +81,7 @@ Resources, you agree to be bound by these Terms.
     these Terms. From time to time New Relic may also place limits on
     access (e.g., limits on the number of API calls).
 
-7.  **Restrictions**. We expect all developers to respect New Relic, end
+7.  **Restrictions.** We expect all developers to respect New Relic, end
     users and other third parties. In using the Developer Resources,
     you must comply with New Relic's Acceptable Use Policy currently
     available
@@ -110,7 +110,7 @@ Resources, you agree to be bound by these Terms.
     would subject the Developer Resources or New Relic Service to any
     open source licenses or other third party terms.
 
-8.  **Use of New Relic Marks**. Subject to these Terms, you may use the
+8.  **Use of New Relic Marks.** Subject to these Terms, you may use the
     appropriate New Relic names, logos and trademarks designated in
     the New Relic Trademark Guidelines currently available
     [here](https://newrelic.com/about/media-assets) ("**New
@@ -122,28 +122,28 @@ Resources, you agree to be bound by these Terms.
     rights to New Relic Marks under these Terms. All goodwill arising
     from use of New Relic Marks belongs to New Relic.
 
-9.  **Use of Your Marks**. Subject to these Terms, New Relic may use your
+9.  **Use of Your Marks.** Subject to these Terms, New Relic may use your
     names, logos, images and trademarks ("**Partner Marks**") to identify
     the relationship under these Terms and for mutually agreed
     marketing activities. New Relic will promptly cease use of Partner
     Marks upon written request by you.
 
-10. **Your Responsibilities**. You and your Apps must meet important
+10. **Your Responsibilities.** You and your Apps must meet important
     standards related to privacy, security, business practices and
     user experience, as set out below.
 
-    a. **Your Apps and End Users**. You are solely responsible, at your
+    a. **Your Apps and End Users.** You are solely responsible, at your
     own expense, for your Apps (including their operation, components,
     integrations and support) and your relationships and agreements
     with end users regarding your Apps.
 
-    b. **Support**. You will provide end users with reasonable web-based
+    b. **Support.** You will provide end users with reasonable web-based
     and/or email support for your Apps. You will also provide New
     Relic with a current email address to which New Relic may direct
     end user inquiries about your Apps and designate a support contact
     (name and email address) for New Relic.
 
-    c. **End User Data**. An end user may enable you or your App to access
+    c. **End User Data.** An end user may enable you or your App to access
     certain of its data, content or information within the New Relic
     Service ("**End User Data**"). You may access and process End User
     Data only to the extent enabled by the end user and as necessary
@@ -163,14 +163,14 @@ Resources, you agree to be bound by these Terms.
     disclosure, modification or deletion of End User Data in the New
     Relic Service by, through or resulting from an App.
 
-    d. **Security Breaches**. In case of any suspected or actual security
+    d. **Security Breaches.** In case of any suspected or actual security
     breach affecting your App or End User Data, you must immediately
     notify New Relic and cooperate with New Relic to remediate the
     issue and mitigate its effects. You must obtain New Relic's prior
     approval for any security breach notifications to end users that
     refer directly or indirectly to New Relic.
 
-    e. **New Relic Customer Terms**. Use of the New Relic Service requires
+    e. **New Relic Customer Terms.** Use of the New Relic Service requires
     each end user to have a valid subscription subject to the New
     Relic Terms of Service. You will not facilitate or encourage any
     end user to violate the New Relic Terms of Service or Acceptable
@@ -180,7 +180,7 @@ Resources, you agree to be bound by these Terms.
     such data will no longer be subject to your own terms with the end
     user.
 
-    f. **Fees**. You may not directly or indirectly charge end users for
+    f. **Fees.** You may not directly or indirectly charge end users for
     use of, or access to, the functionality of the Developer
     Resources. If you charge any fees for your Apps, you are solely
     responsible for collecting those fees independently from New Relic
@@ -196,7 +196,7 @@ Resources, you agree to be bound by these Terms.
     behalf of the other party or regarding the other party's
     services.
 
-    g. **Your Representations and Warranties**. You represent and warrant
+    g. **Your Representations and Warranties.** You represent and warrant
     that: (i) you have full power and authority to enter into and
     perform these Terms and to exploit your Apps without violating any
     other agreement; (ii) your Apps and their use will not violate any
@@ -224,7 +224,7 @@ Resources, you agree to be bound by these Terms.
     Bribery Act 2010, and the OECD Convention on Combating Bribery of
     Foreign Public Officials in International Business Transactions.
 
-    h. **Indemnification**. You will indemnify, defend (at New Relic's
+    h. **Indemnification.** You will indemnify, defend (at New Relic's
     request) and hold harmless New Relic and its affiliates and their
     respective directors, officers, employees, agents, contractors,
     end users and licensees from and against any regulatory actions,
@@ -240,10 +240,10 @@ Resources, you agree to be bound by these Terms.
     New Relic's prior written consent (not to be unreasonably
     withheld)
 
-11. **Listings**. This Section 11 applies only if you choose to submit your
+11. **Listings.** This Section 11 applies only if you choose to submit your
     App for listing in the New Relic Catalog.
 
-    a. **Submission**. To submit your App for potential listing in the New
+    a. **Submission.** To submit your App for potential listing in the New
     Relic Catalog, you must follow New Relic's [Listing
     Requirements](https://newrelic.github.io/nr1-catalog/) and
     provide:
@@ -252,47 +252,44 @@ Resources, you agree to be bound by these Terms.
     Requirements](https://newrelic.github.io/nr1-catalog/),
     including regarding security and coding practices,
 
-    - ii. Listing information, trademarks and documentation
-      ("**Listing Materials**"),
+        - ii. Listing information, trademarks and documentation ("**Listing Materials**"),
+        - iii. End User Terms for your App, and
+        - iv. Other related materials that we reasonably request.
 
-    - iii. End User Terms for your App, and
-
-    - iv. Other related materials that we reasonably request.
-
-    b. **Approval**. New Relic may approve or reject any submitted App in its
+    b. **Approval.** New Relic may approve or reject any submitted App in its
     sole discretion and reserves the right to test Apps against the
     Listing Requirements and other security and performance criteria. You
     remain solely responsible for your Apps despite any New Relic
     approval.
 
-    c. **New Relic Rights**. If New Relic approves your submitted App, you
+    c. **New Relic Rights.** If New Relic approves your submitted App, you
     hereby grant New Relic a license to:
 
-    - i. List your App in the New Relic Catalog;
+        - i. List your App in the New Relic Catalog;
 
-    - ii. Copy, distribute, publicly perform and display, and create
-      derivative works of your Listing Materials, and screenshots of
-      your App's use with the New Relic Service, in order to market and
-      promote your App, the New Relic Catalog and the New Relic Service
-      (but we will not change your trademarks except for sizing and
-      formatting); and
+        - ii. Copy, distribute, publicly perform and display, and create
+    derivative works of your Listing Materials, and screenshots of
+    your App's use with the New Relic Service, in order to market and
+    promote your App, the New Relic Catalog and the New Relic Service
+    (but we will not change your trademarks except for sizing and
+    formatting); and
 
-    - iii. Use, host, copy, distribute, publicly perform and display your
-      App to permit your App to operate with the New Relic Service,
-      including by permitting End Users to enable and deploy your App
-      with their New Relic Service accounts.
+        - iii. Use, host, copy, distribute, publicly perform and display your
+    App to permit your App to operate with the New Relic Service,
+    including by permitting End Users to enable and deploy your App
+    with their New Relic Service accounts.
 
     New Relic's license rights are worldwide, non-exclusive, royalty-free
     and fully paid-up and sublicensable through multiple tiers. New Relic
     retains sole discretion and control over the placement, look and feel
     of the New Relic Catalog.
 
-    d. **End User Deployment**. If New Relic lists your App on the New Relic
+    d. **End User Deployment.** If New Relic lists your App on the New Relic
     Catalog, interested end users may select and deploy your App with
     their New Relic Service accounts. New Relic does not guarantee any end
     users will search for or use your App.
 
-    e. **End User Terms**. You are responsible for your End User Terms and how
+    e. **End User Terms.** You are responsible for your End User Terms and how
     you present them to end users and obtain their agreement. Your End
     User Terms must be consistent with your rights and obligations in
     these Terms (including regarding End User Data and any termination,
@@ -309,7 +306,7 @@ Resources, you agree to be bound by these Terms.
     example purposes only, any version of the GPL or LGPL, Affero, CPL,
     CDDL, Eclipse or Mozilla licenses).
 
-    f. **Take-Downs**. You may request that we take-down your App from the New
+    f. **Take-Downs.** You may request that we take-down your App from the New
     Relic Catalog at any time by contacting
     [opensource+nr1-catalog@newrelic.com](https://developer.newrelic.com/terms/mailto:opensource+nr1-catalog@newrelic.com).
     We will use commercially reasonable efforts to promptly remove your
@@ -319,12 +316,12 @@ Resources, you agree to be bound by these Terms.
     without notice to you. Section 14.c (Wind-Down) will apply following
     any take-down pursuant to this Section 11.f.
 
-    g. **New Relic Catalog**. "**New Relic Catalog**" means (i) the New Relic
+    g. **New Relic Catalog.** "**New Relic Catalog**" means (i) the New Relic
     One Catalog that New Relic makes available in connection with the New
     Relic Service and (ii) any other App listing or catalog that New Relic
     makes available through its own or third party products or websites.
 
-12. **Ownership**. New Relic does not claim ownership of your Apps (other
+12. **Ownership.** New Relic does not claim ownership of your Apps (other
     than our own technology) and you reserve all rights not expressly
     granted in these Terms. New Relic and its licensors retain all
     ownership and other rights (including all intellectual property
@@ -334,7 +331,7 @@ Resources, you agree to be bound by these Terms.
     to New Relic is wholly voluntary. New Relic may freely use
     Feedback for any purpose.
 
-13. **Support; Changes**. New Relic has no obligation to provide maintenance
+13. **Support; Changes.** New Relic has no obligation to provide maintenance
     or support for the Developer Resources or your Apps, or to fix any
     errors or defects. New Relic may change the Developer Resources
     from time to time as our business changes and technology evolves,
@@ -345,13 +342,13 @@ Resources, you agree to be bound by these Terms.
     individually. New Relic will have no liability resulting from
     these changes.
 
-14. **Termination and Suspension**. These Terms remain in effect until
+14. **Termination and Suspension.** These Terms remain in effect until
     terminated.
 
-    a. **By Developer**. Developer may terminate these Terms at any time
+        a. **By Developer.** Developer may terminate these Terms at any time
     by ceasing all use of the Developer Resources.
 
-    b. **By New Relic**. New Relic may terminate or suspend these Terms or
+        b. **By New Relic.** New Relic may terminate or suspend these Terms or
     your access to or right to use the Developer Resources (in whole
     or in part): (i) for no reason or any reason upon 15 days' notice
     to you, (ii) immediately (A) if you breach any provision of these
@@ -364,13 +361,13 @@ Resources, you agree to be bound by these Terms.
     New Relic Service, or any end user. For clarity, suspension may
     include disabling your Apps.
 
-    c. **Wind-Down**. Following any termination of these Terms, at New
+        c. **Wind-Down.** Following any termination of these Terms, at New
     Relic's request (i) the parties will cooperate to effectuate an
     orderly wind-down and (ii) these Terms will continue in effect for
     up to 90 days to enable deployed end users to continue using your
     Apps.
 
-    d. **End User Communications**. In the event of any termination,
+        d. **End User Communications.** In the event of any termination,
     suspension or take-down under this Section 14 or Section 11.f
     (Take-Downs), Developer remains responsible for managing its own
     end user relationships and communications, including as relates to
@@ -380,7 +377,7 @@ Resources, you agree to be bound by these Terms.
     conducted in a positive and professional manner, consistent with
     any guidelines New Relic may provide.
 
-    e. **Effect of Termination**. Upon any termination, subject to Section
+        e. **Effect of Termination.** Upon any termination, subject to Section
     14.c (Wind-Down) (i) your rights to use the Developer Resources
     and New Relic Marks will immediately terminate and you will cease
     all such use, (ii) you will return or destroy all Confidential
@@ -390,11 +387,11 @@ Resources, you agree to be bound by these Terms.
     you will have no further access to any data or content that you
     submitted to New Relic relating to the Developer Resources.
 
-    f. **No Obligation or Liability**. New Relic will have no obligation
+        f. **No Obligation or Liability.** New Relic will have no obligation
     or liability resulting from termination, suspension or take-down
     as described in this Section 14 or Section 11.f (Take-Downs).
 
-15. **Disclaimer of Warranties**. TO THE FULL EXTENT PERMITTED BY LAW, THE
+15. **Disclaimer of Warranties.** TO THE FULL EXTENT PERMITTED BY LAW, THE
     DEVELOPER RESOURCES AND NEW RELIC MARKS ARE PROVIDED "AS IS,"
     "AS AVAILABLE," AND "WITH ALL FAULTS." NEW RELIC AND ITS
     THIRD-PARTY LICENSORS DISCLAIM ALL REPRESENTATIONS, WARRANTIES AND
@@ -409,7 +406,7 @@ Resources, you agree to be bound by these Terms.
     may have other statutory rights, in which case the disclaimers
     above will apply to the full extent permitted by law.
 
-16. **Limitations of Liability**. TO THE FULL EXTENT PERMITTED BY LAW, IN NO
+16. **Limitations of Liability.** TO THE FULL EXTENT PERMITTED BY LAW, IN NO
     EVENT WILL NEW RELIC BE LIABLE (i) FOR ANY LOSS OF USE, LOST DATA,
     FAILURE OF SECURITY MECHANISMS, INTERRUPTION OF BUSINESS OR ANY
     INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES OF ANY KIND
@@ -430,7 +427,7 @@ Resources, you agree to be bound by these Terms.
     these Terms without these liability limitations. This Section will
     survive even if any limited remedy fails its essential purpose.
 
-17. **New Relic Confidential Information**. Any nonpublic elements of the
+17. **New Relic Confidential Information.** Any nonpublic elements of the
     Developer Resources and any other information disclosed by New
     Relic that is marked as confidential or proprietary or that should
     reasonably be understood to be confidential or proprietary from
@@ -459,7 +456,7 @@ Resources, you agree to be bound by these Terms.
     and New Relic will have the right to seek injunctive relief in
     addition to other remedies.
 
-18. **Independent Development; Information You Provide Not Confidential**.
+18. **Independent Development; Information You Provide Not Confidential.**
     New Relic develops a variety of offerings and works with many
     other developers and partners, and either New Relic or these third
     parties could in the future develop (or already have developed)
@@ -470,7 +467,7 @@ Resources, you agree to be bound by these Terms.
     Relic has no confidentiality obligations for information you
     submit in connection with the Developer Program.
 
-19. **Usage Data**. In addition to New Relic's other rights, New Relic may
+19. **Usage Data.** In addition to New Relic's other rights, New Relic may
     collect certain data and information regarding your use of the
     [Developer Site](http://developer.newrelic.com/) and
     Developer Resources, including data about your data pulls or
@@ -478,7 +475,7 @@ Resources, you agree to be bound by these Terms.
     Usage Data for any purpose in connection with operating, improving
     and supporting the Developer Program and Developer Resources.
 
-20. **Changes to Terms**. We may change these Terms from time to time as our
+20. **Changes to Terms.** We may change these Terms from time to time as our
     business changes and technology evolves. New Relic will use
     reasonable efforts to notify you of changes to these Terms as
     provided in Section 23 (Notices). You may be required to click
@@ -489,7 +486,7 @@ Resources, you agree to be bound by these Terms.
     terminate your use of the Developer Resources as described in
     Section 14 (Termination and Suspension).
 
-21. **Open Source Software**. Certain code in the Developer Resources (e.g.,
+21. **Open Source Software.** Certain code in the Developer Resources (e.g.,
     SDKs) may be licensed under or include components subject to
     "open source" software terms ("**OSS**"), as listed in the
     Developer Documentation. The OSS licenses may grant you additional
@@ -498,7 +495,7 @@ Resources, you agree to be bound by these Terms.
     OSS as part of our Developer Program, you must comply with these
     Terms.
 
-22. **Pre-Release Versions**. New Relic may make available certain Developer
+22. **Pre-Release Versions.** New Relic may make available certain Developer
     Resources on a pre-release or early access basis ("Pre-Release
     Versions"). Use of Pre-Release Versions may be subject to
     additional terms designated by New Relic. Pre-Release Versions are
@@ -509,7 +506,7 @@ Resources, you agree to be bound by these Terms.
     may never release, and their features and performance information
     are New Relic's Confidential Information.
 
-23. **Notices**. New Relic may provide you with notices and communications
+23. **Notices.** New Relic may provide you with notices and communications
     at your email or physical address on file, through the [Developer
     Site](http://developer.newrelic.com/) or other reasonable
     means. Any notices or communications to New Relic must be sent to
@@ -517,7 +514,7 @@ Resources, you agree to be bound by these Terms.
     or New Relic, Inc., Attention: Legal Department - Developer Terms,
     188 Spear Street, Suite 1200, San Francisco, CA 94105.
 
-24. **Export**. The Developer Resources may be subject to export
+24. **Export.** The Developer Resources may be subject to export
     restrictions by the United States government and import
     restrictions by certain foreign governments, and you agree to
     comply with all applicable export and import laws and regulations
@@ -532,7 +529,7 @@ Resources, you agree to be bound by these Terms.
     information controlled under the U.S. International Traffic in
     Arms Regulations.
 
-25. **General**. These Terms are the parties' entire agreement and
+25. **General.** These Terms are the parties' entire agreement and
     supersede any prior or concurrent agreements relating to its
     subject matter. Except as set forth in Section 20 (Changes to
     Terms), all amendments or modifications must be in writing and

--- a/src/markdown-pages/terms.mdx
+++ b/src/markdown-pages/terms.mdx
@@ -17,7 +17,7 @@ These terms ("**Terms**") apply to participation in the Developer Program
 and form a legal agreement between you ("**you**" or "**Developer**") and
 New Relic, Inc. ("**New Relic**", "**we**", "**our**" or "**us**"), so please
 read them carefully. If you are entering into these Terms on behalf of a
-company, organization or another legal entity, then **"you**" or
+company, organization or another legal entity, then "**you**" or
 "**Developer**" means that entity, and you represent and warrant that you
 have the authority to bind that entity to these Terms. Please ensure you
 have that authority, since otherwise you may not accept these Terms or

--- a/src/markdown-pages/terms.mdx
+++ b/src/markdown-pages/terms.mdx
@@ -22,8 +22,8 @@ company, organization or another legal entity, then "**you**" or
 have the authority to bind that entity to these Terms. Please ensure you
 have that authority, since otherwise you may not accept these Terms or
 use the Developer Resources. New Relic may modify these Terms from time
-to time, subject to Section 20 (Changes to Terms) below. By clicking "**I
-agree**" (or a similar button) or by accessing or using the Developer
+to time, subject to Section 20 (Changes to Terms) below. By clicking "<b>I
+agree</b>" (or a similar button) or by accessing or using the Developer
 Resources, you agree to be bound by these Terms.
 
 1.  **Introduction.** Our Developer Resources help you build apps, add-ons
@@ -32,8 +32,8 @@ Resources, you agree to be bound by these Terms.
     SDKs, sample code, Developer Accounts, command line interfaces,
     tokens, credentials and other resources we provide as part of the
     Developer Program, as described on the [Developer
-    Site](http://developer.newrelic.com/). The "**New Relic
-    Service**" is our SaaS offering and related software, which we
+    Site](http://developer.newrelic.com/). The "<b>New Relic
+    Service</b>" is our SaaS offering and related software, which we
     provide under separate terms ("**New Relic Terms of Service**").
 
 2.  **How These Terms Apply.** These Terms apply if you use our Developer
@@ -113,8 +113,8 @@ Resources, you agree to be bound by these Terms.
 8.  **Use of New Relic Marks.** Subject to these Terms, you may use the
     appropriate New Relic names, logos and trademarks designated in
     the New Relic Trademark Guidelines currently available
-    [here](https://newrelic.com/about/media-assets) ("**New
-    Relic Marks**") to promote your App's availability for use with
+    [here](https://newrelic.com/about/media-assets) ("<b>New
+    Relic Marks</b>") to promote your App's availability for use with
     the New Relic Service. Your use of New Relic Marks must comply
     with the New Relic Trademark Guidelines and (without limiting New
     Relic's other termination rights) you must promptly cease any use

--- a/src/markdown-pages/terms.mdx
+++ b/src/markdown-pages/terms.mdx
@@ -248,13 +248,16 @@ Resources, you agree to be bound by these Terms.
     Requirements](https://newrelic.github.io/nr1-catalog/) and
     provide:
 
-        i. Your App meeting the [Listing
+    i. Your App meeting the [Listing
     Requirements](https://newrelic.github.io/nr1-catalog/),
     including regarding security and coding practices,
 
-        ii. Listing information, trademarks and documentation ("**Listing Materials**"),
-        iii. End User Terms for your App, and
-        iv. Other related materials that we reasonably request.
+    - ii. Listing information, trademarks and documentation
+      ("**Listing Materials**"),
+
+    - iii. End User Terms for your App, and
+
+    - iv. Other related materials that we reasonably request.
 
     b. **Approval.** New Relic may approve or reject any submitted App in its
     sole discretion and reserves the right to test Apps against the
@@ -265,19 +268,19 @@ Resources, you agree to be bound by these Terms.
     c. **New Relic Rights.** If New Relic approves your submitted App, you
     hereby grant New Relic a license to:
 
-        i. List your App in the New Relic Catalog;
+    - i. List your App in the New Relic Catalog;
 
-        ii. Copy, distribute, publicly perform and display, and create
-    derivative works of your Listing Materials, and screenshots of
-    your App's use with the New Relic Service, in order to market and
-    promote your App, the New Relic Catalog and the New Relic Service
-    (but we will not change your trademarks except for sizing and
-    formatting); and
+    - ii. Copy, distribute, publicly perform and display, and create
+      derivative works of your Listing Materials, and screenshots of
+      your App's use with the New Relic Service, in order to market and
+      promote your App, the New Relic Catalog and the New Relic Service
+      (but we will not change your trademarks except for sizing and
+      formatting); and
 
-        iii. Use, host, copy, distribute, publicly perform and display your
-    App to permit your App to operate with the New Relic Service,
-    including by permitting End Users to enable and deploy your App
-    with their New Relic Service accounts.
+    - iii. Use, host, copy, distribute, publicly perform and display your
+      App to permit your App to operate with the New Relic Service,
+      including by permitting End Users to enable and deploy your App
+      with their New Relic Service accounts.
 
     New Relic's license rights are worldwide, non-exclusive, royalty-free
     and fully paid-up and sublicensable through multiple tiers. New Relic
@@ -345,10 +348,10 @@ Resources, you agree to be bound by these Terms.
 14. **Termination and Suspension.** These Terms remain in effect until
     terminated.
 
-        a. **By Developer.** Developer may terminate these Terms at any time
+    a. **By Developer.** Developer may terminate these Terms at any time
     by ceasing all use of the Developer Resources.
 
-        b. **By New Relic.** New Relic may terminate or suspend these Terms or
+    b. **By New Relic.** New Relic may terminate or suspend these Terms or
     your access to or right to use the Developer Resources (in whole
     or in part): (i) for no reason or any reason upon 15 days' notice
     to you, (ii) immediately (A) if you breach any provision of these
@@ -361,13 +364,13 @@ Resources, you agree to be bound by these Terms.
     New Relic Service, or any end user. For clarity, suspension may
     include disabling your Apps.
 
-        c. **Wind-Down.** Following any termination of these Terms, at New
+    c. **Wind-Down.** Following any termination of these Terms, at New
     Relic's request (i) the parties will cooperate to effectuate an
     orderly wind-down and (ii) these Terms will continue in effect for
     up to 90 days to enable deployed end users to continue using your
     Apps.
 
-        d. **End User Communications.** In the event of any termination,
+    d. **End User Communications.** In the event of any termination,
     suspension or take-down under this Section 14 or Section 11.f
     (Take-Downs), Developer remains responsible for managing its own
     end user relationships and communications, including as relates to
@@ -377,7 +380,7 @@ Resources, you agree to be bound by these Terms.
     conducted in a positive and professional manner, consistent with
     any guidelines New Relic may provide.
 
-        e. **Effect of Termination.** Upon any termination, subject to Section
+    e. **Effect of Termination.** Upon any termination, subject to Section
     14.c (Wind-Down) (i) your rights to use the Developer Resources
     and New Relic Marks will immediately terminate and you will cease
     all such use, (ii) you will return or destroy all Confidential
@@ -387,7 +390,7 @@ Resources, you agree to be bound by these Terms.
     you will have no further access to any data or content that you
     submitted to New Relic relating to the Developer Resources.
 
-        f. **No Obligation or Liability.** New Relic will have no obligation
+    f. **No Obligation or Liability.** New Relic will have no obligation
     or liability resulting from termination, suspension or take-down
     as described in this Section 14 or Section 11.f (Take-Downs).
 

--- a/src/markdown-pages/terms.mdx
+++ b/src/markdown-pages/terms.mdx
@@ -22,8 +22,8 @@ company, organization or another legal entity, then "**you**" or
 have the authority to bind that entity to these Terms. Please ensure you
 have that authority, since otherwise you may not accept these Terms or
 use the Developer Resources. New Relic may modify these Terms from time
-to time, subject to Section 20 (Changes to Terms) below. By clicking "<b>I
-agree</b>" (or a similar button) or by accessing or using the Developer
+to time, subject to Section 20 (Changes to Terms) below. By clicking "**I
+agree**" (or a similar button) or by accessing or using the Developer
 Resources, you agree to be bound by these Terms.
 
 1.  **Introduction.** Our Developer Resources help you build apps, add-ons
@@ -32,8 +32,8 @@ Resources, you agree to be bound by these Terms.
     SDKs, sample code, Developer Accounts, command line interfaces,
     tokens, credentials and other resources we provide as part of the
     Developer Program, as described on the [Developer
-    Site](http://developer.newrelic.com/). The "<b>New Relic
-    Service</b>" is our SaaS offering and related software, which we
+    Site](http://developer.newrelic.com/). The "**New Relic
+    Service**" is our SaaS offering and related software, which we
     provide under separate terms ("**New Relic Terms of Service**").
 
 2.  **How These Terms Apply.** These Terms apply if you use our Developer
@@ -113,8 +113,8 @@ Resources, you agree to be bound by these Terms.
 8.  **Use of New Relic Marks.** Subject to these Terms, you may use the
     appropriate New Relic names, logos and trademarks designated in
     the New Relic Trademark Guidelines currently available
-    [here](https://newrelic.com/about/media-assets) ("<b>New
-    Relic Marks</b>") to promote your App's availability for use with
+    [here](https://newrelic.com/about/media-assets) ("**New
+    Relic Marks**") to promote your App's availability for use with
     the New Relic Service. Your use of New Relic Marks must comply
     with the New Relic Trademark Guidelines and (without limiting New
     Relic's other termination rights) you must promptly cease any use


### PR DESCRIPTION
## Description

Some minor adjustments to the headers 
- Sometimes `**Header.**` instead of `**Header**.` is being used - this is causing the `ReactMarkdown` parser to split the header by the `<strong>` element (which is a `display: block;` by default) but leaves the content (the `<p>` element) on a separate line along with the period.

**Example:**

<img width="339" alt="Screen Shot 2021-12-28 at 11 50 09 AM" src="https://user-images.githubusercontent.com/20836690/147593339-8a2974db-5509-4866-bacc-a9cc1e1011ab.png">


- `**"you**"` is being used vs. `"**you**"`


