### PR TITLE
Remove 'new relic one'

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -28,7 +28,7 @@ What questions do you think we should answer? What, if any, existing documentati
 
 ### What type of documentation change are you suggesting?
 
-Is this a New Relic educational guide or technical specifications of the New Relic One platform?
+Is this a New Relic educational guide or technical specifications of the New Relic platform?
 
 ### Motivation
 

--- a/COMPONENT_GUIDE.md
+++ b/COMPONENT_GUIDE.md
@@ -422,7 +422,7 @@ You can hide any content with this component, including other components. This a
 <HideWhenEmbedded>
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic app from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Install and configure the New Relic One CLI_](/build-apps/ab-test/install-nr1), before starting this one.
 
@@ -436,7 +436,7 @@ Other text ...
 ## Normal Embed
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic app from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Install and configure the New Relic One CLI_](/build-apps/ab-test/install-nr1), before starting this one.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@
       - [Adding new components](#adding-new-components)
     - [Step 3: Add any new APIs or components to the navigation](#step-3-add-any-new-apis-or-components-to-the-navigation)
   - [Updating Developer terms](#updating-developer-terms)
-    - [Developer terms in New Relic One](#developer-terms-in-new-relic-one)
+    - [Developer terms in New Relic](#developer-terms-in-new-relic-one)
     - [Developer terms tips](#developer-terms-tips)
     - [Developer terms testing](#developer-terms-testing)
 
@@ -191,7 +191,7 @@ when creating documentation. Refer to our [Component Guide](COMPONENT_GUIDE.md) 
 
 ## Technical reference contribution guidelines
 
-Technical reference pages are detailed technical specifications of the New Relic One platform and it's components.
+Technical reference pages are detailed technical specifications of the New Relic platform and its components.
 
 ## Editing existing pages
 
@@ -466,9 +466,9 @@ pandoc devterms.docx -o devterms.md
 
 4. Start the process of updating the terms.
 
-### Developer terms in New Relic One
+### Developer terms in New Relic
 
-The developer terms can be accepted in [New Relic One](https://one.newrelic.com) in the Developer Center which is accessible when a user clicks on
+The developer terms can be accepted in the [New Relic platform](https://one.newrelic.com) in the Developer Center which is accessible when a user clicks on
 `Build your own app`.
 
 - The Developer Center functionality is located in an internal Github Enterprise repository:  `wanda/developer-center`.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -77,7 +77,7 @@ The New Relic Developer Experience Team uses [Github](https://github.com/) and [
 
 ### Technical references
 
-Technical reference pages are detailed technical specifications of the New Relic One platform and it's components.
+Technical reference pages are detailed technical specifications of the New Relic platform and itss components.
 
 ### Guides
 
@@ -431,7 +431,7 @@ If a language keyword is omitted, the type will show as TEXT (as shown above)
 
 Proper nouns should use correct capitalization when possible. Below is a list of words as they should appear in pages.
 
-- New Relic One
+- New Relic 
 - GraphQL
 - NerdGraph
 - Nerdpack

--- a/sites.yml
+++ b/sites.yml
@@ -4,7 +4,7 @@
   source_url: https://github.com/newrelic/developer-website
   description:
     The world’s best engineering teams rely on New Relic to visualize,
-    analyze and troubleshoot their software. New Relic One is the most powerful
+    analyze and troubleshoot their software. New Relic is the most powerful
     cloud-based observability platform built to help companies create more perfect software.
   categories:
     - Data

--- a/src/data/nav.yml
+++ b/src/data/nav.yml
@@ -162,7 +162,7 @@
       url: '/build-apps/add-time-picker-guide'
     - title: Add the NerdGraphQuery component to an app
       url: '/build-apps/add-nerdgraphquery-guide'
-    - title: Add tables to your New Relic One application
+    - title: Add tables to your New Relic application
       url: '/build-apps/howto-use-nrone-table-components'
     - title: Add, query, and mutate data using NerdStorage
       url: '/build-apps/add-query-mutate-data-nerdstorage'
@@ -183,7 +183,7 @@
           url: '/build-apps/ab-test/install-nr1'
         - title: Create a Nerdpack
           url: '/build-apps/ab-test/create-nerdpack'
-        - title: Serve your New Relic One application
+        - title: Serve your New Relic application
           url: '/build-apps/ab-test/serve-app'
         - title: Add chart components to your A/B test application
           url: '/build-apps/ab-test/add-charts'
@@ -225,9 +225,9 @@
           url: '/build-apps/ab-test/navigation'
         - title: Describe your app for the catalog
           url: '/build-apps/ab-test/catalog'
-        - title: Publish your New Relic One application
+        - title: Publish your New Relic application
           url: '/build-apps/ab-test/publish'
-        - title: Subscribe to your New Relic One application
+        - title: Subscribe to your New Relic application
           url: '/build-apps/ab-test/subscribe'
     - title: See all open source apps
       url: https://opensource.newrelic.com/nerdpacks/

--- a/src/markdown-pages/ab-test/index.mdx
+++ b/src/markdown-pages/ab-test/index.mdx
@@ -10,19 +10,19 @@ Imagine you've developed a website and instrumented it with New Relic's Browser 
 
 ![A/B test example](../../images/ab-test/ab-test.png)
 
-For this task, you could create a New Relic One application, using React, the New Relic One software development kit, and the limitless power of modern web technologies.
+For this task, you could create a New Relic application, using React, the New Relic One software development kit, and the limitless power of modern web technologies.
 
-New Relic One applications are built with one of web development's most popular JavaScript libraries: React. Because you have freedom when writing React code, you can customize your app logic, design your own components, or take advantage of the abundance of open source component libraries. So, for your A/B test app, if you want to write custom logic to end the test based on results, you can do so.
+New Relic applications are built with one of web development's most popular JavaScript libraries: React. Because you have freedom when writing React code, you can customize your app logic, design your own components, or take advantage of the abundance of open source component libraries. So, for your A/B test app, if you want to write custom logic to end the test based on results, you can do so.
 
-The New Relic One software development kit (SDK) allows you to create, serve, publish, and deploy applications to New Relic One. It also provides a host of React components for gathering data, presenting information, handling user interactions, and more. You use components like `Button` and `Dropdown` to create an interactive experience that looks and feels native to New Relic. You use `Table` and `Chart` components to display data from your New Relic account or elsewhere. When building your A/B test application, you'd use the SDK's `NrqlQuery` component to fetch Browser data from your account.
+The New Relic One software development kit (SDK) allows you to create, serve, publish, and deploy applications to the New Relic platform. It also provides a host of React components for gathering data, presenting information, handling user interactions, and more. You use components like `Button` and `Dropdown` to create an interactive experience that looks and feels native to New Relic. You use `Table` and `Chart` components to display data from your New Relic account or elsewhere. When building your A/B test application, you'd use the SDK's `NrqlQuery` component to fetch Browser data from your account.
 
-With custom React code, SDK components, and the wide world of open source libraries, you can create your A/B test application in New Relic One. But before you create one for yourself, you might want to check the app catalog to see if someone has beaten you to it! If the catalog already had an app for that, you could add it to your account with a couple clicks, another benefit of creating apps in New Relic One.
+With custom React code, SDK components, and the wide world of open source libraries, you can create your A/B test application in New Relic. But before you create one for yourself, you might want to check the app catalog to see if someone has beaten you to it! If the catalog already had an app for that, you could add it to your account with a couple clicks, another benefit of creating apps in New Relic.
 
-Throughout this course, you’re going to build a real-world New Relic One application for running and managing A/B tests. You’ll visualize Browser data for your competing designs, see historical data from past tests, and even choose a winning design and end the test, all from your New Relic One application! But before you get into the weeds of building charts and making http requests, you need to learn what New Relic One applications are made of.
+Throughout this course, you’re going to build a real-world New Relic application for running and managing A/B tests. You’ll visualize Browser data for your competing designs, see historical data from past tests, and even choose a winning design and end the test, all from your New Relic application! But before you get into the weeds of building charts and making http requests, you need to learn what New Relic applications are made of.
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the first lesson: [_Spin up your demo services_](/build-apps/ab-test/demo-setup).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the first lesson: [_Spin up your demo services_](/build-apps/ab-test/demo-setup).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/add-charts.mdx
+++ b/src/markdown-pages/build-apps/ab-test/add-charts.mdx
@@ -8,15 +8,15 @@ description: 'Add chart components to your A/B test application'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Serve your New Relic One application_](/build-apps/ab-test/serve-app), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Serve your New Relic application_](/build-apps/ab-test/serve-app), before starting this one.
 
 </Callout>
 
 </HideWhenEmbedded>
 
-The New Relic One application that you're building throughout this course allows developers to A/B test their websites. To run a successful A/B test, site owners need to be able to analyze the results. Without knowing how each design performs, how will developers determine which design to use?
+The New Relic application that you're building throughout this course allows developers to A/B test their websites. To run a successful A/B test, site owners need to be able to analyze the results. Without knowing how each design performs, how will developers determine which design to use?
 
 Here is a mockup for the A/B test application you're building:
 
@@ -30,7 +30,7 @@ You’ll refer back to this mockup many times throughout this course. It shows y
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add your first chart_](/build-apps/ab-test/first-chart).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Add your first chart_](/build-apps/ab-test/first-chart).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/add-ui.mdx
+++ b/src/markdown-pages/build-apps/ab-test/add-ui.mdx
@@ -8,7 +8,7 @@ description: 'Add user interface components to your application'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add a chart group_](/build-apps/ab-test/chart-group), before starting this one.
 
@@ -28,7 +28,7 @@ In the next lesson, you arrange your charts to look like they do in your design 
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add a grid_](/build-apps/ab-test/grid).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. When you're ready, continue on to the next lesson: [_Add a grid_](/build-apps/ab-test/grid).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/catalog.mdx
+++ b/src/markdown-pages/build-apps/ab-test/catalog.mdx
@@ -9,7 +9,7 @@ duration: 5
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add navigation to your nerdlet_](/build-apps/ab-test/navigation), before starting this one.
 
@@ -17,7 +17,7 @@ Each lesson in the course builds upon the last, so make sure you've completed th
 
 </HideWhenEmbedded>
 
-In the last lesson, you finished the A/B test application you've been building throughout this course. Now, it's time to prepare it for publication. When you publish your app to the New Relic One catalog, users can view it and subscribe to it. You can help your users by showing and telling them what the app does, how to use it, and more.
+In the last lesson, you finished the A/B test application you've been building throughout this course. Now, it's time to prepare it for publication. When you publish your app to the New Relic app catalog, users can view it and subscribe to it. You can help your users by showing and telling them what the app does, how to use it, and more.
 
 ## Create catalog information
 
@@ -152,7 +152,7 @@ In the next lesson, you'll publish your app, submit your catalog information, an
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Publish your New Relic One application_](/build-apps/ab-test/publish).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Publish your New Relic application_](/build-apps/ab-test/publish).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/chart-group.mdx
+++ b/src/markdown-pages/build-apps/ab-test/chart-group.mdx
@@ -8,7 +8,7 @@ description: 'Add a chart group'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add tables_](/build-apps/ab-test/table-charts), before starting this one.
 
