### PR TITLE
fix: update node version for change-log

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           # semantic-release requires >= 14
-          node-version: 14
+          node-version: 16
 
       # deletes node_modules, install dependencies, does NOT update lockfile
       - name: Install Dependencies


### PR DESCRIPTION
change-log check was failing going to `main` needed version 16 of node
