### PR TITLE
fix(dev site): remove insert key

### DIFF
--- a/src/markdown-pages/collect-data/collect-data-from-any-source.mdx
+++ b/src/markdown-pages/collect-data/collect-data-from-any-source.mdx
@@ -140,7 +140,7 @@ For sending arbitrary events to New Relic, you can use our Event API. We save th
 ```shell lineNumbers=true
 curl -i -X POST https://insights-collector.newrelic.com/v1/accounts/$ACCOUNT_ID/events \
   -H "Content-Type: application/json" \
-  -H "x-insert-key: $LICENSE_KEY" \
+  -H "Api-Key: $LICENSE_KEY" \
   -d '[
         {
           "eventType": "LoginEvent",

--- a/src/markdown-pages/collect-data/custom-events.mdx
+++ b/src/markdown-pages/collect-data/custom-events.mdx
@@ -40,7 +40,7 @@ at_exit do
 
   # Send the errors to New Relic as a custom event
   insights_url = URI.parse("https://insights-collector.newrelic.com/v1/accounts/YOUR_ACCOUNT_ID/events")
-  headers = { "x-insert-key" => "YOUR_API_KEY", "content-type" => "application/json" }
+  headers = { "Api-Key" => "YOUR_LICENSE_KEY", "content-type" => "application/json" }
 
   http = Net::HTTP.new(insights_url.host, insights_url.port)
   http.use_ssl = true


### PR DESCRIPTION
## Description

From docs team jira: removing references to insert key and the 'x-insert-key' header and replacing with license key and 'Api-Key' header. 