@@ -208,7 +208,7 @@ View your changes in [New Relic](https://one.newrelic.com?nerdpacks=local):
 
 Here, you see the `LineChart` components synchronized in your application.
 
-When you're finished, stop serving your New Relic One application by pressing `CTRL+C` in your local server's terminal window.
+When you're finished, stop serving your New Relic application by pressing `CTRL+C` in your local server's terminal window.
 
 <Callout variant="tip">
 
@@ -228,7 +228,7 @@ Now your application is filled with charts, but it doesn't look great. The chart
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add user interface components to your application_](/build-apps/ab-test/add-ui).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. When you're ready, continue on to the next lesson: [_Add user interface components to your application_](/build-apps/ab-test/add-ui).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/chart-headings.mdx
+++ b/src/markdown-pages/build-apps/ab-test/chart-headings.mdx
@@ -8,7 +8,7 @@ description: 'Add chart headings'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add a grid_](/build-apps/ab-test/grid), before starting this one.
 
@@ -327,7 +327,7 @@ View your changes in [New Relic](https://one.newrelic.com?nerdpacks=local):
 
 Here, you see that your charts have descriptive headings.
 
-When you're finished, stop serving your New Relic One application by pressing `CTRL+C` in your local server's terminal window.
+When you're finished, stop serving your New Relic application by pressing `CTRL+C` in your local server's terminal window.
 
 </Step>
 
@@ -339,7 +339,7 @@ Well done! You've created all the charts that are laid out in your design guide.
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add version descriptions_](/build-apps/ab-test/version-descriptions).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Add version descriptions_](/build-apps/ab-test/version-descriptions).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/confirmation-modal.mdx
+++ b/src/markdown-pages/build-apps/ab-test/confirmation-modal.mdx
@@ -8,7 +8,7 @@ description: 'Present an end test confirmation modal'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Persist the selected version_](/build-apps/ab-test/persist-version), before starting this one.
 
@@ -1084,7 +1084,7 @@ Select "Version B" from the menu. Click **End test** to see "Version B" in the c
 
 ![The modal shows your selected version](../../../images/ab-test/selected-version-in-modal.png)
 
-When you're finished, stop serving your New Relic One application by pressing `CTRL+C` in your local server's terminal window.
+When you're finished, stop serving your New Relic application by pressing `CTRL+C` in your local server's terminal window.
 
 </Step>
 
@@ -1096,7 +1096,7 @@ Congratulations! You've done a lot of work and it shows in the usefulness of you
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add NrqlQuery components to your nerdlet_](/build-apps/ab-test/nrql).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Add NrqlQuery components to your nerdlet_](/build-apps/ab-test/nrql).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/create-nerdpack.mdx
+++ b/src/markdown-pages/build-apps/ab-test/create-nerdpack.mdx
@@ -8,7 +8,7 @@ description: 'Create a Nerdpack'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Install and configure the New Relic One CLI_](/build-apps/ab-test/install-nr1), before starting this one.
 
@@ -16,7 +16,7 @@ Each lesson in the course builds upon the last, so make sure you've completed th
 
 </HideWhenEmbedded>
 
-A Nerdpack is a package that contains all the files that make up a New Relic One application or visualization. Nerdpacks include files for metadata, Nerdlets, assets, and more. To create a Nerdpack, use the New Relic One CLI:
+A Nerdpack is a package that contains all the files that make up a New Relic application or visualization. Nerdpacks include files for metadata, Nerdlets, assets, and more. To create a Nerdpack, use the New Relic One CLI:
 
 <>
 
@@ -45,7 +45,7 @@ _package.json_, _package-lock.json_, and *node_modules* are important for runnin
 
 ### Metadata file
 
