### PR TITLE
Update dev center launcher location in doc

### DIFF
--- a/src/markdown-pages/explore-docs/nr1-cli.mdx
+++ b/src/markdown-pages/explore-docs/nr1-cli.mdx
@@ -39,7 +39,7 @@ We provide a variety of tools for building apps, including the New Relic One CLI
 
 ## Installing the New Relic One CLI
 
-In New Relic, click **Apps** and then in the **New Relic One catalog** area, click the [**Build your own application** launcher](https://one.newrelic.com/launcher/developer-center.launcher) and follow the quick start instructions. The quick start automatically generates an API key for the account you select, and gives you the pre-populated commands to create a profile, generate your first "Hello World" app, and serve it locally.
+In New Relic, click **Instant Observability**, then check the **Apps** box in the **filter by** section. Click the [**Build on New Relic** launcher](https://one.newrelic.com/launcher/developer-center.launcher) and follow the quick start instructions. The quick start automatically generates an API key for the account you select, and gives you the pre-populated commands to create a profile, generate your first "Hello World" app, and serve it locally.
 
 ![Build New Relic One application](../../images/developercenter.png)
 


### PR DESCRIPTION
The app catalog is on its way to be deprecated and is no longer the place to find the build your own tile, this updates the guide on this

closes https://github.com/newrelic/developer-website/issues/2021