### PR TITLE
Remove 'insert key' refs

### DIFF
--- a/src/markdown-pages/collect-data/collect-data-from-any-source.mdx
+++ b/src/markdown-pages/collect-data/collect-data-from-any-source.mdx
@@ -19,7 +19,7 @@ tags:
 
 <Intro>
 
-New Relic products report a lot of data “out of the box.” When you use products like [APM](https://docs.newrelic.com/docs/apm), [Browser](https://docs.newrelic.com/docs/browser), [Mobile](https://docs.newrelic.com/docs/mobile-monitoring), [Infrastructure monitoring](https://docs.newrelic.com/docs/infrastructure), or an [integration](https://docs.newrelic.com/docs/integrations), by default you receive performance data.
+New Relic products report a lot of data “out of the box.” When you use monitoring solutions like [APM](https://docs.newrelic.com/docs/apm), [browser monitoring](https://docs.newrelic.com/docs/browser), [mobile monitoring](https://docs.newrelic.com/docs/mobile-monitoring), [infrastructure monitoring](https://docs.newrelic.com/docs/infrastructure), or any of our [integrations](https://docs.newrelic.com/docs/integrations), by default you receive various types of performance data.
 
 But you may want to bring data into New Relic that isn't collected by default. Maybe you want an API-based solution that doesn't require install of an agent. Maybe you want to bring telemetry data from another analysis service into New Relic. This page describes several ways to get data into New Relic.
 
@@ -31,22 +31,24 @@ But you may want to bring data into New Relic that isn't collected by default. M
 
 ## Agent APIs
 
-If you use our APM, Browser, or Mobile agents to report data, you can use their associated APIs to report custom data. For example, if you monitor your application with our APM Python agent, you can use the [Python agent API](https://docs.newrelic.com/docs/agents/python-agent/api-guides/guide-using-python-agent-api) to set up custom instrumentation.
+If you use our APM, browser, or mobile agents to report data, you can use their associated APIs to report custom data. For example, if you monitor your application with our APM Python agent, you can use the [Python agent API](https://docs.newrelic.com/docs/agents/python-agent/api-guides/guide-using-python-agent-api) to set up custom instrumentation.
 
 See the [agent APIs](https://docs.newrelic.com/docs/agents).
 </Step>
 
 <Step>
 
-## Telemetry SDK
+## Telemetry SDKs
 
-Our Telemetry SDKs are language wrappers for our [Trace API](https://docs.newrelic.com/docs/apm/distributed-tracing/trace-api/introduction-new-relic-trace-api) and [Metric API](https://docs.newrelic.com/docs/introduction-new-relic-metric-api) (and eventually our Log API and Event API). These SDKs let you easily send metrics and trace data to New Relic without needing to install an agent. For customers, we offer open-source exporters and integrations that use the Telemetry SDKs to send metrics and trace data: 
+Our Telemetry SDKs are language wrappers for our [ingest APIs](https://docs.newrelic.com/docs/apis/intro-apis/introduction-new-relic-apis/#data-type-apis). These SDKs let you easily send metrics and trace data to New Relic without needing to install an agent. We offer open-source exporters and integrations that use our Telemetry SDKs to report metrics and trace data. Some of these solutions are: 
 
+- [OpenTelemetry integrations](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/introduction-opentelemetry-new-relic)
 - [Istio adaptor](https://github.com/newrelic/newrelic-istio-adapter)
 - Prometheus OpenMetrics ([for Docker](https://docs.newrelic.com/docs/new-relic-prometheus-openmetrics-integration-docker) | [for Kubernetes](https://docs.newrelic.com/docs/new-relic-prometheus-openmetrics-integration-kubernetes)) 
-- OpenCensus exporter ([for Go](https://github.com/newrelic/newrelic-opencensus-exporter-go) | [for Python](http://github.com/newrelic/newrelic-opencensus-exporter-python)) 
+- [Grafana integrations](https://docs.newrelic.com/docs/more-integrations/grafana-integrations/get-started/grafana-support-prometheus-promql)
 - [DropWizard exporter](https://github.com/newrelic/dropwizard-metrics-newrelic)
 - [Micrometer exporter](https://github.com/newrelic/micrometer-registry-newrelic)
+- OpenCensus exporter ([for Go](https://github.com/newrelic/newrelic-opencensus-exporter-go) | [for Python](http://github.com/newrelic/newrelic-opencensus-exporter-python)) 
 
 Want to build your own solution? [See our Telemetry SDK docs.](https://docs.newrelic.com/docs/telemetry-sdk-send-custom-telemetry-data-new-relic)
 
@@ -54,7 +56,15 @@ Want to build your own solution? [See our Telemetry SDK docs.](https://docs.newr
 
 <Step>
 
-## Trace API
+## Report custom infrastructure data 
+
+If our infrastructure integrations don't meet your needs, you can use our [Flex integration](https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/flex-integration-tool-build-your-own-integration) to report any type of infrastructure-related metrics or configuration settings to New Relic. 
+
+</Step>
+
+<Step>
+
+## Custom distributed tracing solutions
 
 Our [Trace API](https://docs.newrelic.com/docs/apm/distributed-tracing/trace-api/introduction-new-relic-trace-api) lets you send distributed tracing data to New Relic and consolidate tracing data from multiple sources in one place. We accept trace data in two formats: 
 

--- a/src/markdown-pages/collect-data/collect-data-from-any-source.mdx
+++ b/src/markdown-pages/collect-data/collect-data-from-any-source.mdx
@@ -140,7 +140,7 @@ For sending arbitrary events to New Relic, you can use our Event API. We save th
 ```shell lineNumbers=true
 curl -i -X POST https://insights-collector.newrelic.com/v1/accounts/$ACCOUNT_ID/events \
   -H "Content-Type: application/json" \
-  -H "x-insert-key: $LICENSE_KEY" \
+  -H "Api-Key: $LICENSE_KEY" \
   -d '[
         {
           "eventType": "LoginEvent",

--- a/src/markdown-pages/collect-data/custom-events.mdx
+++ b/src/markdown-pages/collect-data/custom-events.mdx
@@ -40,19 +40,19 @@ at_exit do
 
   # Send the errors to New Relic as a custom event
   insights_url = URI.parse("https://insights-collector.newrelic.com/v1/accounts/YOUR_ACCOUNT_ID/events")
-  headers = { "x-insert-key" => "YOUR_API_KEY", "content-type" => "application/json" }
+  headers = { "Api-Key" => "YOUR_LICENSE_KEY", "content-type" => "application/json" }
 
   http = Net::HTTP.new(insights_url.host, insights_url.port)
   http.use_ssl = true
   request = Net::HTTP::Post.new(insights_url.request_uri, headers)
   request.body = payload.to_json
 
-  puts "Sending run summary to Insights: #{payload.to_json}"
+  puts "Sending run summary to New Relic: #{payload.to_json}"
   begin
     response = http.request(request)
-    puts "Response from Insights: #{response.body}"
+    puts "Response from New Relic: #{response.body}"
   rescue Exception => e
-    puts "There was an error posting to Insights. Error: #{e.inspect}"
+    puts "There was an error posting to New Relic. Error: #{e.inspect}"
   end
 end
 ```

--- a/src/markdown-pages/collect-data/custom-events.mdx
+++ b/src/markdown-pages/collect-data/custom-events.mdx
@@ -18,7 +18,7 @@ tags:
 
 Whereas adding [custom attributes](/collect-data/custom-attributes) adds metadata to an existing event, a custom event creates an entirely new event type. Create custom events to define, visualize, and get alerts on additional data, just as you would with any data we provide from our core agents.  
 
-Custom events can be inserted through the Agent APIs or directly via the Insights Insert API. The following example shows how to send a custom event named CLIRun that tracks when a command line tool written in Ruby has its process exit due to an exception.
+Custom events can be inserted through the agent APIs or directly via the Event API. The following example shows how to send a custom event named CLIRun that tracks when a command line tool written in Ruby has its process exit due to an exception.
 
 ```ruby
 # Hook into the runtime 'at_exit' event


### PR DESCRIPTION
## Description

This is from docs team. Removing some references to 'Insights' and to 'insert key' (as that has been deprecated in favor of license key). Also rewrote some of the 'report custom data' doc as I noticed it seemed a little out of date and incorrect. 