-_nr1.json_ is the Nerdpack's metadata file, containing a schema type, unique identifier, a display name, and a description. Since you’re building a New Relic One application for running and analyzing A/B tests, update the package's `displayName` to "A/B Test" and set the description to "A/B test your application using New Relic One":
+_nr1.json_ is the Nerdpack's metadata file, containing a schema type, unique identifier, a display name, and a description. Since you’re building a New Relic application for running and analyzing A/B tests, update the package's `displayName` to "A/B Test" and set the description to "A/B test your application using New Relic One":
 
 ```json fileName=nr1.json
 {
@@ -62,7 +62,7 @@ Next, look at the _launchers_ and _nerdlets_ subdirectories.
 
 ## Launchers
 
-_launchers_ is a directory because you can create multiple launchers for your New Relic One application. `nr1 create` only created one launcher for your Nerdpack and called it "ab-test-launcher". Inside its directory, there are two files:
+_launchers_ is a directory because you can create multiple launchers for your New Relic application. `nr1 create` only created one launcher for your Nerdpack and called it "ab-test-launcher". Inside its directory, there are two files:
 
 - _icon.png_ is an image that represents the application
 - _nr1.json_ is the launcher's metadata file
@@ -83,7 +83,7 @@ Notice that the launcher has a `rootNerdletId`. This identifies the Nerdlet that
 
 ## Nerdlets
 
-The _nerdlets_ directory contains all the Nerdlets that make up your New Relic One application. Since `ab-test-nerdlet` is the only Nerdlet in this Nerdpack, there is only one subdirectory. In _nerdlets/ab-test-nerdlet_, there are three files:
+The _nerdlets_ directory contains all the Nerdlets that make up your New Relic application. Since `ab-test-nerdlet` is the only Nerdlet in this Nerdpack, there is only one subdirectory. In _nerdlets/ab-test-nerdlet_, there are three files:
 
 - _index.js_ is the JavaScript file that contains your Nerdlet component
 - _styles.scss_ holds the Sass stylesheet for your Nerdlet
@@ -143,7 +143,7 @@ In the next lesson, you'll learn how to serve your Nerdpack locally and see your
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Serve your New Relic One application_](/build-apps/ab-test/serve-app).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Serve your New Relic application_](/build-apps/ab-test/serve-app).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/demo-setup.mdx
+++ b/src/markdown-pages/build-apps/ab-test/demo-setup.mdx
@@ -9,13 +9,13 @@ duration: 5
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 </Callout>
 
 </HideWhenEmbedded>
 
-Before you build your New Relic One application, you need to spin up your demo services. This coursework depends on two important services:
+Before you build your New Relic application, you need to spin up your demo services. This coursework depends on two important services:
 
 - A web service that shows a newsletter signup form. The form's heading text alternates between two versions because you're performing an A/B test to determine which text leads to more high-quality subscriptions.
 - A simulator service that sends steady traffic to the website so that you don't have to manually generate data
@@ -106,13 +106,13 @@ docker-compose down
 
 </Steps>
 
-Now you're ready to build your New Relic One application!
+Now you're ready to build your New Relic application!
 
 <HideWhenEmbedded>
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Install and configure the New Relic One CLI_](/build-apps/ab-test/install-nr1).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Install and configure the New Relic One CLI_](/build-apps/ab-test/install-nr1).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/end-test.mdx
+++ b/src/markdown-pages/build-apps/ab-test/end-test.mdx
@@ -8,7 +8,7 @@ description: 'Add a section to end your test'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add version descriptions_](/build-apps/ab-test/version-descriptions), before starting this one.
 
@@ -279,7 +279,7 @@ Go to [https://one.newrelic.com?nerdpacks=local](https://one.newrelic.com?nerdpa
 
 ![First version of your end test section](../../../images/ab-test/end-test-section-v1.png)
 
-When you're finished, stop serving your New Relic One application by pressing `CTRL+C` in your local server's terminal window.
+When you're finished, stop serving your New Relic application by pressing `CTRL+C` in your local server's terminal window.
 
 </Step>
 
@@ -291,7 +291,7 @@ However, you need to make a few improvements to this code. When you select a ver
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Persist the selected version_](/build-apps/ab-test/persist-version).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Persist the selected version_](/build-apps/ab-test/persist-version).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/first-chart.mdx
+++ b/src/markdown-pages/build-apps/ab-test/first-chart.mdx
@@ -8,7 +8,7 @@ description: 'Add your first chart'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add chart components to your A/B test application_](/build-apps/ab-test/add-charts), before starting this one.
 
@@ -170,19 +170,19 @@ View your changes in [New Relic](https://one.newrelic.com?nerdpacks=local):
 
 Here, you see the `LineChart` displayed in your application.
 
-When you're finished, stop serving your New Relic One application by pressing `CTRL+C` in your local server's terminal window.
+When you're finished, stop serving your New Relic application by pressing `CTRL+C` in your local server's terminal window.
 
 </Step>
 
 </Steps>
 
-In seven steps, you’ve breathed life into your New Relic One application. Instead of a bland “Hello world” message, your application now shows a colorful line chart with two mocked data series. These data series represent server-side traffic for each of the competing designs in your demo website. In the next lesson, you’ll build on this foundation by creating another chart type.
+In seven steps, you’ve breathed life into your New Relic application. Instead of a bland “Hello world” message, your application now shows a colorful line chart with two mocked data series. These data series represent server-side traffic for each of the competing designs in your demo website. In the next lesson, you’ll build on this foundation by creating another chart type.
 
 <HideWhenEmbedded>
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add pie charts_](/build-apps/ab-test/pie-charts).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. When you're ready, continue on to the next lesson: [_Add pie charts_](/build-apps/ab-test/pie-charts).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/grid.mdx
+++ b/src/markdown-pages/build-apps/ab-test/grid.mdx
@@ -8,7 +8,7 @@ description: 'Add a grid'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add user interface components to your application_](/build-apps/ab-test/add-ui), before starting this one.
 
@@ -138,7 +138,7 @@ View your changes in [New Relic](https://one.newrelic.com?nerdpacks=local):
 
 Here, you see your charts styled and arranged in a grid.
 
-When you're finished, stop serving your New Relic One application by pressing `CTRL+C` in your local server's terminal window.
+When you're finished, stop serving your New Relic application by pressing `CTRL+C` in your local server's terminal window.
 
 </Step>
 
@@ -150,7 +150,7 @@ In just six steps, you significantly improved the readability and usability of y
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add chart headings_](/build-apps/ab-test/chart-headings).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. When you're ready, continue on to the next lesson: [_Add chart headings_](/build-apps/ab-test/chart-headings).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/install-nr1.mdx
+++ b/src/markdown-pages/build-apps/ab-test/install-nr1.mdx
@@ -8,7 +8,7 @@ description: 'Install and configure the New Relic One CLI'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Spin up your demo services_](/build-apps/ab-test/demo-setup), before starting this one.
 
@@ -74,7 +74,7 @@ nr1 update
 
 <Callout variant="tip">
 
-It’s important to distinguish between the `newrelic` CLI and the `nr1` CLI. `newrelic` is for managing entities in your New Relic account. `nr1` is for managing New Relic One applications.
+It’s important to distinguish between the `newrelic` CLI and the `nr1` CLI. `newrelic` is for managing entities in your New Relic account. `nr1` is for managing New Relic applications.
 
 </Callout>
 
@@ -146,7 +146,7 @@ Now, you can exit the **Build on New Relic** quick start. You’re ready to buil
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Create a Nerdpack_](/build-apps/ab-test/create-nerdpack).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Create a Nerdpack_](/build-apps/ab-test/create-nerdpack).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/navigation.mdx
+++ b/src/markdown-pages/build-apps/ab-test/navigation.mdx
@@ -9,7 +9,7 @@ duration: 10
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add PlatformStateContext to your nerdlet_](/build-apps/ab-test/platform-state-context), before starting this one.
 
@@ -426,7 +426,7 @@ Go to [https://one.newrelic.com?nerdpacks=local](https://one.newrelic.com?nerdpa
 
 Click **App performance**:
 
-![Your New Relic One application with an App performance button](../../../images/ab-test/performance-button.png)
+![Your New Relic application with an App performance button](../../../images/ab-test/performance-button.png)
 
 Now you see the stacked entity:
 
@@ -448,17 +448,17 @@ If something doesn't work, use your browser's debug tools to try to identify the
 
 </Steps>
 
-Congratulations! You're finished writing all the code you'll write for your New Relic One A/B test application. Now, you have an application reporting New Relic data from your demo service that is running an A/B test. You've created several charts, buttons, and other UI elements. And you've organized your components into a readable and usable view.
+Congratulations! You're finished writing all the code you'll write for your New Relic A/B test application. Now, you have an application reporting New Relic data from your demo service that is running an A/B test. You've created several charts, buttons, and other UI elements. And you've organized your components into a readable and usable view.
 
-On top of the visuals, you've supplied data to your charts from multiple data sources in and outside of New Relic. You've created some backend functionality which utilizes your New Relic One application's own data store. You've also utilized the platform APIs for interacting with platform UI and showing a stacked entity view.
+On top of the visuals, you've supplied data to your charts from multiple data sources in and outside of New Relic. You've created some backend functionality which utilizes your New Relic application's own data store. You've also utilized the platform APIs for interacting with platform UI and showing a stacked entity view.
 
-You've really accomplished a lot throughout this course, so far. There are only a few things left to do! First, is to learn how to publish and subscribe to your New Relic One application so that it can run on our platform instead of your own local server. Second, is to learn how to deal with some common issues you might see in New Relic One application development.
+You've really accomplished a lot throughout this course, so far. There are only a few things left to do! First, is to learn how to publish and subscribe to your New Relic application so that it can run on our platform instead of your own local server. Second, is to learn how to deal with some common issues you might see in New Relic application development.
 
 <HideWhenEmbedded>
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Describe your app for the catalog_](/build-apps/ab-test/catalog).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Describe your app for the catalog_](/build-apps/ab-test/catalog).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/nerdstorage.mdx
+++ b/src/markdown-pages/build-apps/ab-test/nerdstorage.mdx
@@ -8,7 +8,7 @@ description: 'Access NerdStorage from your Nerdlet'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Customize NRQL data_](/build-apps/ab-test/nrql-customizations), before starting this one.
 
@@ -774,7 +774,7 @@ If something doesn't work, use your browser's debug tools to try to identify the
 
 </Callout>
 
-When you're finished, stop serving your New Relic One application by pressing `CTRL+C` in your local server's terminal window.
+When you're finished, stop serving your New Relic application by pressing `CTRL+C` in your local server's terminal window.
 
 </Step>
 
@@ -784,7 +784,7 @@ Great work! You now have experience using the NerdStorage query and mutation com
 
 **Total cancellations per version** is different from the other charts in your A/B test application. Because New Relic knows nothing about how many users unsubscribe to your newsletter, you need to request that information from an external source. For the purposes of this course, we've created an external data service that provides fake newsletter cancellation data for you to consume in your application. This mock service lives at https://api.nerdsletter.net/cancellations.
 
-New Relic One applications are React applications, which means that you can use React and Javascript facilities to gather data not only from New Relic, but any external service. In a later lesson, you'll learn how to look beyond New Relic for data that will inform you of how your software is helping you achieve your business objectives. But before you learn that, you need to know something about our mock data service: it requires an Authorization header!
+New Relic applications are React applications, which means that you can use React and Javascript facilities to gather data not only from New Relic, but any external service. In a later lesson, you'll learn how to look beyond New Relic for data that will inform you of how your software is helping you achieve your business objectives. But before you learn that, you need to know something about our mock data service: it requires an Authorization header!
 
 In this lesson, you learned how to use NerdStorage to query and mutate data in your application's own data store. While NerdStorage is a great place for many categories of data, it's not appropriate for sensitive data, like a token you would pass in an Authorization header to an external service. For that, you'd use NerdStorageVault.
 
@@ -792,7 +792,7 @@ In this lesson, you learned how to use NerdStorage to query and mutate data in y
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Access NerdStorageVault from your nerdlet_](/build-apps/ab-test/nerdstoragevault).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Access NerdStorageVault from your nerdlet_](/build-apps/ab-test/nerdstoragevault).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/nerdstoragevault.mdx
+++ b/src/markdown-pages/build-apps/ab-test/nerdstoragevault.mdx
@@ -8,7 +8,7 @@ description: 'Access NerdStorageVault from your Nerdlet'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Access NerdStorage from your nerdlet_](/build-apps/ab-test/nerdstorage), before starting this one.
 
@@ -16,7 +16,7 @@ Each lesson in the course builds upon the last, so make sure you've completed th
 
 </HideWhenEmbedded>
 
-Throughout this course, you're building a New Relic One application that gathers telemetry data from a demo web service that's running an A/B test on a newsletter signup form. The purpose of your New Relic One application is to help you understand how design changes impact the number of high quality newsletter subscriptions your service gets. The business objective, to increase your service's high quality newsletter subscriptions, relies primarily on three key pieces of information:
+Throughout this course, you're building a New Relic application that gathers telemetry data from a demo web service that's running an A/B test on a newsletter signup form. The purpose of your New Relic application is to help you understand how design changes impact the number of high quality newsletter subscriptions your service gets. The business objective, to increase your service's high quality newsletter subscriptions, relies primarily on three key pieces of information:
 
 - Number of page views per version
 - Number of subscriptions per version
@@ -261,7 +261,7 @@ Unlike `NerdStorage`, which has query and mutation components for your convenien
 
 <Callout variant="important">
 
-It's important to remember that `NerdStorageVault` is limited to the user scope. Any other users of your New Relic One application will have their own `NerdStorageVault` data. This means that even other users on your account will need to enter their token separately.
+It's important to remember that `NerdStorageVault` is limited to the user scope. Any other users of your New Relic application will have their own `NerdStorageVault` data. This means that even other users on your account will need to enter their token separately.
 
 </Callout>
 
@@ -1035,7 +1035,7 @@ Go to [https://one.newrelic.com?nerdpacks=local](https://one.newrelic.com?nerdpa
 
 ![API token prompt](../../../images/ab-test/api-token-prompt.png)
 
-When you visit your application for the first time, the prompt is automatically revealed. Enter "ABC123" in the `TextField`, as that's the token that the third-party service expects. Once you submit your token and your Nerdlet hides the prompt, click **Update API token** at the bottom of your New Relic One application to reveal it again:
+When you visit your application for the first time, the prompt is automatically revealed. Enter "ABC123" in the `TextField`, as that's the token that the third-party service expects. Once you submit your token and your Nerdlet hides the prompt, click **Update API token** at the bottom of your New Relic application to reveal it again:
 
 ![Update API token button](../../../images/ab-test/update-api-token-button.png)
 
@@ -1327,21 +1327,21 @@ If something doesn't work, use your browser's debug tools to try to identify the
 
 </Callout>
 
-When you're finished, stop serving your New Relic One application by pressing `CTRL+C` in your local server's terminal window.
+When you're finished, stop serving your New Relic application by pressing `CTRL+C` in your local server's terminal window.
 
 </Step>
 
 </Steps>
 
-Now you know how to use `NerdGraphQuery` and `NerdGraphMutation` to manage data in `NerdStorageVault`! Remember, use `NerdStorage` for your New Relic One application's non-sensitive data and `NerdStorageVault` for the sensitive stuff like tokens, passwords, and other secrets. As a bonus, you created a way to manage your token in `NerdStorageVault` from the user interface. You also passed the token to your `TotalCancellations` component for later use.
+Now you know how to use `NerdGraphQuery` and `NerdGraphMutation` to manage data in `NerdStorageVault`! Remember, use `NerdStorage` for your New Relic application's non-sensitive data and `NerdStorageVault` for the sensitive stuff like tokens, passwords, and other secrets. As a bonus, you created a way to manage your token in `NerdStorageVault` from the user interface. You also passed the token to your `TotalCancellations` component for later use.
 
-Whether it's been with `NrqlQuery`, `AccountStorageQuery`, `AccountStorageMutation`, `NerdGraphQuery`, or `NerdGraphMutation`, you've learned several ways to interact with New Relic data in your New Relic One application. But New Relic One applications aren't just another way to show New Relic data. The purpose of New Relic One applications is to show you how your software is helping you meet your business objectives. Sometimes, New Relic data is all you need to make that happen, but other times you need to look beyond New Relic for data to fill in the gaps.
+Whether it's been with `NrqlQuery`, `AccountStorageQuery`, `AccountStorageMutation`, `NerdGraphQuery`, or `NerdGraphMutation`, you've learned several ways to interact with New Relic data in your New Relic application. But New Relic applications aren't just another way to show New Relic data. The purpose of New Relic applications is to show you how your software is helping you meet your business objectives. Sometimes, New Relic data is all you need to make that happen, but other times you need to look beyond New Relic for data to fill in the gaps.
 
 <HideWhenEmbedded>
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Fetch data from a third-party service_](/build-apps/ab-test/third-party-service).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Fetch data from a third-party service_](/build-apps/ab-test/third-party-service).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/nrql-customizations.mdx
+++ b/src/markdown-pages/build-apps/ab-test/nrql-customizations.mdx
@@ -8,7 +8,7 @@ description: 'Customize NRQL data'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add NrqlQuery components to your nerdlet_](/build-apps/ab-test/nrql), before starting this one.
 
@@ -16,7 +16,7 @@ Each lesson in the course builds upon the last, so make sure you've completed th
 
 </HideWhenEmbedded>
 
-In this series, you're creating a New Relic One application, or NR1 app for short, that shows A/B test data in a variety of charts. Most of the charts need to show data that comes from a demo service you spun up at the beginning of this series. To refresh your memory on what you're building, review your design guide:
+In this series, you're creating a New Relic application, or NR1 app for short, that shows A/B test data in a variety of charts. Most of the charts need to show data that comes from a demo service you spun up at the beginning of this series. To refresh your memory on what you're building, review your design guide:
 
 ![Design guide for chart components](../../../images/ab-test/charts-design-guide.png)
 
@@ -504,7 +504,7 @@ By similar logic, page view data should go to `state.tableData.data[1].count`.
 
 With your Nerdpack served locally, [view your application](https://one.newrelic.com?nerdpacks=local) to see your charts serving real data:
 
-![Your New Relic One application showing real subscription and page view data](../../../images/ab-test/real-table-chart-data.png)
+![Your New Relic application showing real subscription and page view data](../../../images/ab-test/real-table-chart-data.png)
 
 <Callout variant="tip">
 
@@ -533,7 +533,7 @@ Unfortunately, your demo application doesn't create custom New Relic events when
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Access NerdStorage from your nerdlet_](/build-apps/ab-test/nerdstorage).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Access NerdStorage from your nerdlet_](/build-apps/ab-test/nerdstorage).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/nrql.mdx
+++ b/src/markdown-pages/build-apps/ab-test/nrql.mdx
@@ -8,7 +8,7 @@ description: 'Add NrqlQuery components to your Nerdlet'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Present an end test confirmation modal_](/build-apps/ab-test/confirmation-modal), before starting this one.
 
@@ -16,7 +16,7 @@ Each lesson in the course builds upon the last, so make sure you've completed th
 
 </HideWhenEmbedded>
 
-In this series, you're building a full-fledged New Relic One application that ingests data from a demo service that's running an A/B test. The app shows the A/B test data in interesting ways so that you'll ultimately be able to choose whether Version A or Version B is more effective at accomplishing your business goal: to increase high-quality newsletter subscriptions.
+In this series, you're building a full-fledged New Relic application that ingests data from a demo service that's running an A/B test. The app shows the A/B test data in interesting ways so that you'll ultimately be able to choose whether Version A or Version B is more effective at accomplishing your business goal: to increase high-quality newsletter subscriptions.
 
 In past tutorials, you created charts to visualize your data, and you organized those charts so you can use and understand them. You also created a form in your app for ending your test once you're confident in the most effective version. Until now, though, you can't gauge which version is more effective because your charts have been showing mock data, such as:
 
@@ -98,7 +98,7 @@ The Data explorer presents two options for filtering and sorting your data:
 - User interface (UI) selections like the one you've just made
 - New Relic Query Language (NRQL)
 
-The UI is useful for quickly filtering data, and it doesn't require you to know NRQL. For your New Relic One application, however, you need to use NRQL queries.
+The UI is useful for quickly filtering data, and it doesn't require you to know NRQL. For your New Relic application, however, you need to use NRQL queries.
 
 Click the **NRQL** query to navigate to the Query builder:
 
@@ -116,7 +116,7 @@ Before you begin integrating New Relic data in your NR1 app, consult your design
 
 ![Design guide for chart components](../../../images/ab-test/charts-design-guide.png)
 
-Your New Relic One application has eight charts in total, including line charts, pie charts, and table charts. Each of these charts currently shows mock data, but they need to show real data to be useful. First, focus on querying data for the topmost chart: **Newsletter subscriptions per version**.
+Your New Relic application has eight charts in total, including line charts, pie charts, and table charts. Each of these charts currently shows mock data, but they need to show real data to be useful. First, focus on querying data for the topmost chart: **Newsletter subscriptions per version**.
 
 With the query you've built in the Data explorer, you already have the data you need for this chart:
 
@@ -261,7 +261,7 @@ nr1 nerdpack:serve
 
 Go to [https://one.newrelic.com?nerdpacks=local](https://one.newrelic.com?nerdpacks=local), and view your application under **Apps > Your apps**:
 
-![Your New Relic One application showing real subscription data](../../../images/ab-test/nrql-query-chart.png)
+![Your New Relic application showing real subscription data](../../../images/ab-test/nrql-query-chart.png)
 
 **Newsletter subscriptions by version** now shows real data from New Relic's database rather than the mock data you defined before. Notice that your chart pulls data when your application loads, but does not continue pulling data while the application is open. You can fix this by adding another prop.
 
@@ -393,7 +393,7 @@ You don't need the `TIMESERIES` clause because the pie chart only shows numerica
 
 With your Nerdpack served locally, [view your application](https://one.newrelic.com?nerdpacks=local) to see your charts serving real data:
 
-![Your New Relic One application showing real subscription totals data](../../../images/ab-test/nr1-app-subscription-totals.png)
+![Your New Relic application showing real subscription totals data](../../../images/ab-test/nr1-app-subscription-totals.png)
 
 **Total subscriptions per version** now shows all-time subscription totals from both versions of your demo application.
 
@@ -481,7 +481,7 @@ Make sure you replace `<YOUR NEW RELIC ACCOUNT ID>` with your actual New Relic [
 
 With your Nerdpack served locally, [view your application](https://one.newrelic.com?nerdpacks=local) to see your charts serving real data:
 
-![Your New Relic One application showing real page view data](../../../images/ab-test/page-views-charts.png)
+![Your New Relic application showing real page view data](../../../images/ab-test/page-views-charts.png)
 
 In these new queries, you fetch `pageView` custom events instead of `subscription` events. You also use a `WHERE` clause to filter to a particular `page_version` rather than a `FACET` to group by `page_version`.
 
@@ -512,7 +512,7 @@ You have to handle these differently than you did for the charts you've been dea
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Customize NRQL data_](/build-apps/ab-test/nrql-customizations).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Customize NRQL data_](/build-apps/ab-test/nrql-customizations).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/persist-version.mdx
+++ b/src/markdown-pages/build-apps/ab-test/persist-version.mdx
@@ -8,7 +8,7 @@ description: 'Persist the selected version'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add a section to end your test_](/build-apps/ab-test/end-test), before starting this one.
 
@@ -509,7 +509,7 @@ Go to [https://one.newrelic.com?nerdpacks=local](https://one.newrelic.com?nerdpa
 
 ![Your choice persists in the version selector](../../../images/ab-test/persist-selected-version-final.png)
 
-When you're finished, stop serving your New Relic One application by pressing `CTRL+C` in your local server's terminal window.
+When you're finished, stop serving your New Relic application by pressing `CTRL+C` in your local server's terminal window.
 
 </Step>
 
@@ -521,7 +521,7 @@ Voila! When you select a new version as the winner of the A/B test, that version
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Present an end test confirmation modal_](/build-apps/ab-test/confirmation-modal).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Present an end test confirmation modal_](/build-apps/ab-test/confirmation-modal).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/pie-charts.mdx
+++ b/src/markdown-pages/build-apps/ab-test/pie-charts.mdx
@@ -8,7 +8,7 @@ description: 'Add pie charts'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add your first chart_](/build-apps/ab-test/first-chart), before starting this one.
 
@@ -211,7 +211,7 @@ View your changes in [New Relic](https://one.newrelic.com?nerdpacks=local):
 
 Here, you see the `PieChart` components displayed in your application.
 
-When you're finished, stop serving your New Relic One application by pressing `CTRL+C` in your local server's terminal window.
+When you're finished, stop serving your New Relic application by pressing `CTRL+C` in your local server's terminal window.
 
 </Step>
 
@@ -223,7 +223,7 @@ Your application is starting to take shape. You’ve created a line chart and tw
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add tables_](/build-apps/ab-test/table-charts).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. When you're ready, continue on to the next lesson: [_Add tables_](/build-apps/ab-test/table-charts).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/platform-state-context.mdx
+++ b/src/markdown-pages/build-apps/ab-test/platform-state-context.mdx
@@ -9,7 +9,7 @@ duration: 10
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Fetch data from a third-party service_](/build-apps/ab-test/third-party-service), before starting this one.
 
@@ -17,7 +17,7 @@ Each lesson in the course builds upon the last, so make sure you've completed th
 
 </HideWhenEmbedded>
 
-In this course, you're building a New Relic One application. This application shows telemetry data from a demo service that is running an A/B test so that it can reveal that data in charts, like a dashboard. Your New Relic application is different than a dashboard, however, because it does more than show New Relic data. It pulls external data, provides UI components and functionality, and even has its own small data stores. The purpose of this New Relic application is to present context so you can better understand the A/B test results and how those results tie in to your business objectives.
+In this course, you're building a New Relic application. This application shows telemetry data from a demo service that is running an A/B test so that it can reveal that data in charts, like a dashboard. Your New Relic application is different than a dashboard, however, because it does more than show New Relic data. It pulls external data, provides UI components and functionality, and even has its own small data stores. The purpose of this New Relic application is to present context so you can better understand the A/B test results and how those results tie in to your business objectives.
 
 So far, you've built all your charts, organized them for improved usability, provided them with real data, and more. There are some final improvements you can make, using Platform API components. In this lesson, you learn how to use values in the New Relic platform state.
 
@@ -211,17 +211,17 @@ nr1 nerdpack:serve
 
 [View your application](https://one.newrelic.com?nerdpacks=local):
 
-![Your New Relic One application using platform state](../../../images/ab-test/platform-state.png)
+![Your New Relic application using platform state](../../../images/ab-test/platform-state.png)
 
 Your `NrqlQuery` now uses the platform state's `timeRange`, but your chart probably still shows the last 30 minutes. Why? Where does the `timeRange` in platform state come from?
 
 The time picker sits on the right side of your application's navigation bar:
 
-![Your New Relic One application's time picker](../../../images/ab-test/time-picker.png)
+![Your New Relic application's time picker](../../../images/ab-test/time-picker.png)
 
 Change this value and see your chart update:
 
-![Your New Relic One application showing the last 6 hours of data](../../../images/ab-test/time-picked.png)
+![Your New Relic application showing the last 6 hours of data](../../../images/ab-test/time-picked.png)
 
 <Callout variant="tip">
 
@@ -290,7 +290,7 @@ Make sure you replace `<YOUR NEW RELIC ACCOUNT ID>` with your actual New Relic [
 
 </Callout>
 
-Of all the charts in your New Relic One application, these three charts are the ones that should update with the time picker. The others, **Total subscriptions per version**, **Total cancellations per version**, **Version A - Page views vs. subscriptions**, **Version B - Page views vs. subscriptions**, show total values over time. So, hardcoding their `SINCE` clauses to `7 DAYS AGO` makes sense, as this is a reasonable time period for the purposes of this course.
+Of all the charts in your New Relic application, these three charts are the ones that should update with the time picker. The others, **Total subscriptions per version**, **Total cancellations per version**, **Version A - Page views vs. subscriptions**, **Version B - Page views vs. subscriptions**, show total values over time. So, hardcoding their `SINCE` clauses to `7 DAYS AGO` makes sense, as this is a reasonable time period for the purposes of this course.
 
 </Step>
 
@@ -312,7 +312,7 @@ If something doesn't work, use your browser's debug tools to try to identify the
 
 </Callout>
 
-When you're finished, stop serving your New Relic One application by pressing `CTRL+C` in your local server's terminal window.
+When you're finished, stop serving your New Relic application by pressing `CTRL+C` in your local server's terminal window.
 
 </Step>
 
@@ -326,7 +326,7 @@ The Platform API components offer a lot more functionality, too, including the a
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add navigation to your nerdlet_](/build-apps/ab-test/navigation).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Add navigation to your nerdlet_](/build-apps/ab-test/navigation).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/publish.mdx
+++ b/src/markdown-pages/build-apps/ab-test/publish.mdx
@@ -1,14 +1,14 @@
 ---
-title: 'Publish your New Relic One application'
+title: 'Publish your New Relic application'
 template: 'GuideTemplate'
-description: 'Publish your New Relic One application'
+description: 'Publish your New Relic application'
 ---
 
 <HideWhenEmbedded>
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Describe your app for the catalog_](/build-apps/ab-test/catalog), before starting this one.
 
@@ -71,7 +71,7 @@ nr1 nerdpack:uuid -gf
 ```
 </>
 
