### PR TITLE
chore : Build your own button is moved to left panel

### DIFF
--- a/src/pages/instant-observability.js
+++ b/src/pages/instant-observability.js
@@ -14,7 +14,6 @@ import {
 } from '@newrelic/gatsby-theme-newrelic';
 import { navigate } from '@reach/router';
 
-import BUILD_YOUR_OWN from '../images/build-your-own.svg';
 import { useDebounce } from 'react-use';
 import { sortFeaturedQuickstarts } from '../utils/sortFeaturedQuickstarts';
 import {
@@ -186,6 +185,11 @@ const QuickstartsPage = ({ data, location }) => {
     return found.displayName;
   };
 
+  // OPEN BUILD YOUR OWN QUICKSTART URL ON A NEW TAB
+  const buildYourOwn = (url) => {
+    window.open(url);
+  }
+
   return (
     <>
       <DevSiteSeo
@@ -271,6 +275,17 @@ const QuickstartsPage = ({ data, location }) => {
                   >{`(${count})`}</span>
                 </Button>
               ))}
+            </FormControl>
+            <FormControl>
+              <Label htmlFor="quickstartCategory">Can build QuickStart</Label>
+                <Button
+                  type="button"
+                  key={RESERVED_QUICKSTART_IDS.BUILD_YOUR_OWN_QUICKSTART}
+                  onClick={() => buildYourOwn(QUICKSTARTS_REPO)}
+                  variant={Button.VARIANT.OUTLINE}
+                >
+                  Build your own
+                </Button>
             </FormControl>
           </div>
         </aside>
@@ -539,17 +554,6 @@ const QuickstartsPage = ({ data, location }) => {
               `};
             `}
           >
-            <PackTile
-              id={RESERVED_QUICKSTART_IDS.BUILD_YOUR_OWN_QUICKSTART}
-              css={css`
-                background-color: var(--tertiary-background-color);
-              `}
-              href={QUICKSTARTS_REPO}
-              view={view}
-              logoUrl={BUILD_YOUR_OWN}
-              title="Build your own quickstart"
-              summary="Can't find a quickstart with what you need? Check out our README and build your own."
-            />
             {filteredQuickstarts.map((pack) => (
               <PackTile
                 key={pack.id}

--- a/src/pages/instant-observability.js
+++ b/src/pages/instant-observability.js
@@ -282,7 +282,7 @@ const QuickstartsPage = ({ data, location }) => {
                   type="button"
                   key={RESERVED_QUICKSTART_IDS.BUILD_YOUR_OWN_QUICKSTART}
                   onClick={() => buildYourOwn(QUICKSTARTS_REPO)}
-                  variant={Button.VARIANT.OUTLINE}
+                  variant={Button.VARIANT.PRIMARY}
                 >
                   Build your own
                 </Button>


### PR DESCRIPTION
## Description

JIRA ticket ID: https://newrelic.atlassian.net/browse/CXPUI-5

Removed the "Build your own" tile from the right list.
Applied "Build your own" button on the left menu.

## Reviewer Notes

If there are links or steps needed to test this work, add them here.

## Related Issue(s) / Ticket(s)

If there are any related [GitHub Issues](https://github.com/newrelic/developer-website/issues) or JIRA tickets, add links to them here.
* [issue]()

## Screenshot(s)
OLD:
![image](https://user-images.githubusercontent.com/99316285/153184233-7313e234-40c7-45e7-9f10-b32410d7d53d.png)

NEW:
![image](https://user-images.githubusercontent.com/99316285/153184261-8722a247-e7c9-4f2b-8abc-e952e50dfc1e.png)

## Use Conventional Commits

Please help the maintainers by leveraging the following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
standards in your pull request title and commit messages.

## Use `chore`

* for minor changes / additions / corrections to content.
* for minor changes / additions / corrections to images.
* for minor non-functional changes / additions to github actions, github templates, package or config updates, etc

```bash
git commit -m "chore: adjusting config and content"
```

## Use `fix`

* for minor functional corrections to code.

```bash
git commit -m "fix: typo and prop error in the code of conduct"
```

## Use `feat`

* for major functional changes or additions to code.

```bash
git commit -m "feat(media): creating a video landing page"
```
