### PR TITLE
fix: update link to conventional commit in docs

### DIFF
--- a/src/markdown-pages/contribute-to-quickstarts/build-a-quickstart/create-quickstart.mdx
+++ b/src/markdown-pages/contribute-to-quickstarts/build-a-quickstart/create-quickstart.mdx
@@ -445,7 +445,7 @@ Here's how your final _flashdb_ quickstart folder should look like.
 ## Contribute quickstart to GitHub
 
 Your quickstart is now ready to be published. You're going to commit your changes back to GitHub where it will be reviewed by New Relic.
-Follow the [conventional commit syntax](https://github.com/newrelic/newrelic-observability-packs/blob/alerts-doc-update/CONTRIBUTING.md#using-conventional-commits) for New Relic to commit your changes.
+Follow the [conventional commit syntax](https://github.com/newrelic/developer-website/blob/main/CONTRIBUTING.md#using-conventional-commits) for New Relic to commit your changes.
 
 ```bash
 git add -A


### PR DESCRIPTION
## Description

Fixing link to conventional commits in developer contribution docs. 
https://github.com/newrelic/developer-website/blob/main/CONTRIBUTING.md#using-conventional-commits

## Use Conventional Commits

Please help the maintainers by leveraging the following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
standards in your pull request title and commit messages.

## Use `chore`

* for minor changes / additions / corrections to content.
* for minor changes / additions / corrections to images.
* for minor non-functional changes / additions to github actions, github templates, package or config updates, etc

```bash
git commit -m "chore: adjusting config and content"
```

## Use `fix`

* for minor functional corrections to code.

```bash
git commit -m "fix: typo and prop error in the code of conduct"
```

## Use `feat`

* for major functional changes or additions to code.

```bash
git commit -m "feat(media): creating a video landing page"
```