-The UUID is used to identify your app in the New Relic One app registry. Because you're using code that we developed for this course, an application with the existing UUID already exists in the registry. By generating your own, you're now able to publish this application.
+The UUID is used to identify your app in the New Relic app registry. Because you're using code that we developed for this course, an application with the existing UUID already exists in the registry. By generating your own, you're now able to publish this application.
 
 <Callout variant="tip" title="Technical detail">
 
@@ -109,7 +109,7 @@ In _package.json_, set `version` to `1.0.0`:
 ```
 </>
 
-New Relic One uses [semantic versioning](https://semver.org) and, under this convention, `1.0.0` signals the first major release. Now, you're ready to publish!
+New Relic uses [semantic versioning](https://semver.org) and, under this convention, `1.0.0` signals the first major release. Now, you're ready to publish!
 
 </Step>
 
@@ -121,7 +121,7 @@ Replace all instances of `<YOUR NEW RELIC ACCOUNT ID>` and `<YOUR NEW RELIC ENTI
 
 <Step>
 
-Publish your New Relic One application:
+Publish your New Relic application:
 
 <>
 
@@ -373,7 +373,7 @@ Now that your app is published and its metadata is submitted, you can subscribe 
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Subscribe to your New Relic One application_](/build-apps/ab-test/subscribe).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Subscribe to your New Relic application_](/build-apps/ab-test/subscribe).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/serve-app.mdx
+++ b/src/markdown-pages/build-apps/ab-test/serve-app.mdx
@@ -1,14 +1,14 @@
 ---
