### PR TITLE
WIP: test out splat redirects

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -30,30 +30,6 @@ exports.createSchemaCustomization = ({ actions }) => {
   createTypes(typeDefs);
 };
 
-// TODO: This can be thrown away once we've fully migrated. For now, its just a container for all the work of redirecting to the new domain of IO.
-const createRedirectsForNewIoDomain = (createRedirect, allQuickstarts) => {
-  createRedirect({
-    fromPath: '/instant-observability/',
-    toPath: 'https://www.newrelic.com/instant-observability',
-    redirectInBrowser: true,
-    isPermanent: true,
-  });
-
-  allQuickstarts.edges.forEach(({ node }) => {
-    const {
-      fields: { slug },
-      id,
-    } = node;
-
-    createRedirect({
-      fromPath: path.join(slug, '/'),
-      toPath: `https://www.newrelic.com${path.join(slug, '/')}`,
-      redirectInBrowser: true,
-      isPermanent: true,
-    });
-  });
-};
-
 exports.createPages = async ({ actions, graphql, reporter }) => {
   const { createPage, createRedirect } = actions;
 
@@ -116,22 +92,20 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     return;
   }
 
-  const {
-    allMdx,
-    allNewRelicSdkComponent,
-    allNewRelicSdkApi,
-    allQuickstarts,
-  } = result.data;
-
-  //createRedirectsForNewIoDomain(createRedirect, allQuickstarts);
+  const { allMdx, allNewRelicSdkComponent, allNewRelicSdkApi } = result.data;
 
   createRedirect({
     fromPath: `/instant-observability/`,
     toPath: `https://newrelic.com/instant-observability/`,
+    redirectInBrowser: false,
+    permanent: true,
   });
+
   createRedirect({
     fromPath: `/instant-observability/*`,
     toPath: `https://newrelic.com/instant-observability/*`,
+    redirectInBrowser: false,
+    permanent: true,
   });
 
   allMdx.edges.forEach(({ node }) => {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -123,7 +123,16 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     allQuickstarts,
   } = result.data;
 
-  createRedirectsForNewIoDomain(createRedirect, allQuickstarts);
+  //createRedirectsForNewIoDomain(createRedirect, allQuickstarts);
+
+  createRedirect({
+    fromPath: `/instant-observability/`,
+    toPath: `https://newrelic.com/instant-observability/`,
+  });
+  createRedirect({
+    fromPath: `/instant-observability/*`,
+    toPath: `https://newrelic.com/instant-observability/*`,
+  });
 
   allMdx.edges.forEach(({ node }) => {
     const {


### PR DESCRIPTION
## Description

Quick PR to demonstrate splat redirects.

Notice that `<preview url>/instant-observability/` redirects to `newrelic.com/instant-observability`.
But `<preview url>/instant-observability/apache/ad5affab-545a-4355-ad48-cfd66e2fbf00/` does not redirect to `newrelic.com/instant-observability/apache/ad5affab-545a-4355-ad48-cfd66e2fbf00/`