### PR TITLE
[chore] Update links to Pulumi, Pulumi Service

### DIFF
--- a/src/markdown-pages/automate-workflows/get-started-pulumi.mdx
+++ b/src/markdown-pages/automate-workflows/get-started-pulumi.mdx
@@ -21,7 +21,7 @@ tags:
 
 <Intro>
 
-[Pulumi](https://www.pulumi.com/docs/) is an open-source infrastructure-as-code tool that lets you use general-purpose programming languages like TypeScript, Python, Go, and others to build, deploy, and manage cloud infrastructure. With Pulumi, you can manage cloud resources of all kinds, including New Relic dashboards and alerts.
+[Pulumi](https://www.pulumi.com/) is an open-source infrastructure-as-code tool that lets you use general-purpose programming languages like TypeScript, Python, Go, and others to build, deploy, and manage cloud infrastructure. With Pulumi, you can manage cloud resources of all kinds, including New Relic dashboards and alerts.
 
 In this guide, you'll learn how to set up New Relic alerts with Pulumi, TypeScript, and Node.js.
 
@@ -120,7 +120,7 @@ pulumi new aws-typescript
 
 <Callout variant="course" title="Sign in to Pulumi">
 
-If this is your first time running Pulumi, you'll be prompted to sign in to the Pulumi Service, Pulumi's default [state-management backend](https://www.pulumi.com/docs/intro/concepts/state/). The Pulumi Service is free for individual use, and self-managed options are also available. See the [Pulumi documentation](https://www.pulumi.com/docs/intro/concepts/state/) for details.
+If this is your first time running Pulumi, you'll be prompted to sign in to the [Pulumi Service](https://app.pulumi.com/), Pulumi's default [state-management backend](https://www.pulumi.com/docs/intro/concepts/state/). The Pulumi Service is free for individual use, and self-managed options are also available. See the [Pulumi documentation](https://www.pulumi.com/docs/intro/concepts/state/) for details.
 
 </Callout>
 

--- a/src/markdown-pages/pulumi/get-started-pulumi.mdx
+++ b/src/markdown-pages/pulumi/get-started-pulumi.mdx
@@ -21,7 +21,7 @@ tags:
 
 <Intro>
 
-[Pulumi](https://www.pulumi.com/docs/) is an open-source infrastructure-as-code tool that lets you use general-purpose programming languages like TypeScript, Python, Go, and others to build, deploy, and manage cloud infrastructure. With Pulumi, you can manage cloud resources of all kinds, including New Relic dashboards and alerts.
+[Pulumi](https://www.pulumi.com/) is an open-source infrastructure-as-code tool that lets you use general-purpose programming languages like TypeScript, Python, Go, and others to build, deploy, and manage cloud infrastructure. With Pulumi, you can manage cloud resources of all kinds, including New Relic dashboards and alerts.
 
 In this guide, you'll learn how to set up New Relic alerts with Pulumi, TypeScript, and Node.js.
 
@@ -120,7 +120,7 @@ pulumi new aws-typescript
 
 <Callout variant="course" title="Sign in to Pulumi">
 
-If this is your first time running Pulumi, you'll be prompted to sign in to the Pulumi Service, Pulumi's default [state-management backend](https://www.pulumi.com/docs/intro/concepts/state/). The Pulumi Service is free for individual use, and self-managed options are also available. See the [Pulumi documentation](https://www.pulumi.com/docs/intro/concepts/state/) for details.
+If this is your first time running Pulumi, you'll be prompted to sign in to the [Pulumi Service](https://app.pulumi.com/), Pulumi's default [state-management backend](https://www.pulumi.com/docs/intro/concepts/state/). The Pulumi Service is free for individual use, and self-managed options are also available. See the [Pulumi documentation](https://www.pulumi.com/docs/intro/concepts/state/) for details.
 
 </Callout>
 


### PR DESCRIPTION
## Description

This change just updates a couple of links in the Pulumi documentation -- one to point to the Pulumi home page instead of docs (a better link for more general info), the other to link to the Pulumi Service (easier access for the those who are interested).

## Reviewer Notes

None.

## Related Issue(s) / Ticket(s)

Closes https://github.com/pulumi/devrel-team/issues/110.

## Screenshot(s)

None.
