### PR TITLE
URL updates for I/O site

### DIFF
--- a/src/data/nav.yml
+++ b/src/data/nav.yml
@@ -534,7 +534,7 @@
           url: '/all-things-open'
 - title: Instant Observability
   icon: fe-box
-  url: '/instant-observability'
+  url: 'https://newrelic.com/instant-observability'
 - title: Nerd Bytes
   icon: nr-nerd-bytes
   url: '/nerd-bytes'

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -85,7 +85,7 @@ const IndexPage = ({ data, pageContext, location }) => {
                 <Button
                   as={Link}
                   variant={Button.VARIANT.PRIMARY}
-                  to="/instant-observability"
+                  to="https://newrelic.com/instant-observability"
                   instrumentation={{
                     navInteractionType: 'getQuickstartsButtonClick',
                   }}


### PR DESCRIPTION
Getting hardcoded urls that redirect to the new I/O site changed to the actual url.  This was throwing a 404 error when trying to click on these buttons in prod.