### PR TITLE
fix: Cleanup and remove newrelic-quickstart-id

### DIFF
--- a/src/components/InstallButton.js
+++ b/src/components/InstallButton.js
@@ -154,7 +154,6 @@ const InstallButton = ({ quickstart, location, ...props }) => {
       })
     );
     Cookies.set('start_target', startTarget, options);
-    Cookies.set('newrelic-quickstart-id', quickstart.id, options);
   };
 
   const handleInstallClick = () => {


### PR DESCRIPTION
## Description

With the completion of some work around using `start_target` instead of `newrelic-quickstart-id` this PR cleans up its usage. It's no longer needed. 

## Reviewer Notes

1. Click on an NRIO tile
2. Ensure you land on the Catalog Pack Details page for that NRIO tile

## Related Issue(s) / Ticket(s)

If there are any related [GitHub Issues](https://github.com/newrelic/developer-website/issues) or JIRA tickets, add links to them here.
* [JIRA Ticket](https://newrelic.atlassian.net/browse/VIRTUOSO-1554)

## Screenshot(s)

If relevant, add screenshots here.

## Use Conventional Commits

Please help the maintainers by leveraging the following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
standards in your pull request title and commit messages.

## Use `chore`

* for minor changes / additions / corrections to content.
* for minor changes / additions / corrections to images.
* for minor non-functional changes / additions to github actions, github templates, package or config updates, etc

```bash
git commit -m "chore: adjusting config and content"
```

## Use `fix`

* for minor functional corrections to code.

```bash
git commit -m "fix: typo and prop error in the code of conduct"
```

## Use `feat`

* for major functional changes or additions to code.

```bash
git commit -m "feat(media): creating a video landing page"
```
