### PR TITLE
Fix broken build in instrument.mdx

### DIFF
--- a/src/markdown-pages/collect-data/opentelemetry/instrument.mdx
+++ b/src/markdown-pages/collect-data/opentelemetry/instrument.mdx
@@ -291,11 +291,14 @@ builder.Services.AddOpenTelemetryMetrics(meterProviderBuilder =>
         .AddAspNetCoreInstrumentation();
 
     meterProviderBuilder
-        .AddOtlpExporter(options =>
+        .AddOtlpExporter((options, metricReaderOptions) =>
         {
             options.Endpoint = new Uri($"{Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT")}");
             options.Headers = $"api-key={Environment.GetEnvironmentVariable("NR_LICENSE_KEY")}";
-            options.AggregationTemporality = AggregationTemporality.Delta;
+    
+            // New Relic requires the exporter to use delta aggregation temporality.
+            // The OTLP exporter defaults to using cumulative aggregation temporality.
+            metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
         });
 });
 


### PR DESCRIPTION
## Description

The way that the OTLP library for .NET handles `AggregationTemporality` has been changed. We need to reference a different value (see https://github.com/newrelic/newrelic-opentelemetry-examples/blob/main/dotnet/aspnetcore/Program.cs#L68)

Fixes https://github.com/newrelic/developer-website/issues/2154

## Reviewer Notes

Tested by stepping through the tutorial. Builds and sends metrics as described including traces/spans.

## Related Issue(s) / Ticket(s)

* https://github.com/newrelic/developer-website/issues/2154