-title: 'Serve your New Relic One application'
+title: 'Serve your New Relic application'
 template: 'GuideTemplate'
-description: 'Locally serve your New Relic One application'
+description: 'Locally serve your New Relic application'
 ---
 
 <HideWhenEmbedded>
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Create a Nerdpack_](/build-apps/ab-test/create-nerdpack), before starting this one.
 
@@ -16,7 +16,7 @@ Each lesson in the course builds upon the last, so make sure you've completed th
 
 </HideWhenEmbedded>
 
-When you build a New Relic One application, it's valuable to view it on the platform. This helps you design, implement, and debug your application in the environment it will eventually be published to. With `nr1`, you can launch a development server that hosts your application so that New Relic One can present it to you.
+When you build a New Relic application, it's valuable to view it on the platform. This helps you design, implement, and debug your application in the environment it will eventually be published to. With `nr1`, you can launch a development server that hosts your application so that New Relic can present it to you.
 
 <Steps>
 
@@ -31,7 +31,7 @@ nr1 nerdpack:serve
 ```
 </>
 
-When the Nerdpack has succeeded building and your application is ready to view, you'll see a message with a link to New Relic One:
+When the Nerdpack has succeeded building and your application is ready to view, you'll see a message with a link to New Relic:
 
 <>
 
@@ -53,7 +53,7 @@ If you don't see your application on the New Relic platform, make sure you've in
 
 <Step>
 
-Navigate to the provided url. From the home page, select **Apps** to view New Relic One applications:
+Navigate to the provided url. From the home page, select **Apps** to view New Relic applications:
 
 ![Navigate to the applications view in New Relic](../../../images/build-an-app/nav-to-apps.png)
 
@@ -83,7 +83,7 @@ Here, you've seen how to access your Nerdlet from a launcher. If you want your N
 
 </Steps>
 
-Congratulations, you've served your first New Relic One application!
+Congratulations, you've served your first New Relic application!
 
 Notice, in the command's output, that the server reloads when you change files in your Nerdpack. Give it a try by updating _nerdlets/ab-test-nerdlet/index.js_:
 
@@ -105,7 +105,7 @@ Your app automatically refreshes to show the new heading:
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add chart components to your A/B test application_](/build-apps/ab-test/add-charts).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Add chart components to your A/B test application_](/build-apps/ab-test/add-charts).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/subscribe.mdx
+++ b/src/markdown-pages/build-apps/ab-test/subscribe.mdx
@@ -1,16 +1,16 @@
 ---
-title: 'Subscribe to your New Relic One application'
+title: 'Subscribe to your New Relic application'
 template: 'GuideTemplate'
-description: 'Subscribe to your New Relic One application'
+description: 'Subscribe to your New Relic application'
 ---
 
 <HideWhenEmbedded>
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
-Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Publish your New Relic One application_](/build-apps/ab-test/publish), before starting this one.
+Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Publish your New Relic application_](/build-apps/ab-test/publish), before starting this one.
 
 </Callout>
 
@@ -66,7 +66,7 @@ Here, you only had one version tag to subscribe to. In other projects, you may h
 
 <Callout variant="tip" title="Technical detail">
 
-Notice that the web UI uses the term "channel" instead of "tag". This is a relic of an older version of New Relic One apps. With later versions of `nr1`, we've moved toward "tags" terminology. Eventually, the UI will also use "tags".
+Notice that the web UI uses the term "channel" instead of "tag". This is a relic of an older version of New Relic apps. With later versions of `nr1`, we've moved toward "tags" terminology. Eventually, the UI will also use "tags".
 
 </Callout>
 
@@ -130,17 +130,17 @@ If you navigate back to **Apps**, you will see your app is no longer under **You
 
 </Steps>
 
-Throughout this course, you've built a New Relic One application from the ground up. You've used the `nr1` CLI to create a Nerdpack, launcher, and Nerdlet. You've used many components from the SDK. You've learned how to publish, tag, subscribe, and unsubscribe to and from apps in the Instant Observability catalog. You've also learned how to submit metadata to the catalog.
+Throughout this course, you've built a New Relic application from the ground up. You've used the `nr1` CLI to create a Nerdpack, launcher, and Nerdlet. You've used many components from the SDK. You've learned how to publish, tag, subscribe, and unsubscribe to and from apps in the Instant Observability catalog. You've also learned how to submit metadata to the catalog.
 
 ## Next steps
 
-Now that you know how to build a New Relic One application, you can read the SDK documentation to learn more about all the components you can use to create apps for your own purposes.
+Now that you know how to build a New Relic application, you can read the SDK documentation to learn more about all the components you can use to create apps for your own purposes.
 
 <HideWhenEmbedded>
 
 <Callout variant="course">
 
-This lesson is the final part of a course that teaches you how to build a New Relic One application from the ground up. Congratulations on making it to the end!
+This lesson is the final part of a course that teaches you how to build a New Relic application from the ground up. Congratulations on making it to the end!
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/table-charts.mdx
+++ b/src/markdown-pages/build-apps/ab-test/table-charts.mdx
@@ -8,7 +8,7 @@ description: 'Add tables'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add pie charts_](/build-apps/ab-test/pie-charts), before starting this one.
 
@@ -169,7 +169,7 @@ View your changes in [New Relic](https://one.newrelic.com?nerdpacks=local):
 
 Here, you see the `TableChart` components displayed in your application.
 
-When you're finished, stop serving your New Relic One application by pressing `CTRL+C` in your local server's terminal window.
+When you're finished, stop serving your New Relic application by pressing `CTRL+C` in your local server's terminal window.
 
 </Step>
 
@@ -196,7 +196,7 @@ Each chart you’ll add to your application throughout this course is unique in 
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. When you're ready, continue on to the next lesson: [_Add a chart group_](/build-apps/ab-test/chart-group).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. When you're ready, continue on to the next lesson: [_Add a chart group_](/build-apps/ab-test/chart-group).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/third-party-service.mdx
+++ b/src/markdown-pages/build-apps/ab-test/third-party-service.mdx
@@ -8,7 +8,7 @@ description: 'Fetch data from a third-party service'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Access NerdStorageVault from your nerdlet_](/build-apps/ab-test/nerdstoragevault), before starting this one.
 
@@ -16,7 +16,7 @@ Each lesson in the course builds upon the last, so make sure you've completed th
 
 </HideWhenEmbedded>
 
-In previous lessons, you learned of a third-party service that you can use to fetch mock cancellation data for the **Total cancellations per version** chart in your New Relic One application. Even though the data in this service is fake, the real value of this lesson is learning how you can use third party services to supply data to your New Relic One application.
+In previous lessons, you learned of a third-party service that you can use to fetch mock cancellation data for the **Total cancellations per version** chart in your New Relic application. Even though the data in this service is fake, the real value of this lesson is learning how you can use third party services to supply data to your New Relic application.
 
 If you make a request to the mock service with cancellation data (https://api.nerdsletter.net/cancellations) you'll see a response rejecting your request with a message that reads "Unauthorized":
 
@@ -38,7 +38,7 @@ curl https://api.nerdsletter.net/cancellations -H 'Authorization: Bearer ABC123'
 ```
 </>
 
-In the last lesson, you used `NerdGraph` to store this API token in your New Relic One application's `NerdStorageVault` data store. You also passed the token to your `TotalCancellations` component and logged its use to your browser's console. In this lesson, you follow up that log statement with a real request to the Nerdsletter API using your authorization token. Then, you supply the data from that external resource to your **Total cancellations per version** chart.
+In the last lesson, you used `NerdGraph` to store this API token in your New Relic application's `NerdStorageVault` data store. You also passed the token to your `TotalCancellations` component and logged its use to your browser's console. In this lesson, you follow up that log statement with a real request to the Nerdsletter API using your authorization token. Then, you supply the data from that external resource to your **Total cancellations per version** chart.
 
 <Steps>
 
