### PR TITLE
Remove the event page from navigation

### DIFF
--- a/src/data/nav.yml
+++ b/src/data/nav.yml
@@ -50,23 +50,23 @@
     - title: Automatically instrument your application with OpenTelemetry
       url: '/collect-data/opentelemetry'
       pages:
-          - title: Set up your lab environment
-            url: '/collect-data/opentelemetry/set-up-env'
-          - title: Instrument your app with Open Telemetry
-            url: '/collect-data/opentelemetry/instrument'
-          - title: View your OpenTelemetry data in New Relic
-            url: '/collect-data/opentelemetry/view'
+        - title: Set up your lab environment
+          url: '/collect-data/opentelemetry/set-up-env'
+        - title: Instrument your app with Open Telemetry
+          url: '/collect-data/opentelemetry/instrument'
+        - title: View your OpenTelemetry data in New Relic
+          url: '/collect-data/opentelemetry/view'
     - title: Manually instrument your application with OpenTelemetry
       url: '/collect-data/opentelemetry-manual'
       pages:
-          - title: Set up your lab environment
-            url: '/collect-data/opentelemetry-manual/set-up-env'
-          - title: Instrument your app with Open Telemetry
-            url: '/collect-data/opentelemetry-manual/instrument'
-          - title: View your OpenTelemetry data in New Relic
-            url: '/collect-data/opentelemetry-manual/view'
-          - title: Send a custom span event
-            url: '/collect-data/opentelemetry-manual/custom-span-event'
+        - title: Set up your lab environment
+          url: '/collect-data/opentelemetry-manual/set-up-env'
+        - title: Instrument your app with Open Telemetry
+          url: '/collect-data/opentelemetry-manual/instrument'
+        - title: View your OpenTelemetry data in New Relic
+          url: '/collect-data/opentelemetry-manual/view'
+        - title: Send a custom span event
+          url: '/collect-data/opentelemetry-manual/custom-span-event'
 - title: Automate workflows
   icon: nr-automation
   url: '/automate-workflows'
@@ -597,18 +597,6 @@
               url: '/apis/nerdlet'
             - title: ngql
               url: '/apis/ngql'
-- title: Developer events
-  icon: nr-event
-  url: '/developer-events'
-  pages:
-    - title: FutureHack 2021
-      url: '/futurehack-2021'
-    - title: Past events
-      pages:
-        - title: Kubecon & CloudNativeCon
-          url: '/kubecon-europe-2020'
-        - title: All things open
-          url: '/all-things-open'
 - title: Instant Observability
   icon: fe-box
   url: 'https://newrelic.com/instant-observability'


### PR DESCRIPTION
## Description

We deleted events page from developers navigation  because it is outdated, if we will have any updates we can just restore that to nav.

## Reviewer Notes

If there are links or steps needed to test this work, add them here.

## Related Issue(s) / Ticket(s)

* [Deprecate the events page](https://github.com/newrelic/developer-website/issues/1891)

## Screenshot(s)

If relevant, add screenshots here.

## Use Conventional Commits

Please help the maintainers by leveraging the following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
standards in your pull request title and commit messages.

## Use `chore`

* for minor changes / additions / corrections to content.
* for minor changes / additions / corrections to images.
* for minor non-functional changes / additions to github actions, github templates, package or config updates, etc

```bash
git commit -m "chore: adjusting config and content"
```

## Use `fix`

* for minor functional corrections to code.

```bash
git commit -m "fix: typo and prop error in the code of conduct"
```

## Use `feat`

* for major functional changes or additions to code.

```bash
git commit -m "feat(media): creating a video landing page"
```