@@ -149,7 +149,7 @@ export default class TotalCancellations extends React.Component {
 ```
 </>
 
-In this code, you initialize `TotalCancellations.state.cancellations` with zero for the y-value in each series instead of the previously hardcoded values. This helps to more realistically represent what the chart should show if your New Relic One app hasn't successfully requested data from the Nerdsletter API. Next, you use Javascript's `fetch()` function to make an HTTP request to the Nerdsletter API. You then pass your token in the request's `Authorization` header. If the request is successful, you update the cancellation data in `TotalCancellations.state` so that that data is reflected in the component's render method.
+In this code, you initialize `TotalCancellations.state.cancellations` with zero for the y-value in each series instead of the previously hardcoded values. This helps to more realistically represent what the chart should show if your New Relic app hasn't successfully requested data from the Nerdsletter API. Next, you use Javascript's `fetch()` function to make an HTTP request to the Nerdsletter API. You then pass your token in the request's `Authorization` header. If the request is successful, you update the cancellation data in `TotalCancellations.state` so that that data is reflected in the component's render method.
 
 </Step>
 
@@ -211,7 +211,7 @@ If something doesn't work, use your browser's debug tools to try to identify the
 
 </Callout>
 
-When you're finished, stop serving your New Relic One application by pressing `CTRL+C` in your local server's terminal window.
+When you're finished, stop serving your New Relic application by pressing `CTRL+C` in your local server's terminal window.
 
 </Step>
 
@@ -223,13 +223,13 @@ Great job! You've come a long way from running `nr1 nerdpack:create` for the fir
 
 You've created eight charts with varying styles and supplied them with dynamic data from multiple sources. You've learned about the New Relic One SDK and used many of its components. You've even gathered data from a third-party service and mixed it seemlessly with your New Relic data to provide a complete look at how the competing versions in your A/B test perform against each other.
 
-From here, there is only one more set of APIs in the New Relic One SDK that you've yet to get your hands on: Platform APIs. These will come in handy in improving the usability of your New Relic One application.
+From here, there is only one more set of APIs in the New Relic One SDK that you've yet to get your hands on: Platform APIs. These will come in handy in improving the usability of your New Relic application.
 
 <HideWhenEmbedded>
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add PlatformStateContext to your nerdlet_](/build-apps/ab-test/platform-state-context).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Add PlatformStateContext to your nerdlet_](/build-apps/ab-test/platform-state-context).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/ab-test/version-descriptions.mdx
+++ b/src/markdown-pages/build-apps/ab-test/version-descriptions.mdx
@@ -8,7 +8,7 @@ description: 'Add version descriptions'
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. If you haven't already, check out the [course introduction](/ab-test).
 
 Each lesson in the course builds upon the last, so make sure you've completed the last lesson, [_Add chart headings_](/build-apps/ab-test/chart-headings), before starting this one.
 
@@ -16,7 +16,7 @@ Each lesson in the course builds upon the last, so make sure you've completed th
 
 </HideWhenEmbedded>
 
-With your charts organized and descriptive headings above each one, your New Relic One application is becoming more usable. In this lesson, you'll continue that trend by creating descriptions for each design version in your A/B test.
+With your charts organized and descriptive headings above each one, your New Relic application is becoming more usable. In this lesson, you'll continue that trend by creating descriptions for each design version in your A/B test.
 
 <Steps>
 
@@ -184,7 +184,7 @@ Go to [https://one.newrelic.com?nerdpacks=local](https://one.newrelic.com?nerdpa
 
 ![Your choice persists in the version selector](../../../images/ab-test/version-descriptions.png)
 
-When you're finished, stop serving your New Relic One application by pressing `CTRL+C` in your local server's terminal window.
+When you're finished, stop serving your New Relic application by pressing `CTRL+C` in your local server's terminal window.
 
 </Step>
 
@@ -196,7 +196,7 @@ Now, you've added descriptions for your competing designs and your charts. In th
 
 <Callout variant="course">
 
-This lesson is part of a course that teaches you how to build a New Relic One application from the ground up. Continue on to the next lesson: [_Add a section to end your test_](/build-apps/ab-test/end-test).
+This lesson is part of a course that teaches you how to build a New Relic application from the ground up. Continue on to the next lesson: [_Add a section to end your test_](/build-apps/ab-test/end-test).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/add-query-mutate-data-nerdstorage.mdx
+++ b/src/markdown-pages/build-apps/add-query-mutate-data-nerdstorage.mdx
@@ -281,4 +281,4 @@ Back inside the application, you should now see both the individual trash button
 
 ## Next steps
 
-Now that you’ve successfully implemented NerdStorage into a New Relic One application, you can store and mutate data connected to your `User`. For more information on the various NerdStorage components, please visit the New Relic developer website [API documentation](/components/user-storage-mutation).
+Now that you’ve successfully implemented NerdStorage into a New Relic application, you can store and mutate data connected to your `User`. For more information on the various NerdStorage components, please visit the New Relic developer website [API documentation](/components/user-storage-mutation).

--- a/src/markdown-pages/build-apps/add-time-picker-guide.mdx
+++ b/src/markdown-pages/build-apps/add-time-picker-guide.mdx
@@ -116,7 +116,7 @@ nr1 nerdpack:serve
 
   <Step>
 
-Once the sample application is successfully served, go to the local version of New Relic One (https://one.newrelic.com/?nerdpacks=local) click **Apps**, and click **Add Time Picker**.
+Once the sample application is successfully served, go to the local version of New Relic (https://one.newrelic.com/?nerdpacks=local) click **Apps**, and click **Add Time Picker**.
 
   </Step>
 
@@ -126,7 +126,7 @@ After launching the **Add Time Picker** application, you see a dashboard that gi
 
 ![Transaction overview application](../../images/time-picker-guide/add-timepicker.png)
 
-By default, the application shows your data within the last 60 minutes. If you toggle the time picker, it doesn't update the charts because the transaction overview application isn't connected to the New Relic One platform. It has no access to the data from the time picker.
+By default, the application shows your data within the last 60 minutes. If you toggle the time picker, it doesn't update the charts because the transaction overview application isn't connected to the New Relic platform. It has no access to the data from the time picker.
 
 In the following sections, you'll add the time picker to the example application and add the time to the queries.
 
@@ -295,11 +295,11 @@ After you complete these steps, your browser console displays something like thi
 
 In your console, you should see some data from the New Relic platform state. Now you're ready to add `timeRange` data to update the charts in the transaction overview application.
 
-This step requires you to import the `timeRangeToNrql` utility method from the New Relic One community library.
+This step requires you to import the `timeRangeToNrql` utility method from the New Relic app community library.
 
 <Callout variant="important">
 
-You can get more details on the New Relic One community library from our [GitHub repo](https://github.com/newrelic/nr1-community).
+You can get more details on the New Relic app community library from our [GitHub repo](https://github.com/newrelic/nr1-community).
 
 </Callout>
 

--- a/src/markdown-pages/build-apps/attach-nerdlet-to-entities.mdx
+++ b/src/markdown-pages/build-apps/attach-nerdlet-to-entities.mdx
@@ -83,7 +83,7 @@ Go to [https://one.newrelic.com/?nerdpacks=local](https://one.newrelic.com/?nerd
 
 <Step>
 
-Under **Your apps**, click your launcher to view your New Relic One application:
+Under **Your apps**, click your launcher to view your New Relic application:
 
 ![Click entity-nerdlet launcher](../../images/build-an-app/entity-nerdlet.png)
 

--- a/src/markdown-pages/build-apps/build-hello-world-app.mdx
+++ b/src/markdown-pages/build-apps/build-hello-world-app.mdx
@@ -6,7 +6,7 @@ description: 'Build a "Hello, World!" app and publish it to New Relic'
 redirects:
   - /build-new-relic-one-applications
 resources:
-  - title: New Relic One VSCode extension
+  - title: New Relic app VSCode extension
     url: https://marketplace.visualstudio.com/items?itemName=new-relic.nr1
   - title: 'Build on New Relic'
     url: https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/build-new-relic-one/new-relic-one-build-your-own-custom-new-relic-one-application

--- a/src/markdown-pages/build-apps/build-react-hooks-app.mdx
+++ b/src/markdown-pages/build-apps/build-react-hooks-app.mdx
@@ -1,13 +1,13 @@
 ---
 duration: 15
-title: 'Build a New Relic One app with React hooks'
+title: 'Build a New Relic app with React hooks'
 template: 'GuideTemplate'
-description: 'Build a simple New Relic One app with React hooks'
+description: 'Build a simple New Relic app with React hooks'
 ---
 
 <Intro>
 
-Starting with version 2.49.1 of our `nr1` CLI, you can build New Relic One applications and custom visualizations with [React hooks](https://reactjs.org/docs/hooks-intro.html). This guide gives some Nerdlet examples of React hooks in action!
+Starting with version 2.49.1 of our `nr1` CLI, you can build New Relic applications and custom visualizations with [React hooks](https://reactjs.org/docs/hooks-intro.html). This guide gives some Nerdlet examples of React hooks in action!
 
 </Intro>
 

--- a/src/markdown-pages/build-apps/howto-use-nrone-table-components.mdx
+++ b/src/markdown-pages/build-apps/howto-use-nrone-table-components.mdx
@@ -1,14 +1,14 @@
 ---
 duration: 30
-title: 'Add tables to your New Relic One application'
+title: 'Add tables to your New Relic application'
 template: 'GuideTemplate'
-description: 'Add a table to your New Relic One app.'
+description: 'Add a table to your New Relic app.'
 promote: true
 tileShorthand:
   title: 'Add a table to your app'
-  description: 'Add a table to your New Relic One app'
+  description: 'Add a table to your New Relic app'
 resources:
-  - title: 'How to use New Relic One table components'
+  - title: 'How to use New Relic app table components'
     url: https://discuss.newrelic.com/t/how-to-use-nr1-table-components/98934
   - title: 'New Relic SDK documentation'
     url: https://developer.newrelic.com/client-side-sdk/index.html
@@ -25,7 +25,7 @@ tags:
 
 Tables are a popular way of displaying data in New Relic applications. For example, with the [query builder](https://docs.newrelic.com/docs/chart-builder/use-chart-builder/get-started/introduction-chart-builder) you can create tables from [NRQL queries](https://docs.newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql).
 
-Whether you need to have more control over tables or you're importing third-party data, you can build your own tables into your New Relic One application.
+Whether you need to have more control over tables or you're importing third-party data, you can build your own tables into your New Relic application.
 
 In this guide, you are going to build a sample table using various New Relic components.
 
@@ -288,6 +288,6 @@ Go back to your application and try hovering over any of the rows: Notice how th
 
 ## Next steps
 
-You've built a table into a New Relic One application, using components to format data automatically and provide contextual actions. Well done!
+You've built a table into a New Relic application, using components to format data automatically and provide contextual actions. Well done!
 
 Keep exploring the `Table` components, their properties, and how to use them, in our [SDK documentation](https://developer.newrelic.com/client-side-sdk/index.html#components/Table).

--- a/src/markdown-pages/build-apps/nr1-deprecations.mdx
+++ b/src/markdown-pages/build-apps/nr1-deprecations.mdx
@@ -4,7 +4,7 @@ template: 'GuideTemplate'
 description: 'Learn how to manage New Relic One SDK deprecations'
 ---
 
-We frequently update the New Relic One SDK. These updates include new features, improvements to existing features, and the deprecation, or removal, of existing features. When we remove a feature, you, as a developer of New Relic One Nerdpacks, need to know because if you don't update your code, it will eventually stop working.
+We frequently update the New Relic One SDK. These updates include new features, improvements to existing features, and the deprecation, or removal, of existing features. When we remove a feature, you, as a developer of New Relic Nerdpacks, need to know because if you don't update your code, it will eventually stop working.
 
 In this guide, you learn:
 
@@ -176,7 +176,7 @@ git push origin
 
 <Step>
 
-[Publish your updated Nerdpack](/build-apps/publish-deploy/publish/) to the New Relic One catalog.
+[Publish your updated Nerdpack](/build-apps/publish-deploy/publish/) to the New Relic app catalog.
 
 </Step>
 

--- a/src/markdown-pages/build-apps/permission-manage-apps.mdx
+++ b/src/markdown-pages/build-apps/permission-manage-apps.mdx
@@ -22,11 +22,27 @@ Understand the requirements for managing and using Nerdpacks in New Relic.
 
 Your ability to manage and use Nerdpacks is affected by your New Relic user's:
 
-- User model (original or New Relic One model)
+- User model (original or newer model)
 - User type
 - Assigned roles
 
-Whether you're on the [original user model](https://docs.newrelic.com/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model/) or the [New Relic One user model](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-user-management/new-relic-one-user-model-understand-user-structure/), review the tables below for a summary of your Nerdpack capabilities.
+Whether you're on the [original user model](https://docs.newrelic.com/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model/) or [our newer user model](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-user-management/new-relic-one-user-model-understand-user-structure/), review the tables below for a summary of your Nerdpack capabilities.
+
+### Newer user model
+
+If you're on [our newer user model](https://docs.newrelic.com/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models), here's how you can interact with Nerdpacks:
+
+| | Basic user | Core or full platform user |
+|---|---|---|
+| Serve Nerdpacks | yes | yes |
+| Publish Nerdpacks | no | yes |
+| Subscribe to Nerdpacks | no | yes |
+| Tag Nerdpacks | no | yes |
+| Use Nerdlets or visualizations created by your accounts | no | yes |
+| Use Nerdlets created by New Relic | no* | yes |
+| Use visualizations created by New Relic | no | yes |
+
+_* There are a few Nerdlets that basic users are allowed to use. See [Basic users](#basic-users-1) for more information._
 
 ### Original user model
 
@@ -44,21 +60,34 @@ If you're on our [original user model](https://docs.newrelic.com/docs/accounts/o
 
 _* There are a few Nerdlets that basic users are allowed to use. See [Basic users](#basic-users) for more information._
 
-### New Relic One user model
 
-If you're on our [New Relic One user model](https://docs.newrelic.com/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models), here's how you can interact with Nerdpacks:
+## Nerdpack permissions: Newer user model
 
-| | Basic user | Core or full platform user |
-|---|---|---|
-| Serve Nerdpacks | yes | yes |
-| Publish Nerdpacks | no | yes |
-| Subscribe to Nerdpacks | no | yes |
-| Tag Nerdpacks | no | yes |
-| Use Nerdlets or visualizations created by your accounts | no | yes |
-| Use Nerdlets created by New Relic | no* | yes |
-| Use visualizations created by New Relic | no | yes |
+Learn the differences between how basic users, full platform users, and core users on [our newer user model](https://docs.newrelic.com/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models) can use and manage Nerdpacks.
 
-_* There are a few Nerdlets that basic users are allowed to use. See [Basic users](#basic-users-1) for more information._
+### Basic users
+
+If you're a basic user on our newer user model, you're limited in your Nerdpack capabilities. You can only create and serve Nerdpacks locally. To publish, tag, subscribe to, and use your Nerdpacks, an admin must upgrade you to a full platform user or core user.
+
+<Callout variant="tip">
+
+If you're a basic user, you generally can't use any Nerdpacks. However, there are some Nerdlets that New Relic maintains that you can use. These are rare and there is currently no way for you to distinguish them in our web interface. And even if you can use a Nerdlet in a Nerdpack, you're never able to use custom visualizations. For this, you must be upgraded to a full platform user or a core user.
+
+</Callout>
+
+### Core users and full platform users
+
+If you're a core user or a full platform user on our newer user model, you either have the **Nerdpacks "modify"** privilege, or you don't.
+
+The **Nerdpacks "modify"** privilege is required to publish, subscribe to, and tag Nerdpacks. So if you don't have the **Nerdpacks "modify"** privilege, you can only create and serve Nerdpacks locally and use Nerdpacks that your accounts have already been subscribed to.
+
+To publish, tag, or subscribe to your Nerdpack, an admin must grant you the **Nerdpacks "modify"** capability.
+
+<Callout variant="tip">
+
+The **Nerdpacks "modify"** capability is included in both the **User** and **Admin** groups, the only groups available by default. So in most cases, you'll have the ability to manage Nerdpacks as a full platform user or a core user. However, if you're a full platform user or a core user assigned to a custom group that doesn't include the **Nerdpacks "modify"** privilege, you won't be able to manage Nerdpacks.
+
+</Callout>
 
 ## Nerdpack permissions: Original user model
 
@@ -86,33 +115,6 @@ To publish, tag, or subscribe to a Nerdpack, an admin must upgrade you to a core
 
 If you're an owner or admin user, you can perform any of the Nerdpack capabilities. You can create, serve, publish, tag, subscribe to, and use any and all Nerdpack items, both Nerdlets and visualizations. This includes Nerdpacks built by New Relic or by one of your accounts.
 
-## Nerdpack permissions: New Relic One user model
-
-Learn the differences between how basic users, full platform users, and core users on our [New Relic One user model](https://docs.newrelic.com/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models) can use and manage Nerdpacks.
-
-### Basic users
-
-If you're a basic user on our New Relic One user model, you're limited in your Nerdpack capabilities. You can only create and serve Nerdpacks locally. To publish, tag, subscribe to, and use your Nerdpacks, an admin must upgrade you to a full platform user or core user.
-
-<Callout variant="tip">
-
-If you're a basic user, you generally can't use any Nerdpacks. However, there are some Nerdlets that New Relic maintains that you can use. These are rare and there is currently no way for you to distinguish them in our web interface. And even if you can use a Nerdlet in a Nerdpack, you're never able to use custom visualizations. For this, you must be upgraded to a full platform user or a core user.
-
-</Callout>
-
-### Core users and full platform users
-
-If you're a core user or a full platform user on the New Relic One user model, you either have the **Nerdpacks "modify"** privilege, or you don't.
-
-The **Nerdpacks "modify"** privilege is required to publish, subscribe to, and tag Nerdpacks. So if you don't have the **Nerdpacks "modify"** privilege, you can only create and serve Nerdpacks locally and use Nerdpacks that your accounts have already been subscribed to.
-
-To publish, tag, or subscribe to your Nerdpack, an admin must grant you the **Nerdpacks "modify"** capability.
-
-<Callout variant="tip">
-
-The **Nerdpacks "modify"** capability is included in both the **User** and **Admin** groups, the only groups available by default. So in most cases, you'll have the ability to manage Nerdpacks as a full platform user or a core user. However, if you're a full platform user or a core user assigned to a custom group that doesn't include the **Nerdpacks "modify"** privilege, you won't be able to manage Nerdpacks.
-
-</Callout>
 
 ## Parent/child account capabilities
 

--- a/src/markdown-pages/build-apps/publish-deploy/publish.mdx
+++ b/src/markdown-pages/build-apps/publish-deploy/publish.mdx
@@ -184,7 +184,7 @@ Navigate to **Add data** in the top navigation bar:
 
 ![Navigate to Add data](../../../images/serve-publish-subscribe/nav-to-io.png)
 
-Whether you published a New Relic One application or a custom visualization, you'll find your project here.
+Whether you published a New Relic application or a custom visualization, you'll find your project here.
 
 </Step>
 

--- a/src/markdown-pages/build-apps/publish-deploy/serve.mdx
+++ b/src/markdown-pages/build-apps/publish-deploy/serve.mdx
@@ -77,7 +77,7 @@ Navigate to **Apps**:
 
 ![Navigate to Apps page](../../../images/serve-publish-subscribe/nav-to-apps.png)
 
-Whether you're creating a New Relic One application or a custom visualization, you'll find your project under **Apps**.
+Whether you're creating a New Relic application or a custom visualization, you'll find your project under **Apps**.
 
 </Step>
 

--- a/src/markdown-pages/build-apps/publish-deploy/tag.mdx
+++ b/src/markdown-pages/build-apps/publish-deploy/tag.mdx
@@ -40,7 +40,7 @@ You need to [publish](/build-apps/publish-deploy/publish) Nerdpacks that you cre
 
 ## Tag a version
 
-After you've published a Nerdpack version to the New Relic One catalog, you can tag it with the `nr1` CLI.
+After you've published a Nerdpack version to the New Relic app catalog, you can tag it with the `nr1` CLI.
 
 <Steps>
 

--- a/src/markdown-pages/build-apps/set-up-dev-env.mdx
+++ b/src/markdown-pages/build-apps/set-up-dev-env.mdx
@@ -42,7 +42,7 @@ To start building, you must have:
 
 ### A note on support
 
-Building a New Relic One application is the same as building any JavaScript/React application. We offer support to help with our building tools ([our CLI](/explore-docs/nr1-cli) and [SDK library](/explore-docs/intro-to-sdk)). However, we don't offer support for basic JavaScript or React coding questions or issues.
+Building a New Relic application is the same as building any JavaScript/React application. We offer support to help with our building tools ([our CLI](/explore-docs/nr1-cli) and [SDK library](/explore-docs/intro-to-sdk)). However, we don't offer support for basic JavaScript or React coding questions or issues.
 
 For common questions and answers about building, see the [Explorers Hub page on building on New Relic](https://discuss.newrelic.com/c/build-on-new-relic).
 
@@ -61,7 +61,7 @@ or the [New Relic VSCode extension pack](https://marketplace.visualstudio.com/it
 
 Download the CLI and API key.
 
-On the [Build New Relic One applications page](https://one.newrelic.com/launcher/developer-center.launcher?pane=eyJuZXJkbGV0SWQiOiJkZXZlbG9wZXItY2VudGVyLmRldmVsb3Blci1jZW50ZXIifQ==), complete the **Quick start** steps.
+On the [Build New Relic applications page](https://one.newrelic.com/launcher/developer-center.launcher?pane=eyJuZXJkbGV0SWQiOiJkZXZlbG9wZXItY2VudGVyLmRldmVsb3Blci1jZW50ZXIifQ==), complete the **Quick start** steps.
 
 These six Quick start steps get you an API key for use with developing apps, and the New Relic One CLI, for building and deploying apps. At the end of the Quick start, you have a project consisting of the following:
 

--- a/src/markdown-pages/explore-docs/custom-viz.mdx
+++ b/src/markdown-pages/explore-docs/custom-viz.mdx
@@ -120,9 +120,9 @@ During development, you can serve your visualization locally. Under **Apps > Cus
 
 ![No local visualizations in dashboards](../../images/custom-viz/local-viz.png)
 
-To do that, you need to publish it to the New Relic One catalog and subscribe to it from your account.
+To do that, you need to publish it to the New Relic app catalog and subscribe to it from your account.
 
-Because custom visualizations are Nerdpack items, you publish and subscribe to them the same way you [publish and subscribe to New Relic One applications](/build-apps/publish-deploy). Once you've done so, you can add your custom visualization to a dashboard:
+Because custom visualizations are Nerdpack items, you publish and subscribe to them the same way you [publish and subscribe to New Relic applications](/build-apps/publish-deploy). Once you've done so, you can add your custom visualization to a dashboard:
 
 ![Add your published visualization to a dashboard](../../images/custom-viz/published-viz.png)
 

--- a/src/markdown-pages/explore-docs/custom-viz/build-visualization.mdx
+++ b/src/markdown-pages/explore-docs/custom-viz/build-visualization.mdx
@@ -30,7 +30,7 @@ In this guide, you learn how to:
 
 - Use the `nr1` CLI to generate a default visualization
 - Run your visualization locally where you can quickly test and iterate
-- Publish your visualization to the New Relic One catalog
+- Publish your visualization to the New Relic app catalog
 - Add your visualization to a dashboard
 
 </Intro>
@@ -492,7 +492,7 @@ Look for a success message in your output:
 [output] {success}✔{normal}  Tagged {purple}5f4c2af8-3b27-40b5-954c-356d1ef88dd0{normal} version {blue}1.0.0{normal} as {blue}STABLE{normal}.
 ```
 
-This means that your Nerdpack was published to the New Relic One catalog that you can find under **Apps**.
+This means that your Nerdpack was published to the New Relic app catalog that you can find under **Apps**.
 
 </Step>
 
@@ -513,7 +513,7 @@ Now, you're subscribed to your Nerdpack and can build an instance of a visualiza
 
 Once again, open the **Apps** page at [New Relic](https://one.newrelic.com):
 
-![Apps navigation is located in the New Relic One top navigation](../../../images/build-an-app/nav-to-apps.png)
+![Apps navigation is located in the New Relic top navigation](../../../images/build-an-app/nav-to-apps.png)
 
 Here, you don't need to use the `?nerdpacks=local` query string because you're looking for a visualization that you've published and subscribed to, rather than one that is locally served.
 

--- a/src/markdown-pages/explore-docs/intro-to-sdk.mdx
+++ b/src/markdown-pages/explore-docs/intro-to-sdk.mdx
@@ -3,7 +3,7 @@ title: 'Intro to New Relic One SDK'
 template: 'GuideTemplate'
 description: 'Intro to New Relic One SDK'
 tileShorthand:
-  title: 'New Relic One component reference'
+  title: 'New Relic app component reference'
   description: 'Reference for all New Relic One SDK components'
 redirects:
   - /build-tools/new-relic-one-applications/intro-to-sdk
@@ -17,7 +17,7 @@ resources:
     url: https://github.com/newrelic?q=layout&type=&language=
 tags:
   - SDK components
-  - New Relic One apps
+  - New Relic apps
   - UI components
   - chart components
   - query and storage components
@@ -26,7 +26,8 @@ tags:
 
 <Intro>
 
-To help you build New Relic One applications, we provide you with the New Relic One SDK.
+To help you build New Relic applications, we provide you with the New Relic One SDK, which is used to build New Relic apps.
+
 Here we give you an introduction to the types of API calls and components in the SDK. The SDK provides everything you need to build your Nerdlets, create visualizations, and fetch New Relic or third-party data.
 
 </Intro>
@@ -95,12 +96,12 @@ We also provide storage for storing small data sets, such as configuration setti
 
 ### Platform APIs
 
-The Platform API components of the SDK enable your application to interact with different parts of the New Relic One platform, by reading and writing state from and to the URL, setting the configuration, etc. They can be divided into these categories:
+The Platform API components of the SDK enable your application to interact with different parts of the New Relic platform, by reading and writing state from and to the URL, setting the configuration, etc. They can be divided into these categories:
 
 - [`PlatformStateContext`](/components/platform-state-context): provides read access to the platform URL state variables.
   Example: `timeRange` in the time picker.
 - [`navigation`](/apis/navigation): an object that allows programmatic manipulation of the navigation
-  in New Relic One. Example: opening a new Nerdlet.
+  in New Relic. Example: opening a new Nerdlet.
 - [`NerdletStateContext`](/components/nerdlet-state-context): provides read access to the Nerdlet URL state variables.
   Example: an `entityGuid` in the [entity explorer](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer-view-performance-across-apps-services-hosts).
 - [`nerdlet`](/apis/nerdlet): allows you to configure your Nerdlet and write to your Nerdlet's URL state.

--- a/src/markdown-pages/explore-docs/nerdpack-file-structure.mdx
+++ b/src/markdown-pages/explore-docs/nerdpack-file-structure.mdx
@@ -20,7 +20,7 @@ tags:
 
 <Intro>
 
-A [New Relic One application](/build-apps) is represented by a **Nerdpack** folder, which can include one or more **Nerdlet** files,
+A [New Relic application](/build-apps) is represented by a **Nerdpack** folder, which can include one or more **Nerdlet** files,
 and (optionally) one or more **launcher** files. Here we explain:
 
 - The file structure for a Nerdpack, a Nerdlet, and a launcher
@@ -137,7 +137,7 @@ An empty SCSS file for styling your application.
 
 ### `icon.png`
 
-The launcher icon that appears on the **Apps** page in New Relic One when an application is deployed.
+The launcher icon that appears on the **Apps** page in New Relic when an application is deployed.
 
 ## Launcher file structure
 

--- a/src/markdown-pages/explore-docs/nerdstorage.mdx
+++ b/src/markdown-pages/explore-docs/nerdstorage.mdx
@@ -2,7 +2,7 @@
 title: 'Intro to NerdStorage'
 duration: 30
 template: 'GuideTemplate'
-description: 'Intro to NerdStorage on New Relic One'
+description: 'Intro to NerdStorage on New Relic'
 tileShorthand:
   title: 'Intro to NerdStorage'
   description: 'Learn about NerdStorage components'
@@ -11,13 +11,13 @@ redirects:
 tags:
   - nerdstorage
   - nerdstorage components
-  - new relic one apps
+  - New Relic apps
   - data access
 ---
 
 <Intro>
 
-To help you build a [New Relic One application](/use-cases/build-new-relic-one-applications), we provide you with the [New Relic One SDK](/explore-docs/intro-to-sdk). On this page, you’ll learn how to use NerdStorage SDK components.
+To help you build a [New Relic application](/use-cases/build-new-relic-one-applications), we provide you with the [New Relic One SDK](/explore-docs/intro-to-sdk). On this page, you’ll learn how to use NerdStorage SDK components.
 
 </Intro>
 

--- a/src/markdown-pages/explore-docs/nerdstoragevault.mdx
+++ b/src/markdown-pages/explore-docs/nerdstoragevault.mdx
@@ -9,7 +9,7 @@ tileShorthand:
 tags:
   - nerdstoragevault
   - nerdstoragevault components
-  - new relic one apps
+  - New Relic apps
   - data access
   - encrypted storage
 resources:
@@ -21,7 +21,7 @@ resources:
 
 <Intro>
 
-To help you build a [New Relic One application](/use-cases/build-new-relic-one-applications),
+To help you build a [New Relic application](/use-cases/build-new-relic-one-applications),
 we provide you with the [New Relic One SDK](/explore-docs/intro-to-sdk).
 On this page, you’ll learn how to use NerdStorageVault to store data in an encrypted
 storage solution.

--- a/src/markdown-pages/explore-docs/nr1-catalog.mdx
+++ b/src/markdown-pages/explore-docs/nr1-catalog.mdx
@@ -1,10 +1,10 @@
 ---
 title: 'New Relic One CLI catalog commands'
 template: 'GuideTemplate'
-description: 'An overview of the CLI commands you can use to manage your New Relic One catalog information.'
+description: 'An overview of the CLI commands you can use to manage your New Relic app catalog information.'
 tileShorthand:
   title: 'Catalog CLI commands'
-  description: 'Manage your New Relic One catalog with our CLI.'
+  description: 'Manage your New Relic app catalog with our CLI.'
 ---
 
 <Intro>

--- a/src/markdown-pages/explore-docs/nr1-cli.mdx
+++ b/src/markdown-pages/explore-docs/nr1-cli.mdx
@@ -13,13 +13,13 @@ resources:
   - title: Deploy an app
     url: /build-apps/publish-deploy
 tags:
-  - New Relic One app
+  - New Relic app
   - nerdpack commands
 ---
 
 <Intro>
 
-To build a [New Relic One app](/build-apps/build-hello-world-app), you must install the New Relic One CLI. The CLI helps you build, publish, and manage your New Relic app.
+To build a [New Relic app](/build-apps/build-hello-world-app), you must install the New Relic One CLI. The CLI helps you build, publish, and manage your New Relic app.
 
 <br />
 
@@ -41,7 +41,7 @@ We provide a variety of tools for building apps, including the New Relic One CLI
 
 In New Relic, click **Instant Observability**, then check the **Apps** box in the **filter by** section. Click the [**Build on New Relic** launcher](https://one.newrelic.com/launcher/developer-center.launcher) and follow the quick start instructions. The quick start automatically generates an API key for the account you select, and gives you the pre-populated commands to create a profile, generate your first "Hello World" app, and serve it locally.
 
-![Build New Relic One application](../../images/developercenter.png)
+![Build New Relic application](../../images/developercenter.png)
 
 <br />
 
@@ -53,11 +53,11 @@ Use the [NR1 VS Code extension](https://marketplace.visualstudio.com/items?itemN
 
 ## New Relic One CLI Commands
 
-This table provides descriptions for the New Relic One commands. For more context, including usage and option details, click any individual command or the command category.
+This table provides descriptions for the New Relic app commands. For more context, including usage and option details, click any individual command or the command category.
 
 For details on user permissions, see [Permissions](/build-apps/permission-manage-apps).
 
-For more on how to serve and publish your application, see our guide on [Deploying your New Relic One app](/build-tools/new-relic-one-applications/publish-deploy).
+For more on how to serve and publish your application, see our guide on [Deploying your New Relic app](/build-tools/new-relic-one-applications/publish-deploy).
 
 ### [Get started](/explore-docs/nr1-common)
 

--- a/src/markdown-pages/explore-docs/nr1-common.mdx
+++ b/src/markdown-pages/explore-docs/nr1-common.mdx
@@ -3,7 +3,7 @@ title: 'New Relic One CLI common commands'
 template: 'GuideTemplate'
 description: 'An overview of common commands you can use with the New Relic One CLI.'
 tileShorthand:
-  title: 'New Relic One general commands'
+  title: 'New Relic general commands'
   description: 'Common commands to get you started with the New Relic One CLI.'
 ---
 

--- a/src/markdown-pages/explore-docs/nr1-nerdpack.mdx
+++ b/src/markdown-pages/explore-docs/nr1-nerdpack.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'New Relic One CLI Nerdpack commands'
 template: 'GuideTemplate'
-description: 'An overview of the CLI commands you can use to set up your New Relic One Nerdpacks.'
+description: 'An overview of the CLI commands you can use to set up your New Relic Nerdpacks.'
 tileShorthand:
   title: 'Nerdpack CLI commands'
   description: 'Set up your Nerdpacks with the New Relic One CLI.'

--- a/src/markdown-pages/explore-docs/query-and-store-data.mdx
+++ b/src/markdown-pages/explore-docs/query-and-store-data.mdx
@@ -16,7 +16,7 @@ tags:
 
 <Intro>
 
-To help you build a [New Relic One application](/build-apps/build-hello-world-app), we provide you with the [New Relic One SDK](/explore-docs/intro-to-sdk). Here you can learn how to use the SDK query components, which allow you to make queries and mutations via [NerdGraph](/collect-data/get-started-nerdgraph-api-explorer), our GraphQL endpoint.
+To help you build a [New Relic application](/build-apps/build-hello-world-app), we provide you with the [New Relic One SDK](/explore-docs/intro-to-sdk). Here you can learn how to use the SDK query components, which allow you to make queries and mutations via [NerdGraph](/collect-data/get-started-nerdgraph-api-explorer), our GraphQL endpoint.
 
 </Intro>
 


### PR DESCRIPTION
Removing instances of 'New Relic One application', 'New Relic One app' and replacing with 'New Relic app', and replacing references to 'New Relic One' platform context as just 'New Relic'. 

What I didn't change: 
New Relic One CLI (as this is still in codebase, but we explain that in doc that it is about building New Relic apps)
New Relic One SDK (as that's also in codebase still)

It was thought these references were less important and could stay as-is for now, based on conversations. 