### PR TITLE
Tabatha/theme bump 6.13.7

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -27,6 +27,7 @@ module.exports = {
         layout: {
           contentPadding: '2rem',
           maxWidth: '1700px',
+          sidebarWidth: '340px',
           component: require.resolve('./src/layouts'),
           mobileBreakpoint: '760px',
         },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "^1.6.19",
     "@mdx-js/react": "^1.6.19",
-    "@newrelic/gatsby-theme-newrelic": "6.8.0",
+    "@newrelic/gatsby-theme-newrelic": "6.13.7",
     "@splitsoftware/splitio-react": "^1.2.0",
     "@xstate/react": "^1.0.2",
     "classnames": "^2.2.6",

--- a/src/@newrelic/gatsby-theme-newrelic/components/Logo.js
+++ b/src/@newrelic/gatsby-theme-newrelic/components/Logo.js
@@ -19,10 +19,7 @@ const Logo = ({ className, height }) => (
         stroke-width: 3.72px;
       }
       .text-color {
-        fill: #1d252c;
-        .dark-mode & {
-          fill: #dddedf;
-        }
+        fill: #dddedf;
       }
     `}
     className={className}

--- a/src/__generated__/gatsby-schema.graphql
+++ b/src/__generated__/gatsby-schema.graphql
@@ -385,24 +385,24 @@ type SitePage implements Node {
   internalComponentName: String!
   componentChunkName: String!
   matchPath: String
-  isCreatedByStatefulCreatePages: Boolean
-  pluginCreator: SitePlugin
-  pluginCreatorId: String
   id: ID!
   parent: Node
   children: [Node!]!
   internal: Internal!
+  isCreatedByStatefulCreatePages: Boolean
   context: SitePageContext
+  pluginCreator: SitePlugin
+  pluginCreatorId: String
 }
 
 type SitePageContext {
+  slug: String
+  fileRelativePath: String
   layout: String
+  locale: String
+  guidesFilter: String
   themeOptions: SitePageContextThemeOptions
   swiftypeEngineKey: String
-  fileRelativePath: String
-  locale: String
-  slug: String
-  guidesFilter: String
 }
 
 type SitePageContextThemeOptions {
@@ -419,6 +419,7 @@ type SitePageContextThemeOptions {
 type SitePageContextThemeOptionsLayout {
   contentPadding: String
   maxWidth: String
+  sidebarWidth: String
   component: String
   mobileBreakpoint: String
 }
@@ -646,6 +647,7 @@ type SitePluginPluginOptionsConfigsStaging {
 type SitePluginPluginOptionsLayout {
   contentPadding: String
   maxWidth: String
+  sidebarWidth: String
   component: String
   mobileBreakpoint: String
 }
@@ -1170,6 +1172,8 @@ type NewRelicThemeConfig implements Node {
   relatedResources: NewRelicThemeRelatedResourceConfig!
   tessen: NewRelicThemeTessenConfig
   signup: NewRelicThemeSignupConfig
+  shouldUpdateScroll: RoutesAllowingScroll
+  feedback: NewRelicThemeFeedbackConfig
   id: ID!
   parent: Node
   children: [Node!]!
@@ -1194,6 +1198,15 @@ type NewRelicThemeSignupConfig {
   environment: String!
   reCaptchaToken: String!
   signupURL: String!
+}
+
+type NewRelicThemeFeedbackConfig {
+  environment: String!
+  reCaptchaToken: String!
+}
+
+type RoutesAllowingScroll {
+  routes: [String!]
 }
 
 type MarkdownHeading {
@@ -1453,7 +1466,7 @@ type Query {
   allSite(filter: SiteFilterInput, sort: SiteSortInput, skip: Int, limit: Int): SiteConnection!
   siteFunction(functionRoute: StringQueryOperatorInput, pluginName: StringQueryOperatorInput, originalAbsoluteFilePath: StringQueryOperatorInput, originalRelativeFilePath: StringQueryOperatorInput, relativeCompiledFilePath: StringQueryOperatorInput, absoluteCompiledFilePath: StringQueryOperatorInput, matchPath: StringQueryOperatorInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): SiteFunction
   allSiteFunction(filter: SiteFunctionFilterInput, sort: SiteFunctionSortInput, skip: Int, limit: Int): SiteFunctionConnection!
-  sitePage(path: StringQueryOperatorInput, component: StringQueryOperatorInput, internalComponentName: StringQueryOperatorInput, componentChunkName: StringQueryOperatorInput, matchPath: StringQueryOperatorInput, isCreatedByStatefulCreatePages: BooleanQueryOperatorInput, pluginCreator: SitePluginFilterInput, pluginCreatorId: StringQueryOperatorInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput, context: SitePageContextFilterInput): SitePage
+  sitePage(path: StringQueryOperatorInput, component: StringQueryOperatorInput, internalComponentName: StringQueryOperatorInput, componentChunkName: StringQueryOperatorInput, matchPath: StringQueryOperatorInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput, isCreatedByStatefulCreatePages: BooleanQueryOperatorInput, context: SitePageContextFilterInput, pluginCreator: SitePluginFilterInput, pluginCreatorId: StringQueryOperatorInput): SitePage
   allSitePage(filter: SitePageFilterInput, sort: SitePageSortInput, skip: Int, limit: Int): SitePageConnection!
   sitePlugin(resolve: StringQueryOperatorInput, name: StringQueryOperatorInput, version: StringQueryOperatorInput, nodeAPIs: StringQueryOperatorInput, browserAPIs: StringQueryOperatorInput, ssrAPIs: StringQueryOperatorInput, pluginFilepath: StringQueryOperatorInput, pluginOptions: SitePluginPluginOptionsFilterInput, packageJson: SitePluginPackageJsonFilterInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): SitePlugin
   allSitePlugin(filter: SitePluginFilterInput, sort: SitePluginSortInput, skip: Int, limit: Int): SitePluginConnection!
@@ -1465,7 +1478,7 @@ type Query {
   allLocale(filter: LocaleFilterInput, sort: LocaleSortInput, skip: Int, limit: Int): LocaleConnection!
   relatedResource(id: StringQueryOperatorInput, title: StringQueryOperatorInput, url: StringQueryOperatorInput, plugin: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): RelatedResource
   allRelatedResource(filter: RelatedResourceFilterInput, sort: RelatedResourceSortInput, skip: Int, limit: Int): RelatedResourceConnection!
-  newRelicThemeConfig(env: StringQueryOperatorInput, relatedResources: NewRelicThemeRelatedResourceConfigFilterInput, tessen: NewRelicThemeTessenConfigFilterInput, signup: NewRelicThemeSignupConfigFilterInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): NewRelicThemeConfig
+  newRelicThemeConfig(env: StringQueryOperatorInput, relatedResources: NewRelicThemeRelatedResourceConfigFilterInput, tessen: NewRelicThemeTessenConfigFilterInput, signup: NewRelicThemeSignupConfigFilterInput, shouldUpdateScroll: RoutesAllowingScrollFilterInput, feedback: NewRelicThemeFeedbackConfigFilterInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): NewRelicThemeConfig
   allNewRelicThemeConfig(filter: NewRelicThemeConfigFilterInput, sort: NewRelicThemeConfigSortInput, skip: Int, limit: Int): NewRelicThemeConfigConnection!
   markdownRemark(id: StringQueryOperatorInput, html: StringQueryOperatorInput, htmlAst: JSONQueryOperatorInput, excerpt: StringQueryOperatorInput, excerptAst: JSONQueryOperatorInput, headings: MarkdownHeadingFilterListInput, timeToRead: IntQueryOperatorInput, tableOfContents: StringQueryOperatorInput, wordCount: MarkdownWordCountFilterInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): MarkdownRemark
   allMarkdownRemark(filter: MarkdownRemarkFilterInput, sort: MarkdownRemarkSortInput, skip: Int, limit: Int): MarkdownRemarkConnection!
@@ -2802,6 +2815,132 @@ input SiteFunctionSortInput {
   order: [SortOrderEnum] = [ASC]
 }
 
+input SitePageContextFilterInput {
+  slug: StringQueryOperatorInput
+  fileRelativePath: StringQueryOperatorInput
+  layout: StringQueryOperatorInput
+  locale: StringQueryOperatorInput
+  guidesFilter: StringQueryOperatorInput
+  themeOptions: SitePageContextThemeOptionsFilterInput
+  swiftypeEngineKey: StringQueryOperatorInput
+}
+
+input SitePageContextThemeOptionsFilterInput {
+  oneTrustID: StringQueryOperatorInput
+  forceTrailingSlashes: BooleanQueryOperatorInput
+  layout: SitePageContextThemeOptionsLayoutFilterInput
+  prism: SitePageContextThemeOptionsPrismFilterInput
+  splitio: SitePageContextThemeOptionsSplitioFilterInput
+  relatedResources: SitePageContextThemeOptionsRelatedResourcesFilterInput
+  newrelic: SitePageContextThemeOptionsNewrelicFilterInput
+  tessen: SitePageContextThemeOptionsTessenFilterInput
+}
+
+input SitePageContextThemeOptionsLayoutFilterInput {
+  contentPadding: StringQueryOperatorInput
+  maxWidth: StringQueryOperatorInput
+  sidebarWidth: StringQueryOperatorInput
+  component: StringQueryOperatorInput
+  mobileBreakpoint: StringQueryOperatorInput
+}
+
+input SitePageContextThemeOptionsPrismFilterInput {
+  languages: StringQueryOperatorInput
+}
+
+input SitePageContextThemeOptionsSplitioFilterInput {
+  core: SitePageContextThemeOptionsSplitioCoreFilterInput
+  features: SitePageContextThemeOptionsSplitioFeaturesFilterInput
+  env: SitePageContextThemeOptionsSplitioEnvFilterInput
+}
+
+input SitePageContextThemeOptionsSplitioCoreFilterInput {
+  authorizationKey: StringQueryOperatorInput
+}
+
+input SitePageContextThemeOptionsSplitioFeaturesFilterInput {
+  free_account_button_color: SitePageContextThemeOptionsSplitioFeaturesFree_account_button_colorFilterInput
+}
+
+input SitePageContextThemeOptionsSplitioFeaturesFree_account_button_colorFilterInput {
+  treatment: StringQueryOperatorInput
+}
+
+input SitePageContextThemeOptionsSplitioEnvFilterInput {
+  development: SitePageContextThemeOptionsSplitioEnvDevelopmentFilterInput
+}
+
+input SitePageContextThemeOptionsSplitioEnvDevelopmentFilterInput {
+  features: SitePageContextThemeOptionsSplitioEnvDevelopmentFeaturesFilterInput
+  core: SitePageContextThemeOptionsSplitioEnvDevelopmentCoreFilterInput
+}
+
+input SitePageContextThemeOptionsSplitioEnvDevelopmentFeaturesFilterInput {
+  developer_website_global_header_gh_buttons: StringQueryOperatorInput
+  developer_website_right_rail_buttons: StringQueryOperatorInput
+  super_tiles: StringQueryOperatorInput
+}
+
+input SitePageContextThemeOptionsSplitioEnvDevelopmentCoreFilterInput {
+  authorizationKey: StringQueryOperatorInput
+}
+
+input SitePageContextThemeOptionsRelatedResourcesFilterInput {
+  swiftype: SitePageContextThemeOptionsRelatedResourcesSwiftypeFilterInput
+}
+
+input SitePageContextThemeOptionsRelatedResourcesSwiftypeFilterInput {
+  resultsPath: StringQueryOperatorInput
+  refetch: BooleanQueryOperatorInput
+  engineKey: StringQueryOperatorInput
+  limit: IntQueryOperatorInput
+}
+
+input SitePageContextThemeOptionsNewrelicFilterInput {
+  configs: SitePageContextThemeOptionsNewrelicConfigsFilterInput
+}
+
+input SitePageContextThemeOptionsNewrelicConfigsFilterInput {
+  production: SitePageContextThemeOptionsNewrelicConfigsProductionFilterInput
+  staging: SitePageContextThemeOptionsNewrelicConfigsStagingFilterInput
+}
+
+input SitePageContextThemeOptionsNewrelicConfigsProductionFilterInput {
+  instrumentationType: StringQueryOperatorInput
+  accountId: StringQueryOperatorInput
+  trustKey: StringQueryOperatorInput
+  agentID: StringQueryOperatorInput
+  licenseKey: StringQueryOperatorInput
+  applicationID: StringQueryOperatorInput
+  beacon: StringQueryOperatorInput
+  errorBeacon: StringQueryOperatorInput
+}
+
+input SitePageContextThemeOptionsNewrelicConfigsStagingFilterInput {
+  instrumentationType: StringQueryOperatorInput
+  accountId: StringQueryOperatorInput
+  trustKey: StringQueryOperatorInput
+  agentID: StringQueryOperatorInput
+  licenseKey: StringQueryOperatorInput
+  applicationID: StringQueryOperatorInput
+  beacon: StringQueryOperatorInput
+  errorBeacon: StringQueryOperatorInput
+}
+
+input SitePageContextThemeOptionsTessenFilterInput {
+  tessenVersion: StringQueryOperatorInput
+  product: StringQueryOperatorInput
+  subproduct: StringQueryOperatorInput
+  segmentWriteKey: StringQueryOperatorInput
+  trackPageViews: BooleanQueryOperatorInput
+  pageView: SitePageContextThemeOptionsTessenPageViewFilterInput
+}
+
+input SitePageContextThemeOptionsTessenPageViewFilterInput {
+  eventName: StringQueryOperatorInput
+  category: StringQueryOperatorInput
+}
+
 input SitePluginFilterInput {
   resolve: StringQueryOperatorInput
   name: StringQueryOperatorInput
@@ -2932,6 +3071,7 @@ input SitePluginPluginOptionsConfigsStagingFilterInput {
 input SitePluginPluginOptionsLayoutFilterInput {
   contentPadding: StringQueryOperatorInput
   maxWidth: StringQueryOperatorInput
+  sidebarWidth: StringQueryOperatorInput
   component: StringQueryOperatorInput
   mobileBreakpoint: StringQueryOperatorInput
 }
@@ -3104,131 +3244,6 @@ input SitePluginPackageJsonPeerDependenciesFilterInput {
   version: StringQueryOperatorInput
 }
 
-input SitePageContextFilterInput {
-  layout: StringQueryOperatorInput
-  themeOptions: SitePageContextThemeOptionsFilterInput
-  swiftypeEngineKey: StringQueryOperatorInput
-  fileRelativePath: StringQueryOperatorInput
-  locale: StringQueryOperatorInput
-  slug: StringQueryOperatorInput
-  guidesFilter: StringQueryOperatorInput
-}
-
-input SitePageContextThemeOptionsFilterInput {
-  oneTrustID: StringQueryOperatorInput
-  forceTrailingSlashes: BooleanQueryOperatorInput
-  layout: SitePageContextThemeOptionsLayoutFilterInput
-  prism: SitePageContextThemeOptionsPrismFilterInput
-  splitio: SitePageContextThemeOptionsSplitioFilterInput
-  relatedResources: SitePageContextThemeOptionsRelatedResourcesFilterInput
-  newrelic: SitePageContextThemeOptionsNewrelicFilterInput
-  tessen: SitePageContextThemeOptionsTessenFilterInput
-}
-
-input SitePageContextThemeOptionsLayoutFilterInput {
-  contentPadding: StringQueryOperatorInput
-  maxWidth: StringQueryOperatorInput
-  component: StringQueryOperatorInput
-  mobileBreakpoint: StringQueryOperatorInput
-}
-
-input SitePageContextThemeOptionsPrismFilterInput {
-  languages: StringQueryOperatorInput
-}
-
-input SitePageContextThemeOptionsSplitioFilterInput {
-  core: SitePageContextThemeOptionsSplitioCoreFilterInput
-  features: SitePageContextThemeOptionsSplitioFeaturesFilterInput
-  env: SitePageContextThemeOptionsSplitioEnvFilterInput
-}
-
-input SitePageContextThemeOptionsSplitioCoreFilterInput {
-  authorizationKey: StringQueryOperatorInput
-}
-
-input SitePageContextThemeOptionsSplitioFeaturesFilterInput {
-  free_account_button_color: SitePageContextThemeOptionsSplitioFeaturesFree_account_button_colorFilterInput
-}
-
-input SitePageContextThemeOptionsSplitioFeaturesFree_account_button_colorFilterInput {
-  treatment: StringQueryOperatorInput
-}
-
-input SitePageContextThemeOptionsSplitioEnvFilterInput {
-  development: SitePageContextThemeOptionsSplitioEnvDevelopmentFilterInput
-}
-
-input SitePageContextThemeOptionsSplitioEnvDevelopmentFilterInput {
-  features: SitePageContextThemeOptionsSplitioEnvDevelopmentFeaturesFilterInput
-  core: SitePageContextThemeOptionsSplitioEnvDevelopmentCoreFilterInput
-}
-
-input SitePageContextThemeOptionsSplitioEnvDevelopmentFeaturesFilterInput {
-  developer_website_global_header_gh_buttons: StringQueryOperatorInput
-  developer_website_right_rail_buttons: StringQueryOperatorInput
-  super_tiles: StringQueryOperatorInput
-}
-
-input SitePageContextThemeOptionsSplitioEnvDevelopmentCoreFilterInput {
-  authorizationKey: StringQueryOperatorInput
-}
-
-input SitePageContextThemeOptionsRelatedResourcesFilterInput {
-  swiftype: SitePageContextThemeOptionsRelatedResourcesSwiftypeFilterInput
-}
-
-input SitePageContextThemeOptionsRelatedResourcesSwiftypeFilterInput {
-  resultsPath: StringQueryOperatorInput
-  refetch: BooleanQueryOperatorInput
-  engineKey: StringQueryOperatorInput
-  limit: IntQueryOperatorInput
-}
-
-input SitePageContextThemeOptionsNewrelicFilterInput {
-  configs: SitePageContextThemeOptionsNewrelicConfigsFilterInput
-}
-
-input SitePageContextThemeOptionsNewrelicConfigsFilterInput {
-  production: SitePageContextThemeOptionsNewrelicConfigsProductionFilterInput
-  staging: SitePageContextThemeOptionsNewrelicConfigsStagingFilterInput
-}
-
-input SitePageContextThemeOptionsNewrelicConfigsProductionFilterInput {
-  instrumentationType: StringQueryOperatorInput
-  accountId: StringQueryOperatorInput
-  trustKey: StringQueryOperatorInput
-  agentID: StringQueryOperatorInput
-  licenseKey: StringQueryOperatorInput
-  applicationID: StringQueryOperatorInput
-  beacon: StringQueryOperatorInput
-  errorBeacon: StringQueryOperatorInput
-}
-
-input SitePageContextThemeOptionsNewrelicConfigsStagingFilterInput {
-  instrumentationType: StringQueryOperatorInput
-  accountId: StringQueryOperatorInput
-  trustKey: StringQueryOperatorInput
-  agentID: StringQueryOperatorInput
-  licenseKey: StringQueryOperatorInput
-  applicationID: StringQueryOperatorInput
-  beacon: StringQueryOperatorInput
-  errorBeacon: StringQueryOperatorInput
-}
-
-input SitePageContextThemeOptionsTessenFilterInput {
-  tessenVersion: StringQueryOperatorInput
-  product: StringQueryOperatorInput
-  subproduct: StringQueryOperatorInput
-  segmentWriteKey: StringQueryOperatorInput
-  trackPageViews: BooleanQueryOperatorInput
-  pageView: SitePageContextThemeOptionsTessenPageViewFilterInput
-}
-
-input SitePageContextThemeOptionsTessenPageViewFilterInput {
-  eventName: StringQueryOperatorInput
-  category: StringQueryOperatorInput
-}
-
 type SitePageConnection {
   totalCount: Int!
   edges: [SitePageEdge!]!
@@ -3253,7 +3268,112 @@ enum SitePageFieldsEnum {
   internalComponentName
   componentChunkName
   matchPath
+  id
+  parent___id
+  parent___parent___id
+  parent___parent___parent___id
+  parent___parent___parent___children
+  parent___parent___children
+  parent___parent___children___id
+  parent___parent___children___children
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___children
+  parent___children___id
+  parent___children___parent___id
+  parent___children___parent___children
+  parent___children___children
+  parent___children___children___id
+  parent___children___children___children
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  children
+  children___id
+  children___parent___id
+  children___parent___parent___id
+  children___parent___parent___children
+  children___parent___children
+  children___parent___children___id
+  children___parent___children___children
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___children
+  children___children___id
+  children___children___parent___id
+  children___children___parent___children
+  children___children___children
+  children___children___children___id
+  children___children___children___children
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
   isCreatedByStatefulCreatePages
+  context___slug
+  context___fileRelativePath
+  context___layout
+  context___locale
+  context___guidesFilter
+  context___themeOptions___oneTrustID
+  context___themeOptions___forceTrailingSlashes
+  context___themeOptions___layout___contentPadding
+  context___themeOptions___layout___maxWidth
+  context___themeOptions___layout___sidebarWidth
+  context___themeOptions___layout___component
+  context___themeOptions___layout___mobileBreakpoint
+  context___themeOptions___prism___languages
+  context___themeOptions___tessen___tessenVersion
+  context___themeOptions___tessen___product
+  context___themeOptions___tessen___subproduct
+  context___themeOptions___tessen___segmentWriteKey
+  context___themeOptions___tessen___trackPageViews
+  context___swiftypeEngineKey
   pluginCreator___resolve
   pluginCreator___name
   pluginCreator___version
@@ -3288,6 +3408,7 @@ enum SitePageFieldsEnum {
   pluginCreator___pluginOptions___forceTrailingSlashes
   pluginCreator___pluginOptions___layout___contentPadding
   pluginCreator___pluginOptions___layout___maxWidth
+  pluginCreator___pluginOptions___layout___sidebarWidth
   pluginCreator___pluginOptions___layout___component
   pluginCreator___pluginOptions___layout___mobileBreakpoint
   pluginCreator___pluginOptions___prism___languages
@@ -3396,110 +3517,6 @@ enum SitePageFieldsEnum {
   pluginCreator___internal___owner
   pluginCreator___internal___type
   pluginCreatorId
-  id
-  parent___id
-  parent___parent___id
-  parent___parent___parent___id
-  parent___parent___parent___children
-  parent___parent___children
-  parent___parent___children___id
-  parent___parent___children___children
-  parent___parent___internal___content
-  parent___parent___internal___contentDigest
-  parent___parent___internal___description
-  parent___parent___internal___fieldOwners
-  parent___parent___internal___ignoreType
-  parent___parent___internal___mediaType
-  parent___parent___internal___owner
-  parent___parent___internal___type
-  parent___children
-  parent___children___id
-  parent___children___parent___id
-  parent___children___parent___children
-  parent___children___children
-  parent___children___children___id
-  parent___children___children___children
-  parent___children___internal___content
-  parent___children___internal___contentDigest
-  parent___children___internal___description
-  parent___children___internal___fieldOwners
-  parent___children___internal___ignoreType
-  parent___children___internal___mediaType
-  parent___children___internal___owner
-  parent___children___internal___type
-  parent___internal___content
-  parent___internal___contentDigest
-  parent___internal___description
-  parent___internal___fieldOwners
-  parent___internal___ignoreType
-  parent___internal___mediaType
-  parent___internal___owner
-  parent___internal___type
-  children
-  children___id
-  children___parent___id
-  children___parent___parent___id
-  children___parent___parent___children
-  children___parent___children
-  children___parent___children___id
-  children___parent___children___children
-  children___parent___internal___content
-  children___parent___internal___contentDigest
-  children___parent___internal___description
-  children___parent___internal___fieldOwners
-  children___parent___internal___ignoreType
-  children___parent___internal___mediaType
-  children___parent___internal___owner
-  children___parent___internal___type
-  children___children
-  children___children___id
-  children___children___parent___id
-  children___children___parent___children
-  children___children___children
-  children___children___children___id
-  children___children___children___children
-  children___children___internal___content
-  children___children___internal___contentDigest
-  children___children___internal___description
-  children___children___internal___fieldOwners
-  children___children___internal___ignoreType
-  children___children___internal___mediaType
-  children___children___internal___owner
-  children___children___internal___type
-  children___internal___content
-  children___internal___contentDigest
-  children___internal___description
-  children___internal___fieldOwners
-  children___internal___ignoreType
-  children___internal___mediaType
-  children___internal___owner
-  children___internal___type
-  internal___content
-  internal___contentDigest
-  internal___description
-  internal___fieldOwners
-  internal___ignoreType
-  internal___mediaType
-  internal___owner
-  internal___type
-  context___layout
-  context___themeOptions___oneTrustID
-  context___themeOptions___forceTrailingSlashes
-  context___themeOptions___layout___contentPadding
-  context___themeOptions___layout___maxWidth
-  context___themeOptions___layout___component
-  context___themeOptions___layout___mobileBreakpoint
-  context___themeOptions___prism___languages
-  context___themeOptions___tessen___tessenVersion
-  context___themeOptions___tessen___product
-  context___themeOptions___tessen___subproduct
-  context___themeOptions___tessen___segmentWriteKey
-  context___themeOptions___tessen___trackPageViews
-  context___swiftypeEngineKey
-  context___fileRelativePath
-  context___locale
-  context___slug
-  context___guidesFilter
 }
 
 type SitePageGroupConnection {
@@ -3522,14 +3539,14 @@ input SitePageFilterInput {
   internalComponentName: StringQueryOperatorInput
   componentChunkName: StringQueryOperatorInput
   matchPath: StringQueryOperatorInput
-  isCreatedByStatefulCreatePages: BooleanQueryOperatorInput
-  pluginCreator: SitePluginFilterInput
-  pluginCreatorId: StringQueryOperatorInput
   id: StringQueryOperatorInput
   parent: NodeFilterInput
   children: NodeFilterListInput
   internal: InternalFilterInput
+  isCreatedByStatefulCreatePages: BooleanQueryOperatorInput
   context: SitePageContextFilterInput
+  pluginCreator: SitePluginFilterInput
+  pluginCreatorId: StringQueryOperatorInput
 }
 
 input SitePageSortInput {
@@ -3606,6 +3623,7 @@ enum SitePluginFieldsEnum {
   pluginOptions___forceTrailingSlashes
   pluginOptions___layout___contentPadding
   pluginOptions___layout___maxWidth
+  pluginOptions___layout___sidebarWidth
   pluginOptions___layout___component
   pluginOptions___layout___mobileBreakpoint
   pluginOptions___prism___languages
@@ -4383,6 +4401,15 @@ input NewRelicThemeSignupConfigFilterInput {
   signupURL: StringQueryOperatorInput
 }
 
+input RoutesAllowingScrollFilterInput {
+  routes: StringQueryOperatorInput
+}
+
+input NewRelicThemeFeedbackConfigFilterInput {
+  environment: StringQueryOperatorInput
+  reCaptchaToken: StringQueryOperatorInput
+}
+
 type NewRelicThemeConfigConnection {
   totalCount: Int!
   edges: [NewRelicThemeConfigEdge!]!
@@ -4411,6 +4438,9 @@ enum NewRelicThemeConfigFieldsEnum {
   signup___environment
   signup___reCaptchaToken
   signup___signupURL
+  shouldUpdateScroll___routes
+  feedback___environment
+  feedback___reCaptchaToken
   id
   parent___id
   parent___parent___id
@@ -4518,6 +4548,8 @@ input NewRelicThemeConfigFilterInput {
   relatedResources: NewRelicThemeRelatedResourceConfigFilterInput
   tessen: NewRelicThemeTessenConfigFilterInput
   signup: NewRelicThemeSignupConfigFilterInput
+  shouldUpdateScroll: RoutesAllowingScrollFilterInput
+  feedback: NewRelicThemeFeedbackConfigFilterInput
   id: StringQueryOperatorInput
   parent: NodeFilterInput
   children: NodeFilterListInput

--- a/src/__generated__/gatsby-schema.graphql
+++ b/src/__generated__/gatsby-schema.graphql
@@ -1124,13 +1124,13 @@ type MdxFrontmatter {
   ): Date
   title: String!
   path: String
-  template: String
   description: String
+  template: String
+  redirects: [String]
+  duration: Int
   tileShorthand: MdxFrontmatterTileShorthand
   resources: [MdxFrontmatterResources]
   tags: [String]
-  redirects: [String]
-  duration: Int
   procIdx: Float
   promote: Boolean
 }
@@ -1660,13 +1660,13 @@ input MdxFrontmatterFilterInput {
   endDate: DateQueryOperatorInput
   title: StringQueryOperatorInput
   path: StringQueryOperatorInput
-  template: StringQueryOperatorInput
   description: StringQueryOperatorInput
+  template: StringQueryOperatorInput
+  redirects: StringQueryOperatorInput
+  duration: IntQueryOperatorInput
   tileShorthand: MdxFrontmatterTileShorthandFilterInput
   resources: MdxFrontmatterResourcesFilterListInput
   tags: StringQueryOperatorInput
-  redirects: StringQueryOperatorInput
-  duration: IntQueryOperatorInput
   procIdx: FloatQueryOperatorInput
   promote: BooleanQueryOperatorInput
 }
@@ -1931,16 +1931,16 @@ enum FileFieldsEnum {
   childrenMdx___frontmatter___endDate
   childrenMdx___frontmatter___title
   childrenMdx___frontmatter___path
-  childrenMdx___frontmatter___template
   childrenMdx___frontmatter___description
+  childrenMdx___frontmatter___template
+  childrenMdx___frontmatter___redirects
+  childrenMdx___frontmatter___duration
   childrenMdx___frontmatter___tileShorthand___title
   childrenMdx___frontmatter___tileShorthand___description
   childrenMdx___frontmatter___resources
   childrenMdx___frontmatter___resources___title
   childrenMdx___frontmatter___resources___url
   childrenMdx___frontmatter___tags
-  childrenMdx___frontmatter___redirects
-  childrenMdx___frontmatter___duration
   childrenMdx___frontmatter___procIdx
   childrenMdx___frontmatter___promote
   childrenMdx___slug
@@ -2038,16 +2038,16 @@ enum FileFieldsEnum {
   childMdx___frontmatter___endDate
   childMdx___frontmatter___title
   childMdx___frontmatter___path
-  childMdx___frontmatter___template
   childMdx___frontmatter___description
+  childMdx___frontmatter___template
+  childMdx___frontmatter___redirects
+  childMdx___frontmatter___duration
   childMdx___frontmatter___tileShorthand___title
   childMdx___frontmatter___tileShorthand___description
   childMdx___frontmatter___resources
   childMdx___frontmatter___resources___title
   childMdx___frontmatter___resources___url
   childMdx___frontmatter___tags
-  childMdx___frontmatter___redirects
-  childMdx___frontmatter___duration
   childMdx___frontmatter___procIdx
   childMdx___frontmatter___promote
   childMdx___slug
@@ -4756,16 +4756,16 @@ enum MdxFieldsEnum {
   frontmatter___endDate
   frontmatter___title
   frontmatter___path
-  frontmatter___template
   frontmatter___description
+  frontmatter___template
+  frontmatter___redirects
+  frontmatter___duration
   frontmatter___tileShorthand___title
   frontmatter___tileShorthand___description
   frontmatter___resources
   frontmatter___resources___title
   frontmatter___resources___url
   frontmatter___tags
-  frontmatter___redirects
-  frontmatter___duration
   frontmatter___procIdx
   frontmatter___promote
   slug

--- a/src/__generated__/gatsby-types.d.ts
+++ b/src/__generated__/gatsby-types.d.ts
@@ -318,24 +318,24 @@ type SitePage = Node & {
   readonly internalComponentName: Scalars['String'];
   readonly componentChunkName: Scalars['String'];
   readonly matchPath: Maybe<Scalars['String']>;
-  readonly isCreatedByStatefulCreatePages: Maybe<Scalars['Boolean']>;
-  readonly pluginCreator: Maybe<SitePlugin>;
-  readonly pluginCreatorId: Maybe<Scalars['String']>;
   readonly id: Scalars['ID'];
   readonly parent: Maybe<Node>;
   readonly children: ReadonlyArray<Node>;
   readonly internal: Internal;
+  readonly isCreatedByStatefulCreatePages: Maybe<Scalars['Boolean']>;
   readonly context: Maybe<SitePageContext>;
+  readonly pluginCreator: Maybe<SitePlugin>;
+  readonly pluginCreatorId: Maybe<Scalars['String']>;
 };
 
 type SitePageContext = {
+  readonly slug: Maybe<Scalars['String']>;
+  readonly fileRelativePath: Maybe<Scalars['String']>;
   readonly layout: Maybe<Scalars['String']>;
+  readonly locale: Maybe<Scalars['String']>;
+  readonly guidesFilter: Maybe<Scalars['String']>;
   readonly themeOptions: Maybe<SitePageContextThemeOptions>;
   readonly swiftypeEngineKey: Maybe<Scalars['String']>;
-  readonly fileRelativePath: Maybe<Scalars['String']>;
-  readonly locale: Maybe<Scalars['String']>;
-  readonly slug: Maybe<Scalars['String']>;
-  readonly guidesFilter: Maybe<Scalars['String']>;
 };
 
 type SitePageContextThemeOptions = {
@@ -352,6 +352,7 @@ type SitePageContextThemeOptions = {
 type SitePageContextThemeOptionsLayout = {
   readonly contentPadding: Maybe<Scalars['String']>;
   readonly maxWidth: Maybe<Scalars['String']>;
+  readonly sidebarWidth: Maybe<Scalars['String']>;
   readonly component: Maybe<Scalars['String']>;
   readonly mobileBreakpoint: Maybe<Scalars['String']>;
 };
@@ -579,6 +580,7 @@ type SitePluginPluginOptionsConfigsStaging = {
 type SitePluginPluginOptionsLayout = {
   readonly contentPadding: Maybe<Scalars['String']>;
   readonly maxWidth: Maybe<Scalars['String']>;
+  readonly sidebarWidth: Maybe<Scalars['String']>;
   readonly component: Maybe<Scalars['String']>;
   readonly mobileBreakpoint: Maybe<Scalars['String']>;
 };
@@ -1076,6 +1078,8 @@ type NewRelicThemeConfig = Node & {
   readonly relatedResources: NewRelicThemeRelatedResourceConfig;
   readonly tessen: Maybe<NewRelicThemeTessenConfig>;
   readonly signup: Maybe<NewRelicThemeSignupConfig>;
+  readonly shouldUpdateScroll: Maybe<RoutesAllowingScroll>;
+  readonly feedback: Maybe<NewRelicThemeFeedbackConfig>;
   readonly id: Scalars['ID'];
   readonly parent: Maybe<Node>;
   readonly children: ReadonlyArray<Node>;
@@ -1100,6 +1104,15 @@ type NewRelicThemeSignupConfig = {
   readonly environment: Scalars['String'];
   readonly reCaptchaToken: Scalars['String'];
   readonly signupURL: Scalars['String'];
+};
+
+type NewRelicThemeFeedbackConfig = {
+  readonly environment: Scalars['String'];
+  readonly reCaptchaToken: Scalars['String'];
+};
+
+type RoutesAllowingScroll = {
+  readonly routes: Maybe<ReadonlyArray<Scalars['String']>>;
 };
 
 type MarkdownHeading = {
@@ -1573,14 +1586,14 @@ type Query_sitePageArgs = {
   internalComponentName: Maybe<StringQueryOperatorInput>;
   componentChunkName: Maybe<StringQueryOperatorInput>;
   matchPath: Maybe<StringQueryOperatorInput>;
-  isCreatedByStatefulCreatePages: Maybe<BooleanQueryOperatorInput>;
-  pluginCreator: Maybe<SitePluginFilterInput>;
-  pluginCreatorId: Maybe<StringQueryOperatorInput>;
   id: Maybe<StringQueryOperatorInput>;
   parent: Maybe<NodeFilterInput>;
   children: Maybe<NodeFilterListInput>;
   internal: Maybe<InternalFilterInput>;
+  isCreatedByStatefulCreatePages: Maybe<BooleanQueryOperatorInput>;
   context: Maybe<SitePageContextFilterInput>;
+  pluginCreator: Maybe<SitePluginFilterInput>;
+  pluginCreatorId: Maybe<StringQueryOperatorInput>;
 };
 
 
@@ -1700,6 +1713,8 @@ type Query_newRelicThemeConfigArgs = {
   relatedResources: Maybe<NewRelicThemeRelatedResourceConfigFilterInput>;
   tessen: Maybe<NewRelicThemeTessenConfigFilterInput>;
   signup: Maybe<NewRelicThemeSignupConfigFilterInput>;
+  shouldUpdateScroll: Maybe<RoutesAllowingScrollFilterInput>;
+  feedback: Maybe<NewRelicThemeFeedbackConfigFilterInput>;
   id: Maybe<StringQueryOperatorInput>;
   parent: Maybe<NodeFilterInput>;
   children: Maybe<NodeFilterListInput>;
@@ -3354,6 +3369,132 @@ type SiteFunctionSortInput = {
   readonly order: Maybe<ReadonlyArray<Maybe<SortOrderEnum>>>;
 };
 
+type SitePageContextFilterInput = {
+  readonly slug: Maybe<StringQueryOperatorInput>;
+  readonly fileRelativePath: Maybe<StringQueryOperatorInput>;
+  readonly layout: Maybe<StringQueryOperatorInput>;
+  readonly locale: Maybe<StringQueryOperatorInput>;
+  readonly guidesFilter: Maybe<StringQueryOperatorInput>;
+  readonly themeOptions: Maybe<SitePageContextThemeOptionsFilterInput>;
+  readonly swiftypeEngineKey: Maybe<StringQueryOperatorInput>;
+};
+
+type SitePageContextThemeOptionsFilterInput = {
+  readonly oneTrustID: Maybe<StringQueryOperatorInput>;
+  readonly forceTrailingSlashes: Maybe<BooleanQueryOperatorInput>;
+  readonly layout: Maybe<SitePageContextThemeOptionsLayoutFilterInput>;
+  readonly prism: Maybe<SitePageContextThemeOptionsPrismFilterInput>;
+  readonly splitio: Maybe<SitePageContextThemeOptionsSplitioFilterInput>;
+  readonly relatedResources: Maybe<SitePageContextThemeOptionsRelatedResourcesFilterInput>;
+  readonly newrelic: Maybe<SitePageContextThemeOptionsNewrelicFilterInput>;
+  readonly tessen: Maybe<SitePageContextThemeOptionsTessenFilterInput>;
+};
+
+type SitePageContextThemeOptionsLayoutFilterInput = {
+  readonly contentPadding: Maybe<StringQueryOperatorInput>;
+  readonly maxWidth: Maybe<StringQueryOperatorInput>;
+  readonly sidebarWidth: Maybe<StringQueryOperatorInput>;
+  readonly component: Maybe<StringQueryOperatorInput>;
+  readonly mobileBreakpoint: Maybe<StringQueryOperatorInput>;
+};
+
+type SitePageContextThemeOptionsPrismFilterInput = {
+  readonly languages: Maybe<StringQueryOperatorInput>;
+};
+
+type SitePageContextThemeOptionsSplitioFilterInput = {
+  readonly core: Maybe<SitePageContextThemeOptionsSplitioCoreFilterInput>;
+  readonly features: Maybe<SitePageContextThemeOptionsSplitioFeaturesFilterInput>;
+  readonly env: Maybe<SitePageContextThemeOptionsSplitioEnvFilterInput>;
+};
+
+type SitePageContextThemeOptionsSplitioCoreFilterInput = {
+  readonly authorizationKey: Maybe<StringQueryOperatorInput>;
+};
+
+type SitePageContextThemeOptionsSplitioFeaturesFilterInput = {
+  readonly free_account_button_color: Maybe<SitePageContextThemeOptionsSplitioFeaturesFree_account_button_colorFilterInput>;
+};
+
+type SitePageContextThemeOptionsSplitioFeaturesFree_account_button_colorFilterInput = {
+  readonly treatment: Maybe<StringQueryOperatorInput>;
+};
+
+type SitePageContextThemeOptionsSplitioEnvFilterInput = {
+  readonly development: Maybe<SitePageContextThemeOptionsSplitioEnvDevelopmentFilterInput>;
+};
+
+type SitePageContextThemeOptionsSplitioEnvDevelopmentFilterInput = {
+  readonly features: Maybe<SitePageContextThemeOptionsSplitioEnvDevelopmentFeaturesFilterInput>;
+  readonly core: Maybe<SitePageContextThemeOptionsSplitioEnvDevelopmentCoreFilterInput>;
+};
+
+type SitePageContextThemeOptionsSplitioEnvDevelopmentFeaturesFilterInput = {
+  readonly developer_website_global_header_gh_buttons: Maybe<StringQueryOperatorInput>;
+  readonly developer_website_right_rail_buttons: Maybe<StringQueryOperatorInput>;
+  readonly super_tiles: Maybe<StringQueryOperatorInput>;
+};
+
+type SitePageContextThemeOptionsSplitioEnvDevelopmentCoreFilterInput = {
+  readonly authorizationKey: Maybe<StringQueryOperatorInput>;
+};
+
+type SitePageContextThemeOptionsRelatedResourcesFilterInput = {
+  readonly swiftype: Maybe<SitePageContextThemeOptionsRelatedResourcesSwiftypeFilterInput>;
+};
+
+type SitePageContextThemeOptionsRelatedResourcesSwiftypeFilterInput = {
+  readonly resultsPath: Maybe<StringQueryOperatorInput>;
+  readonly refetch: Maybe<BooleanQueryOperatorInput>;
+  readonly engineKey: Maybe<StringQueryOperatorInput>;
+  readonly limit: Maybe<IntQueryOperatorInput>;
+};
+
+type SitePageContextThemeOptionsNewrelicFilterInput = {
+  readonly configs: Maybe<SitePageContextThemeOptionsNewrelicConfigsFilterInput>;
+};
+
+type SitePageContextThemeOptionsNewrelicConfigsFilterInput = {
+  readonly production: Maybe<SitePageContextThemeOptionsNewrelicConfigsProductionFilterInput>;
+  readonly staging: Maybe<SitePageContextThemeOptionsNewrelicConfigsStagingFilterInput>;
+};
+
+type SitePageContextThemeOptionsNewrelicConfigsProductionFilterInput = {
+  readonly instrumentationType: Maybe<StringQueryOperatorInput>;
+  readonly accountId: Maybe<StringQueryOperatorInput>;
+  readonly trustKey: Maybe<StringQueryOperatorInput>;
+  readonly agentID: Maybe<StringQueryOperatorInput>;
+  readonly licenseKey: Maybe<StringQueryOperatorInput>;
+  readonly applicationID: Maybe<StringQueryOperatorInput>;
+  readonly beacon: Maybe<StringQueryOperatorInput>;
+  readonly errorBeacon: Maybe<StringQueryOperatorInput>;
+};
+
+type SitePageContextThemeOptionsNewrelicConfigsStagingFilterInput = {
+  readonly instrumentationType: Maybe<StringQueryOperatorInput>;
+  readonly accountId: Maybe<StringQueryOperatorInput>;
+  readonly trustKey: Maybe<StringQueryOperatorInput>;
+  readonly agentID: Maybe<StringQueryOperatorInput>;
+  readonly licenseKey: Maybe<StringQueryOperatorInput>;
+  readonly applicationID: Maybe<StringQueryOperatorInput>;
+  readonly beacon: Maybe<StringQueryOperatorInput>;
+  readonly errorBeacon: Maybe<StringQueryOperatorInput>;
+};
+
+type SitePageContextThemeOptionsTessenFilterInput = {
+  readonly tessenVersion: Maybe<StringQueryOperatorInput>;
+  readonly product: Maybe<StringQueryOperatorInput>;
+  readonly subproduct: Maybe<StringQueryOperatorInput>;
+  readonly segmentWriteKey: Maybe<StringQueryOperatorInput>;
+  readonly trackPageViews: Maybe<BooleanQueryOperatorInput>;
+  readonly pageView: Maybe<SitePageContextThemeOptionsTessenPageViewFilterInput>;
+};
+
+type SitePageContextThemeOptionsTessenPageViewFilterInput = {
+  readonly eventName: Maybe<StringQueryOperatorInput>;
+  readonly category: Maybe<StringQueryOperatorInput>;
+};
+
 type SitePluginFilterInput = {
   readonly resolve: Maybe<StringQueryOperatorInput>;
   readonly name: Maybe<StringQueryOperatorInput>;
@@ -3484,6 +3625,7 @@ type SitePluginPluginOptionsConfigsStagingFilterInput = {
 type SitePluginPluginOptionsLayoutFilterInput = {
   readonly contentPadding: Maybe<StringQueryOperatorInput>;
   readonly maxWidth: Maybe<StringQueryOperatorInput>;
+  readonly sidebarWidth: Maybe<StringQueryOperatorInput>;
   readonly component: Maybe<StringQueryOperatorInput>;
   readonly mobileBreakpoint: Maybe<StringQueryOperatorInput>;
 };
@@ -3656,131 +3798,6 @@ type SitePluginPackageJsonPeerDependenciesFilterInput = {
   readonly version: Maybe<StringQueryOperatorInput>;
 };
 
-type SitePageContextFilterInput = {
-  readonly layout: Maybe<StringQueryOperatorInput>;
-  readonly themeOptions: Maybe<SitePageContextThemeOptionsFilterInput>;
-  readonly swiftypeEngineKey: Maybe<StringQueryOperatorInput>;
-  readonly fileRelativePath: Maybe<StringQueryOperatorInput>;
-  readonly locale: Maybe<StringQueryOperatorInput>;
-  readonly slug: Maybe<StringQueryOperatorInput>;
-  readonly guidesFilter: Maybe<StringQueryOperatorInput>;
-};
-
-type SitePageContextThemeOptionsFilterInput = {
-  readonly oneTrustID: Maybe<StringQueryOperatorInput>;
-  readonly forceTrailingSlashes: Maybe<BooleanQueryOperatorInput>;
-  readonly layout: Maybe<SitePageContextThemeOptionsLayoutFilterInput>;
-  readonly prism: Maybe<SitePageContextThemeOptionsPrismFilterInput>;
-  readonly splitio: Maybe<SitePageContextThemeOptionsSplitioFilterInput>;
-  readonly relatedResources: Maybe<SitePageContextThemeOptionsRelatedResourcesFilterInput>;
-  readonly newrelic: Maybe<SitePageContextThemeOptionsNewrelicFilterInput>;
-  readonly tessen: Maybe<SitePageContextThemeOptionsTessenFilterInput>;
-};
-
-type SitePageContextThemeOptionsLayoutFilterInput = {
-  readonly contentPadding: Maybe<StringQueryOperatorInput>;
-  readonly maxWidth: Maybe<StringQueryOperatorInput>;
-  readonly component: Maybe<StringQueryOperatorInput>;
-  readonly mobileBreakpoint: Maybe<StringQueryOperatorInput>;
-};
-
-type SitePageContextThemeOptionsPrismFilterInput = {
-  readonly languages: Maybe<StringQueryOperatorInput>;
-};
-
-type SitePageContextThemeOptionsSplitioFilterInput = {
-  readonly core: Maybe<SitePageContextThemeOptionsSplitioCoreFilterInput>;
-  readonly features: Maybe<SitePageContextThemeOptionsSplitioFeaturesFilterInput>;
-  readonly env: Maybe<SitePageContextThemeOptionsSplitioEnvFilterInput>;
-};
-
-type SitePageContextThemeOptionsSplitioCoreFilterInput = {
-  readonly authorizationKey: Maybe<StringQueryOperatorInput>;
-};
-
-type SitePageContextThemeOptionsSplitioFeaturesFilterInput = {
-  readonly free_account_button_color: Maybe<SitePageContextThemeOptionsSplitioFeaturesFree_account_button_colorFilterInput>;
-};
-
-type SitePageContextThemeOptionsSplitioFeaturesFree_account_button_colorFilterInput = {
-  readonly treatment: Maybe<StringQueryOperatorInput>;
-};
-
-type SitePageContextThemeOptionsSplitioEnvFilterInput = {
-  readonly development: Maybe<SitePageContextThemeOptionsSplitioEnvDevelopmentFilterInput>;
-};
-
-type SitePageContextThemeOptionsSplitioEnvDevelopmentFilterInput = {
-  readonly features: Maybe<SitePageContextThemeOptionsSplitioEnvDevelopmentFeaturesFilterInput>;
-  readonly core: Maybe<SitePageContextThemeOptionsSplitioEnvDevelopmentCoreFilterInput>;
-};
-
-type SitePageContextThemeOptionsSplitioEnvDevelopmentFeaturesFilterInput = {
-  readonly developer_website_global_header_gh_buttons: Maybe<StringQueryOperatorInput>;
-  readonly developer_website_right_rail_buttons: Maybe<StringQueryOperatorInput>;
-  readonly super_tiles: Maybe<StringQueryOperatorInput>;
-};
-
-type SitePageContextThemeOptionsSplitioEnvDevelopmentCoreFilterInput = {
-  readonly authorizationKey: Maybe<StringQueryOperatorInput>;
-};
-
-type SitePageContextThemeOptionsRelatedResourcesFilterInput = {
-  readonly swiftype: Maybe<SitePageContextThemeOptionsRelatedResourcesSwiftypeFilterInput>;
-};
-
-type SitePageContextThemeOptionsRelatedResourcesSwiftypeFilterInput = {
-  readonly resultsPath: Maybe<StringQueryOperatorInput>;
-  readonly refetch: Maybe<BooleanQueryOperatorInput>;
-  readonly engineKey: Maybe<StringQueryOperatorInput>;
-  readonly limit: Maybe<IntQueryOperatorInput>;
-};
-
-type SitePageContextThemeOptionsNewrelicFilterInput = {
-  readonly configs: Maybe<SitePageContextThemeOptionsNewrelicConfigsFilterInput>;
-};
-
-type SitePageContextThemeOptionsNewrelicConfigsFilterInput = {
-  readonly production: Maybe<SitePageContextThemeOptionsNewrelicConfigsProductionFilterInput>;
-  readonly staging: Maybe<SitePageContextThemeOptionsNewrelicConfigsStagingFilterInput>;
-};
-
-type SitePageContextThemeOptionsNewrelicConfigsProductionFilterInput = {
-  readonly instrumentationType: Maybe<StringQueryOperatorInput>;
-  readonly accountId: Maybe<StringQueryOperatorInput>;
-  readonly trustKey: Maybe<StringQueryOperatorInput>;
-  readonly agentID: Maybe<StringQueryOperatorInput>;
-  readonly licenseKey: Maybe<StringQueryOperatorInput>;
-  readonly applicationID: Maybe<StringQueryOperatorInput>;
-  readonly beacon: Maybe<StringQueryOperatorInput>;
-  readonly errorBeacon: Maybe<StringQueryOperatorInput>;
-};
-
-type SitePageContextThemeOptionsNewrelicConfigsStagingFilterInput = {
-  readonly instrumentationType: Maybe<StringQueryOperatorInput>;
-  readonly accountId: Maybe<StringQueryOperatorInput>;
-  readonly trustKey: Maybe<StringQueryOperatorInput>;
-  readonly agentID: Maybe<StringQueryOperatorInput>;
-  readonly licenseKey: Maybe<StringQueryOperatorInput>;
-  readonly applicationID: Maybe<StringQueryOperatorInput>;
-  readonly beacon: Maybe<StringQueryOperatorInput>;
-  readonly errorBeacon: Maybe<StringQueryOperatorInput>;
-};
-
-type SitePageContextThemeOptionsTessenFilterInput = {
-  readonly tessenVersion: Maybe<StringQueryOperatorInput>;
-  readonly product: Maybe<StringQueryOperatorInput>;
-  readonly subproduct: Maybe<StringQueryOperatorInput>;
-  readonly segmentWriteKey: Maybe<StringQueryOperatorInput>;
-  readonly trackPageViews: Maybe<BooleanQueryOperatorInput>;
-  readonly pageView: Maybe<SitePageContextThemeOptionsTessenPageViewFilterInput>;
-};
-
-type SitePageContextThemeOptionsTessenPageViewFilterInput = {
-  readonly eventName: Maybe<StringQueryOperatorInput>;
-  readonly category: Maybe<StringQueryOperatorInput>;
-};
-
 type SitePageConnection = {
   readonly totalCount: Scalars['Int'];
   readonly edges: ReadonlyArray<SitePageEdge>;
@@ -3832,7 +3849,112 @@ type SitePageFieldsEnum =
   | 'internalComponentName'
   | 'componentChunkName'
   | 'matchPath'
+  | 'id'
+  | 'parent.id'
+  | 'parent.parent.id'
+  | 'parent.parent.parent.id'
+  | 'parent.parent.parent.children'
+  | 'parent.parent.children'
+  | 'parent.parent.children.id'
+  | 'parent.parent.children.children'
+  | 'parent.parent.internal.content'
+  | 'parent.parent.internal.contentDigest'
+  | 'parent.parent.internal.description'
+  | 'parent.parent.internal.fieldOwners'
+  | 'parent.parent.internal.ignoreType'
+  | 'parent.parent.internal.mediaType'
+  | 'parent.parent.internal.owner'
+  | 'parent.parent.internal.type'
+  | 'parent.children'
+  | 'parent.children.id'
+  | 'parent.children.parent.id'
+  | 'parent.children.parent.children'
+  | 'parent.children.children'
+  | 'parent.children.children.id'
+  | 'parent.children.children.children'
+  | 'parent.children.internal.content'
+  | 'parent.children.internal.contentDigest'
+  | 'parent.children.internal.description'
+  | 'parent.children.internal.fieldOwners'
+  | 'parent.children.internal.ignoreType'
+  | 'parent.children.internal.mediaType'
+  | 'parent.children.internal.owner'
+  | 'parent.children.internal.type'
+  | 'parent.internal.content'
+  | 'parent.internal.contentDigest'
+  | 'parent.internal.description'
+  | 'parent.internal.fieldOwners'
+  | 'parent.internal.ignoreType'
+  | 'parent.internal.mediaType'
+  | 'parent.internal.owner'
+  | 'parent.internal.type'
+  | 'children'
+  | 'children.id'
+  | 'children.parent.id'
+  | 'children.parent.parent.id'
+  | 'children.parent.parent.children'
+  | 'children.parent.children'
+  | 'children.parent.children.id'
+  | 'children.parent.children.children'
+  | 'children.parent.internal.content'
+  | 'children.parent.internal.contentDigest'
+  | 'children.parent.internal.description'
+  | 'children.parent.internal.fieldOwners'
+  | 'children.parent.internal.ignoreType'
+  | 'children.parent.internal.mediaType'
+  | 'children.parent.internal.owner'
+  | 'children.parent.internal.type'
+  | 'children.children'
+  | 'children.children.id'
+  | 'children.children.parent.id'
+  | 'children.children.parent.children'
+  | 'children.children.children'
+  | 'children.children.children.id'
+  | 'children.children.children.children'
+  | 'children.children.internal.content'
+  | 'children.children.internal.contentDigest'
+  | 'children.children.internal.description'
+  | 'children.children.internal.fieldOwners'
+  | 'children.children.internal.ignoreType'
+  | 'children.children.internal.mediaType'
+  | 'children.children.internal.owner'
+  | 'children.children.internal.type'
+  | 'children.internal.content'
+  | 'children.internal.contentDigest'
+  | 'children.internal.description'
+  | 'children.internal.fieldOwners'
+  | 'children.internal.ignoreType'
+  | 'children.internal.mediaType'
+  | 'children.internal.owner'
+  | 'children.internal.type'
+  | 'internal.content'
+  | 'internal.contentDigest'
+  | 'internal.description'
+  | 'internal.fieldOwners'
+  | 'internal.ignoreType'
+  | 'internal.mediaType'
+  | 'internal.owner'
+  | 'internal.type'
   | 'isCreatedByStatefulCreatePages'
+  | 'context.slug'
+  | 'context.fileRelativePath'
+  | 'context.layout'
+  | 'context.locale'
+  | 'context.guidesFilter'
+  | 'context.themeOptions.oneTrustID'
+  | 'context.themeOptions.forceTrailingSlashes'
+  | 'context.themeOptions.layout.contentPadding'
+  | 'context.themeOptions.layout.maxWidth'
+  | 'context.themeOptions.layout.sidebarWidth'
+  | 'context.themeOptions.layout.component'
+  | 'context.themeOptions.layout.mobileBreakpoint'
+  | 'context.themeOptions.prism.languages'
+  | 'context.themeOptions.tessen.tessenVersion'
+  | 'context.themeOptions.tessen.product'
+  | 'context.themeOptions.tessen.subproduct'
+  | 'context.themeOptions.tessen.segmentWriteKey'
+  | 'context.themeOptions.tessen.trackPageViews'
+  | 'context.swiftypeEngineKey'
   | 'pluginCreator.resolve'
   | 'pluginCreator.name'
   | 'pluginCreator.version'
@@ -3867,6 +3989,7 @@ type SitePageFieldsEnum =
   | 'pluginCreator.pluginOptions.forceTrailingSlashes'
   | 'pluginCreator.pluginOptions.layout.contentPadding'
   | 'pluginCreator.pluginOptions.layout.maxWidth'
+  | 'pluginCreator.pluginOptions.layout.sidebarWidth'
   | 'pluginCreator.pluginOptions.layout.component'
   | 'pluginCreator.pluginOptions.layout.mobileBreakpoint'
   | 'pluginCreator.pluginOptions.prism.languages'
@@ -3974,111 +4097,7 @@ type SitePageFieldsEnum =
   | 'pluginCreator.internal.mediaType'
   | 'pluginCreator.internal.owner'
   | 'pluginCreator.internal.type'
-  | 'pluginCreatorId'
-  | 'id'
-  | 'parent.id'
-  | 'parent.parent.id'
-  | 'parent.parent.parent.id'
-  | 'parent.parent.parent.children'
-  | 'parent.parent.children'
-  | 'parent.parent.children.id'
-  | 'parent.parent.children.children'
-  | 'parent.parent.internal.content'
-  | 'parent.parent.internal.contentDigest'
-  | 'parent.parent.internal.description'
-  | 'parent.parent.internal.fieldOwners'
-  | 'parent.parent.internal.ignoreType'
-  | 'parent.parent.internal.mediaType'
-  | 'parent.parent.internal.owner'
-  | 'parent.parent.internal.type'
-  | 'parent.children'
-  | 'parent.children.id'
-  | 'parent.children.parent.id'
-  | 'parent.children.parent.children'
-  | 'parent.children.children'
-  | 'parent.children.children.id'
-  | 'parent.children.children.children'
-  | 'parent.children.internal.content'
-  | 'parent.children.internal.contentDigest'
-  | 'parent.children.internal.description'
-  | 'parent.children.internal.fieldOwners'
-  | 'parent.children.internal.ignoreType'
-  | 'parent.children.internal.mediaType'
-  | 'parent.children.internal.owner'
-  | 'parent.children.internal.type'
-  | 'parent.internal.content'
-  | 'parent.internal.contentDigest'
-  | 'parent.internal.description'
-  | 'parent.internal.fieldOwners'
-  | 'parent.internal.ignoreType'
-  | 'parent.internal.mediaType'
-  | 'parent.internal.owner'
-  | 'parent.internal.type'
-  | 'children'
-  | 'children.id'
-  | 'children.parent.id'
-  | 'children.parent.parent.id'
-  | 'children.parent.parent.children'
-  | 'children.parent.children'
-  | 'children.parent.children.id'
-  | 'children.parent.children.children'
-  | 'children.parent.internal.content'
-  | 'children.parent.internal.contentDigest'
-  | 'children.parent.internal.description'
-  | 'children.parent.internal.fieldOwners'
-  | 'children.parent.internal.ignoreType'
-  | 'children.parent.internal.mediaType'
-  | 'children.parent.internal.owner'
-  | 'children.parent.internal.type'
-  | 'children.children'
-  | 'children.children.id'
-  | 'children.children.parent.id'
-  | 'children.children.parent.children'
-  | 'children.children.children'
-  | 'children.children.children.id'
-  | 'children.children.children.children'
-  | 'children.children.internal.content'
-  | 'children.children.internal.contentDigest'
-  | 'children.children.internal.description'
-  | 'children.children.internal.fieldOwners'
-  | 'children.children.internal.ignoreType'
-  | 'children.children.internal.mediaType'
-  | 'children.children.internal.owner'
-  | 'children.children.internal.type'
-  | 'children.internal.content'
-  | 'children.internal.contentDigest'
-  | 'children.internal.description'
-  | 'children.internal.fieldOwners'
-  | 'children.internal.ignoreType'
-  | 'children.internal.mediaType'
-  | 'children.internal.owner'
-  | 'children.internal.type'
-  | 'internal.content'
-  | 'internal.contentDigest'
-  | 'internal.description'
-  | 'internal.fieldOwners'
-  | 'internal.ignoreType'
-  | 'internal.mediaType'
-  | 'internal.owner'
-  | 'internal.type'
-  | 'context.layout'
-  | 'context.themeOptions.oneTrustID'
-  | 'context.themeOptions.forceTrailingSlashes'
-  | 'context.themeOptions.layout.contentPadding'
-  | 'context.themeOptions.layout.maxWidth'
-  | 'context.themeOptions.layout.component'
-  | 'context.themeOptions.layout.mobileBreakpoint'
-  | 'context.themeOptions.prism.languages'
-  | 'context.themeOptions.tessen.tessenVersion'
-  | 'context.themeOptions.tessen.product'
-  | 'context.themeOptions.tessen.subproduct'
-  | 'context.themeOptions.tessen.segmentWriteKey'
-  | 'context.themeOptions.tessen.trackPageViews'
-  | 'context.swiftypeEngineKey'
-  | 'context.fileRelativePath'
-  | 'context.locale'
-  | 'context.slug'
-  | 'context.guidesFilter';
+  | 'pluginCreatorId';
 
 type SitePageGroupConnection = {
   readonly totalCount: Scalars['Int'];
@@ -4127,14 +4146,14 @@ type SitePageFilterInput = {
   readonly internalComponentName: Maybe<StringQueryOperatorInput>;
   readonly componentChunkName: Maybe<StringQueryOperatorInput>;
   readonly matchPath: Maybe<StringQueryOperatorInput>;
-  readonly isCreatedByStatefulCreatePages: Maybe<BooleanQueryOperatorInput>;
-  readonly pluginCreator: Maybe<SitePluginFilterInput>;
-  readonly pluginCreatorId: Maybe<StringQueryOperatorInput>;
   readonly id: Maybe<StringQueryOperatorInput>;
   readonly parent: Maybe<NodeFilterInput>;
   readonly children: Maybe<NodeFilterListInput>;
   readonly internal: Maybe<InternalFilterInput>;
+  readonly isCreatedByStatefulCreatePages: Maybe<BooleanQueryOperatorInput>;
   readonly context: Maybe<SitePageContextFilterInput>;
+  readonly pluginCreator: Maybe<SitePluginFilterInput>;
+  readonly pluginCreatorId: Maybe<StringQueryOperatorInput>;
 };
 
 type SitePageSortInput = {
@@ -4238,6 +4257,7 @@ type SitePluginFieldsEnum =
   | 'pluginOptions.forceTrailingSlashes'
   | 'pluginOptions.layout.contentPadding'
   | 'pluginOptions.layout.maxWidth'
+  | 'pluginOptions.layout.sidebarWidth'
   | 'pluginOptions.layout.component'
   | 'pluginOptions.layout.mobileBreakpoint'
   | 'pluginOptions.prism.languages'
@@ -5253,6 +5273,15 @@ type NewRelicThemeSignupConfigFilterInput = {
   readonly signupURL: Maybe<StringQueryOperatorInput>;
 };
 
+type RoutesAllowingScrollFilterInput = {
+  readonly routes: Maybe<StringQueryOperatorInput>;
+};
+
+type NewRelicThemeFeedbackConfigFilterInput = {
+  readonly environment: Maybe<StringQueryOperatorInput>;
+  readonly reCaptchaToken: Maybe<StringQueryOperatorInput>;
+};
+
 type NewRelicThemeConfigConnection = {
   readonly totalCount: Scalars['Int'];
   readonly edges: ReadonlyArray<NewRelicThemeConfigEdge>;
@@ -5308,6 +5337,9 @@ type NewRelicThemeConfigFieldsEnum =
   | 'signup.environment'
   | 'signup.reCaptchaToken'
   | 'signup.signupURL'
+  | 'shouldUpdateScroll.routes'
+  | 'feedback.environment'
+  | 'feedback.reCaptchaToken'
   | 'id'
   | 'parent.id'
   | 'parent.parent.id'
@@ -5441,6 +5473,8 @@ type NewRelicThemeConfigFilterInput = {
   readonly relatedResources: Maybe<NewRelicThemeRelatedResourceConfigFilterInput>;
   readonly tessen: Maybe<NewRelicThemeTessenConfigFilterInput>;
   readonly signup: Maybe<NewRelicThemeSignupConfigFilterInput>;
+  readonly shouldUpdateScroll: Maybe<RoutesAllowingScrollFilterInput>;
+  readonly feedback: Maybe<NewRelicThemeFeedbackConfigFilterInput>;
   readonly id: Maybe<StringQueryOperatorInput>;
   readonly parent: Maybe<NodeFilterInput>;
   readonly children: Maybe<NodeFilterListInput>;
@@ -6554,36 +6588,36 @@ type NewRelicSdkAssets = {
   readonly css: Scalars['String'];
 };
 
-type usersmtahirDocumentsGitHubdeveloperWebsitesrctemplatesembedPageJs381472333QueryVariables = Exact<{
+type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesembedPageJs381472333QueryVariables = Exact<{
   slug: Scalars['String'];
 }>;
 
 
-type usersmtahirDocumentsGitHubdeveloperWebsitesrctemplatesembedPageJs381472333Query = { readonly mdx: Maybe<(
+type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesembedPageJs381472333Query = { readonly mdx: Maybe<(
     Pick<Mdx, 'body'>
     & { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title'>> }
   )> };
 
 type PageUpdated_pageFragment = { readonly fields: Maybe<Pick<MdxFields, 'gitAuthorTime'>> };
 
-type usersmtahirDocumentsGitHubdeveloperWebsitesrctemplatesGuideTemplateJs3004003558QueryVariables = Exact<{
+type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesGuideTemplateJs3004003558QueryVariables = Exact<{
   slug: Scalars['String'];
 }>;
 
 
-type usersmtahirDocumentsGitHubdeveloperWebsitesrctemplatesGuideTemplateJs3004003558Query = { readonly mdx: Maybe<(
+type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesGuideTemplateJs3004003558Query = { readonly mdx: Maybe<(
     Pick<Mdx, 'body'>
     & { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'duration' | 'title' | 'description' | 'tags'>>, readonly fields: Maybe<Pick<MdxFields, 'fileRelativePath' | 'slug'>>, readonly relatedResources: Maybe<ReadonlyArray<Pick<RelatedResource, 'title' | 'url'>>> }
     & PageUpdated_pageFragment
   )> };
 
-type usersmtahirDocumentsGitHubdeveloperWebsitesrctemplatesOverviewTemplateJs1786578654QueryVariables = Exact<{
+type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesOverviewTemplateJs1786578654QueryVariables = Exact<{
   slug: Scalars['String'];
   guidesFilter: Scalars['String'];
 }>;
 
 
-type usersmtahirDocumentsGitHubdeveloperWebsitesrctemplatesOverviewTemplateJs1786578654Query = { readonly mdx: Maybe<(
+type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesOverviewTemplateJs1786578654Query = { readonly mdx: Maybe<(
     Pick<Mdx, 'body'>
     & { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'path' | 'title' | 'description'>> }
   )>, readonly guides: { readonly nodes: ReadonlyArray<{ readonly fields: Maybe<Pick<MdxFields, 'slug'>>, readonly frontmatter: Maybe<(
@@ -6591,13 +6625,13 @@ type usersmtahirDocumentsGitHubdeveloperWebsitesrctemplatesOverviewTemplateJs178
         & { readonly tileShorthand: Maybe<Pick<MdxFrontmatterTileShorthand, 'title' | 'description'>> }
       )> }> } };
 
-type usersmtahirDocumentsGitHubdeveloperWebsitesrctemplatesLabOverviewTemplateJs3626099723QueryVariables = Exact<{
+type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesLabOverviewTemplateJs3626099723QueryVariables = Exact<{
   slug: Scalars['String'];
   guidesFilter: Scalars['String'];
 }>;
 
 
-type usersmtahirDocumentsGitHubdeveloperWebsitesrctemplatesLabOverviewTemplateJs3626099723Query = { readonly mdx: Maybe<(
+type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesLabOverviewTemplateJs3626099723Query = { readonly mdx: Maybe<(
     Pick<Mdx, 'body'>
     & { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'path' | 'title' | 'description'>> }
   )>, readonly guides: { readonly nodes: ReadonlyArray<{ readonly fields: Maybe<Pick<MdxFields, 'slug'>>, readonly frontmatter: Maybe<(
@@ -6673,24 +6707,24 @@ type TypeDefReference_typeDefFragment = (
   & { readonly properties: Maybe<ReadonlyArray<Maybe<Pick<NewRelicSdkTypeDefinitionProperty, 'name' | 'description' | 'type'>>>> }
 );
 
-type usersmtahirDocumentsGitHubdeveloperWebsitesrctemplatesComponentReferenceTemplateJs198282387QueryVariables = Exact<{
+type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesComponentReferenceTemplateJs198282387QueryVariables = Exact<{
   slug: Scalars['String'];
 }>;
 
 
-type usersmtahirDocumentsGitHubdeveloperWebsitesrctemplatesComponentReferenceTemplateJs198282387Query = { readonly newRelicSdkComponent: Maybe<(
+type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesComponentReferenceTemplateJs198282387Query = { readonly newRelicSdkComponent: Maybe<(
     Pick<NewRelicSdkComponent, 'name' | 'description' | 'usage'>
     & { readonly propTypes: ReadonlyArray<PropList_propTypesFragment>, readonly examples: ReadonlyArray<ReferenceExample_exampleFragment>, readonly methods: ReadonlyArray<MethodReference_methodFragment>, readonly typeDefs: ReadonlyArray<TypeDefReference_typeDefFragment> }
   )> };
 
 type ConstantReference_constantFragment = Pick<NewRelicSdkConstant, 'name' | 'value'>;
 
-type usersmtahirDocumentsGitHubdeveloperWebsitesrctemplatesApiReferenceTemplateJs1865166777QueryVariables = Exact<{
+type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesApiReferenceTemplateJs1865166777QueryVariables = Exact<{
   slug: Scalars['String'];
 }>;
 
 
-type usersmtahirDocumentsGitHubdeveloperWebsitesrctemplatesApiReferenceTemplateJs1865166777Query = { readonly newRelicSdkApi: Maybe<(
+type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesApiReferenceTemplateJs1865166777Query = { readonly newRelicSdkApi: Maybe<(
     Pick<NewRelicSdkApi, 'name' | 'description' | 'usage'>
     & { readonly examples: ReadonlyArray<ReferenceExample_exampleFragment>, readonly methods: ReadonlyArray<MethodReference_methodFragment>, readonly typeDefs: Maybe<ReadonlyArray<Maybe<TypeDefReference_typeDefFragment>>>, readonly constants: ReadonlyArray<ConstantReference_constantFragment> }
   )> };
@@ -6700,10 +6734,10 @@ type PagesQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 type PagesQueryQuery = { readonly allSiteFunction: { readonly nodes: ReadonlyArray<Pick<SiteFunction, 'functionRoute'>> }, readonly allSitePage: { readonly nodes: ReadonlyArray<Pick<SitePage, 'path'>> } };
 
-type usersmtahirDocumentsGitHubdeveloperWebsitesrcpagesindexJs1455287213QueryVariables = Exact<{ [key: string]: never; }>;
+type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrcpagesindexJs1455287213QueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type usersmtahirDocumentsGitHubdeveloperWebsitesrcpagesindexJs1455287213Query = { readonly allMdx: { readonly nodes: ReadonlyArray<{ readonly fields: Maybe<Pick<MdxFields, 'slug'>>, readonly frontmatter: Maybe<(
+type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrcpagesindexJs1455287213Query = { readonly allMdx: { readonly nodes: ReadonlyArray<{ readonly fields: Maybe<Pick<MdxFields, 'slug'>>, readonly frontmatter: Maybe<(
         Pick<MdxFrontmatter, 'title' | 'description' | 'duration'>
         & { readonly tileShorthand: Maybe<Pick<MdxFrontmatterTileShorthand, 'title' | 'description'>> }
       )> }> } };
@@ -6734,32 +6768,32 @@ type Unnamed_4_Query = { readonly allMdx: { readonly nodes: ReadonlyArray<(
 type Unnamed_5_QueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type Unnamed_5_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'contributingUrl'>> }> };
-
-type Unnamed_6_QueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type Unnamed_6_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'repository' | 'branch'>> }> };
-
-type Unnamed_7_QueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type Unnamed_7_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'siteUrl' | 'repository'>> }> };
+type Unnamed_5_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'repository' | 'branch'>> }> };
 
 type FooterQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 type FooterQueryQuery = { readonly sitePage: Maybe<Pick<SitePage, 'id'>> };
 
-type GlobalNavLinkQueryQueryVariables = Exact<{ [key: string]: never; }>;
+type Unnamed_6_QueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type GlobalNavLinkQueryQuery = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'siteUrl'>> }> };
+type Unnamed_6_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'siteUrl' | 'repository'>> }> };
 
 type GlobalHeaderQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 type GlobalHeaderQueryQuery = { readonly allLocale: { readonly nodes: ReadonlyArray<Pick<Locale, 'locale' | 'localName' | 'isDefault'>> }, readonly site: Maybe<{ readonly layout: Maybe<Pick<SiteLayout, 'mobileBreakpoint'>> }> };
+
+type GlobalNavLinkQueryQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type GlobalNavLinkQueryQuery = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'siteUrl'>> }> };
+
+type Unnamed_7_QueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type Unnamed_7_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'siteUrl'>> }> };
 
 type Unnamed_8_QueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -6769,7 +6803,7 @@ type Unnamed_8_Query = { readonly allLocale: { readonly nodes: ReadonlyArray<Pic
 type Unnamed_9_QueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type Unnamed_9_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'siteUrl'>> }> };
+type Unnamed_9_Query = { readonly site: Maybe<{ readonly layout: Maybe<Pick<SiteLayout, 'mobileBreakpoint'>> }> };
 
 type Unnamed_10_QueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -6779,35 +6813,30 @@ type Unnamed_10_Query = { readonly site: Maybe<{ readonly layout: Maybe<Pick<Sit
 type Unnamed_11_QueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type Unnamed_11_Query = { readonly site: Maybe<{ readonly layout: Maybe<Pick<SiteLayout, 'mobileBreakpoint'>> }> };
+type Unnamed_11_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'siteUrl'>> }>, readonly newRelicThemeConfig: Maybe<{ readonly relatedResources: { readonly labels: ReadonlyArray<Pick<RelatedResourceLabel, 'baseUrl' | 'label'>> } }> };
 
 type Unnamed_12_QueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type Unnamed_12_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'siteUrl'>> }>, readonly newRelicThemeConfig: Maybe<{ readonly relatedResources: { readonly labels: ReadonlyArray<Pick<RelatedResourceLabel, 'baseUrl' | 'label'>> } }> };
+type Unnamed_12_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<(
+      Pick<SiteSiteMetadata, 'titleTemplate' | 'siteUrl'>
+      & { defaultTitle: SiteSiteMetadata['title'] }
+    )> }>, readonly allLocale: { readonly nodes: ReadonlyArray<Pick<Locale, 'locale' | 'hrefLang' | 'isDefault'>> }, readonly newRelicThemeConfig: Maybe<{ readonly signup: Maybe<Pick<NewRelicThemeSignupConfig, 'reCaptchaToken'>>, readonly feedback: Maybe<Pick<NewRelicThemeFeedbackConfig, 'reCaptchaToken'>> }> };
 
 type Unnamed_13_QueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type Unnamed_13_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<(
-      Pick<SiteSiteMetadata, 'titleTemplate' | 'siteUrl'>
-      & { defaultTitle: SiteSiteMetadata['title'] }
-    )> }>, readonly allLocale: { readonly nodes: ReadonlyArray<Pick<Locale, 'locale' | 'hrefLang' | 'isDefault'>> }, readonly newRelicThemeConfig: Maybe<{ readonly signup: Maybe<Pick<NewRelicThemeSignupConfig, 'reCaptchaToken'>> }> };
-
-type Unnamed_14_QueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type Unnamed_14_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'siteUrl'>>, readonly layout: Maybe<Pick<SiteLayout, 'mobileBreakpoint'>> }> };
+type Unnamed_13_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'siteUrl'>>, readonly layout: Maybe<Pick<SiteLayout, 'mobileBreakpoint'>> }> };
 
 type BarQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 type BarQueryQuery = { readonly site: Maybe<{ readonly layout: Maybe<Pick<SiteLayout, 'mobileBreakpoint'>> }> };
 
-type Unnamed_15_QueryVariables = Exact<{ [key: string]: never; }>;
+type Unnamed_14_QueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type Unnamed_15_Query = { readonly newRelicThemeConfig: Maybe<{ readonly tessen: Maybe<Pick<NewRelicThemeTessenConfig, 'product' | 'subproduct'>> }> };
+type Unnamed_14_Query = { readonly newRelicThemeConfig: Maybe<{ readonly tessen: Maybe<Pick<NewRelicThemeTessenConfig, 'product' | 'subproduct'>> }> };
 
 type Resources_pageFragment = { readonly frontmatter: Maybe<{ readonly resources: Maybe<ReadonlyArray<Maybe<Pick<MdxFrontmatterResources, 'title' | 'url'>>>> }>, readonly relatedResources: Maybe<ReadonlyArray<Pick<RelatedResource, 'title' | 'url'>>> };
 

--- a/src/__generated__/gatsby-types.d.ts
+++ b/src/__generated__/gatsby-types.d.ts
@@ -1014,13 +1014,13 @@ type MdxFrontmatter = {
   readonly endDate: Maybe<Scalars['Date']>;
   readonly title: Scalars['String'];
   readonly path: Maybe<Scalars['String']>;
-  readonly template: Maybe<Scalars['String']>;
   readonly description: Maybe<Scalars['String']>;
+  readonly template: Maybe<Scalars['String']>;
+  readonly redirects: Maybe<ReadonlyArray<Maybe<Scalars['String']>>>;
+  readonly duration: Maybe<Scalars['Int']>;
   readonly tileShorthand: Maybe<MdxFrontmatterTileShorthand>;
   readonly resources: Maybe<ReadonlyArray<Maybe<MdxFrontmatterResources>>>;
   readonly tags: Maybe<ReadonlyArray<Maybe<Scalars['String']>>>;
-  readonly redirects: Maybe<ReadonlyArray<Maybe<Scalars['String']>>>;
-  readonly duration: Maybe<Scalars['Int']>;
   readonly procIdx: Maybe<Scalars['Float']>;
   readonly promote: Maybe<Scalars['Boolean']>;
 };
@@ -2003,13 +2003,13 @@ type MdxFrontmatterFilterInput = {
   readonly endDate: Maybe<DateQueryOperatorInput>;
   readonly title: Maybe<StringQueryOperatorInput>;
   readonly path: Maybe<StringQueryOperatorInput>;
-  readonly template: Maybe<StringQueryOperatorInput>;
   readonly description: Maybe<StringQueryOperatorInput>;
+  readonly template: Maybe<StringQueryOperatorInput>;
+  readonly redirects: Maybe<StringQueryOperatorInput>;
+  readonly duration: Maybe<IntQueryOperatorInput>;
   readonly tileShorthand: Maybe<MdxFrontmatterTileShorthandFilterInput>;
   readonly resources: Maybe<MdxFrontmatterResourcesFilterListInput>;
   readonly tags: Maybe<StringQueryOperatorInput>;
-  readonly redirects: Maybe<StringQueryOperatorInput>;
-  readonly duration: Maybe<IntQueryOperatorInput>;
   readonly procIdx: Maybe<FloatQueryOperatorInput>;
   readonly promote: Maybe<BooleanQueryOperatorInput>;
 };
@@ -2301,16 +2301,16 @@ type FileFieldsEnum =
   | 'childrenMdx.frontmatter.endDate'
   | 'childrenMdx.frontmatter.title'
   | 'childrenMdx.frontmatter.path'
-  | 'childrenMdx.frontmatter.template'
   | 'childrenMdx.frontmatter.description'
+  | 'childrenMdx.frontmatter.template'
+  | 'childrenMdx.frontmatter.redirects'
+  | 'childrenMdx.frontmatter.duration'
   | 'childrenMdx.frontmatter.tileShorthand.title'
   | 'childrenMdx.frontmatter.tileShorthand.description'
   | 'childrenMdx.frontmatter.resources'
   | 'childrenMdx.frontmatter.resources.title'
   | 'childrenMdx.frontmatter.resources.url'
   | 'childrenMdx.frontmatter.tags'
-  | 'childrenMdx.frontmatter.redirects'
-  | 'childrenMdx.frontmatter.duration'
   | 'childrenMdx.frontmatter.procIdx'
   | 'childrenMdx.frontmatter.promote'
   | 'childrenMdx.slug'
@@ -2408,16 +2408,16 @@ type FileFieldsEnum =
   | 'childMdx.frontmatter.endDate'
   | 'childMdx.frontmatter.title'
   | 'childMdx.frontmatter.path'
-  | 'childMdx.frontmatter.template'
   | 'childMdx.frontmatter.description'
+  | 'childMdx.frontmatter.template'
+  | 'childMdx.frontmatter.redirects'
+  | 'childMdx.frontmatter.duration'
   | 'childMdx.frontmatter.tileShorthand.title'
   | 'childMdx.frontmatter.tileShorthand.description'
   | 'childMdx.frontmatter.resources'
   | 'childMdx.frontmatter.resources.title'
   | 'childMdx.frontmatter.resources.url'
   | 'childMdx.frontmatter.tags'
-  | 'childMdx.frontmatter.redirects'
-  | 'childMdx.frontmatter.duration'
   | 'childMdx.frontmatter.procIdx'
   | 'childMdx.frontmatter.promote'
   | 'childMdx.slug'
@@ -5761,16 +5761,16 @@ type MdxFieldsEnum =
   | 'frontmatter.endDate'
   | 'frontmatter.title'
   | 'frontmatter.path'
-  | 'frontmatter.template'
   | 'frontmatter.description'
+  | 'frontmatter.template'
+  | 'frontmatter.redirects'
+  | 'frontmatter.duration'
   | 'frontmatter.tileShorthand.title'
   | 'frontmatter.tileShorthand.description'
   | 'frontmatter.resources'
   | 'frontmatter.resources.title'
   | 'frontmatter.resources.url'
   | 'frontmatter.tags'
-  | 'frontmatter.redirects'
-  | 'frontmatter.duration'
   | 'frontmatter.procIdx'
   | 'frontmatter.promote'
   | 'slug'
@@ -6588,36 +6588,36 @@ type NewRelicSdkAssets = {
   readonly css: Scalars['String'];
 };
 
-type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesembedPageJs381472333QueryVariables = Exact<{
+type usersjmcadooprojectsdeveloperWebsitesrctemplatesembedPageJs381472333QueryVariables = Exact<{
   slug: Scalars['String'];
 }>;
 
 
-type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesembedPageJs381472333Query = { readonly mdx: Maybe<(
+type usersjmcadooprojectsdeveloperWebsitesrctemplatesembedPageJs381472333Query = { readonly mdx: Maybe<(
     Pick<Mdx, 'body'>
     & { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'title'>> }
   )> };
 
 type PageUpdated_pageFragment = { readonly fields: Maybe<Pick<MdxFields, 'gitAuthorTime'>> };
 
-type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesGuideTemplateJs3004003558QueryVariables = Exact<{
+type usersjmcadooprojectsdeveloperWebsitesrctemplatesGuideTemplateJs3004003558QueryVariables = Exact<{
   slug: Scalars['String'];
 }>;
 
 
-type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesGuideTemplateJs3004003558Query = { readonly mdx: Maybe<(
+type usersjmcadooprojectsdeveloperWebsitesrctemplatesGuideTemplateJs3004003558Query = { readonly mdx: Maybe<(
     Pick<Mdx, 'body'>
     & { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'duration' | 'title' | 'description' | 'tags'>>, readonly fields: Maybe<Pick<MdxFields, 'fileRelativePath' | 'slug'>>, readonly relatedResources: Maybe<ReadonlyArray<Pick<RelatedResource, 'title' | 'url'>>> }
     & PageUpdated_pageFragment
   )> };
 
-type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesOverviewTemplateJs1786578654QueryVariables = Exact<{
+type usersjmcadooprojectsdeveloperWebsitesrctemplatesOverviewTemplateJs1786578654QueryVariables = Exact<{
   slug: Scalars['String'];
   guidesFilter: Scalars['String'];
 }>;
 
 
-type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesOverviewTemplateJs1786578654Query = { readonly mdx: Maybe<(
+type usersjmcadooprojectsdeveloperWebsitesrctemplatesOverviewTemplateJs1786578654Query = { readonly mdx: Maybe<(
     Pick<Mdx, 'body'>
     & { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'path' | 'title' | 'description'>> }
   )>, readonly guides: { readonly nodes: ReadonlyArray<{ readonly fields: Maybe<Pick<MdxFields, 'slug'>>, readonly frontmatter: Maybe<(
@@ -6625,13 +6625,13 @@ type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesOverviewTemplateJs
         & { readonly tileShorthand: Maybe<Pick<MdxFrontmatterTileShorthand, 'title' | 'description'>> }
       )> }> } };
 
-type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesLabOverviewTemplateJs3626099723QueryVariables = Exact<{
+type usersjmcadooprojectsdeveloperWebsitesrctemplatesLabOverviewTemplateJs3626099723QueryVariables = Exact<{
   slug: Scalars['String'];
   guidesFilter: Scalars['String'];
 }>;
 
 
-type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesLabOverviewTemplateJs3626099723Query = { readonly mdx: Maybe<(
+type usersjmcadooprojectsdeveloperWebsitesrctemplatesLabOverviewTemplateJs3626099723Query = { readonly mdx: Maybe<(
     Pick<Mdx, 'body'>
     & { readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'path' | 'title' | 'description'>> }
   )>, readonly guides: { readonly nodes: ReadonlyArray<{ readonly fields: Maybe<Pick<MdxFields, 'slug'>>, readonly frontmatter: Maybe<(
@@ -6707,24 +6707,24 @@ type TypeDefReference_typeDefFragment = (
   & { readonly properties: Maybe<ReadonlyArray<Maybe<Pick<NewRelicSdkTypeDefinitionProperty, 'name' | 'description' | 'type'>>>> }
 );
 
-type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesComponentReferenceTemplateJs198282387QueryVariables = Exact<{
+type usersjmcadooprojectsdeveloperWebsitesrctemplatesComponentReferenceTemplateJs198282387QueryVariables = Exact<{
   slug: Scalars['String'];
 }>;
 
 
-type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesComponentReferenceTemplateJs198282387Query = { readonly newRelicSdkComponent: Maybe<(
+type usersjmcadooprojectsdeveloperWebsitesrctemplatesComponentReferenceTemplateJs198282387Query = { readonly newRelicSdkComponent: Maybe<(
     Pick<NewRelicSdkComponent, 'name' | 'description' | 'usage'>
     & { readonly propTypes: ReadonlyArray<PropList_propTypesFragment>, readonly examples: ReadonlyArray<ReferenceExample_exampleFragment>, readonly methods: ReadonlyArray<MethodReference_methodFragment>, readonly typeDefs: ReadonlyArray<TypeDefReference_typeDefFragment> }
   )> };
 
 type ConstantReference_constantFragment = Pick<NewRelicSdkConstant, 'name' | 'value'>;
 
-type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesApiReferenceTemplateJs1865166777QueryVariables = Exact<{
+type usersjmcadooprojectsdeveloperWebsitesrctemplatesApiReferenceTemplateJs1865166777QueryVariables = Exact<{
   slug: Scalars['String'];
 }>;
 
 
-type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrctemplatesApiReferenceTemplateJs1865166777Query = { readonly newRelicSdkApi: Maybe<(
+type usersjmcadooprojectsdeveloperWebsitesrctemplatesApiReferenceTemplateJs1865166777Query = { readonly newRelicSdkApi: Maybe<(
     Pick<NewRelicSdkApi, 'name' | 'description' | 'usage'>
     & { readonly examples: ReadonlyArray<ReferenceExample_exampleFragment>, readonly methods: ReadonlyArray<MethodReference_methodFragment>, readonly typeDefs: Maybe<ReadonlyArray<Maybe<TypeDefReference_typeDefFragment>>>, readonly constants: ReadonlyArray<ConstantReference_constantFragment> }
   )> };
@@ -6734,10 +6734,10 @@ type PagesQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 type PagesQueryQuery = { readonly allSiteFunction: { readonly nodes: ReadonlyArray<Pick<SiteFunction, 'functionRoute'>> }, readonly allSitePage: { readonly nodes: ReadonlyArray<Pick<SitePage, 'path'>> } };
 
-type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrcpagesindexJs1455287213QueryVariables = Exact<{ [key: string]: never; }>;
+type usersjmcadooprojectsdeveloperWebsitesrcpagesindexJs1455287213QueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type userstzeitkeDocumentsCodeDocSdeveloperWebsitesrcpagesindexJs1455287213Query = { readonly allMdx: { readonly nodes: ReadonlyArray<{ readonly fields: Maybe<Pick<MdxFields, 'slug'>>, readonly frontmatter: Maybe<(
+type usersjmcadooprojectsdeveloperWebsitesrcpagesindexJs1455287213Query = { readonly allMdx: { readonly nodes: ReadonlyArray<{ readonly fields: Maybe<Pick<MdxFields, 'slug'>>, readonly frontmatter: Maybe<(
         Pick<MdxFrontmatter, 'title' | 'description' | 'duration'>
         & { readonly tileShorthand: Maybe<Pick<MdxFrontmatterTileShorthand, 'title' | 'description'>> }
       )> }> } };
@@ -6770,35 +6770,35 @@ type Unnamed_5_QueryVariables = Exact<{ [key: string]: never; }>;
 
 type Unnamed_5_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'repository' | 'branch'>> }> };
 
-type FooterQueryQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type FooterQueryQuery = { readonly sitePage: Maybe<Pick<SitePage, 'id'>> };
-
 type Unnamed_6_QueryVariables = Exact<{ [key: string]: never; }>;
 
 
 type Unnamed_6_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'siteUrl' | 'repository'>> }> };
 
-type GlobalHeaderQueryQueryVariables = Exact<{ [key: string]: never; }>;
+type FooterQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type GlobalHeaderQueryQuery = { readonly allLocale: { readonly nodes: ReadonlyArray<Pick<Locale, 'locale' | 'localName' | 'isDefault'>> }, readonly site: Maybe<{ readonly layout: Maybe<Pick<SiteLayout, 'mobileBreakpoint'>> }> };
+type FooterQueryQuery = { readonly sitePage: Maybe<Pick<SitePage, 'id'>> };
 
 type GlobalNavLinkQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 type GlobalNavLinkQueryQuery = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'siteUrl'>> }> };
 
+type GlobalHeaderQueryQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type GlobalHeaderQueryQuery = { readonly allLocale: { readonly nodes: ReadonlyArray<Pick<Locale, 'locale' | 'localName' | 'isDefault'>> }, readonly site: Maybe<{ readonly layout: Maybe<Pick<SiteLayout, 'mobileBreakpoint'>> }> };
+
 type Unnamed_7_QueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type Unnamed_7_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'siteUrl'>> }> };
+type Unnamed_7_Query = { readonly allLocale: { readonly nodes: ReadonlyArray<Pick<Locale, 'name' | 'locale' | 'localName' | 'hrefLang' | 'isDefault'>> } };
 
 type Unnamed_8_QueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type Unnamed_8_Query = { readonly allLocale: { readonly nodes: ReadonlyArray<Pick<Locale, 'name' | 'locale' | 'localName' | 'hrefLang' | 'isDefault'>> } };
+type Unnamed_8_Query = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'siteUrl'>> }> };
 
 type Unnamed_9_QueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -66,7 +66,6 @@ const MainLayout = ({ children, pageContext }) => {
               padding: 2rem 0.5rem 1rem;
               width: var(--sidebar-width);
               margin: -2rem -2rem 0rem;
-              padding: 2rem 2rem 1rem;
             `}
           >
             <Link

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -45,15 +45,28 @@ const MainLayout = ({ children, pageContext }) => {
           display: ${isMobileNavOpen ? 'none' : 'grid'};
         `}
       >
-        <Layout.Sidebar>
+        <Layout.Sidebar
+          css={css`
+            background: var(--erno-black);
+            padding: 0.5rem 0;
+
+            span,
+            svg {
+              color: #afe2e3;
+            }
+          `}
+        >
           <div
             css={css`
-              background: var(--primary-background-color);
               position: sticky;
+              background: var(--erno-black);
               top: -2rem;
               z-index: 10;
               margin: -2rem -0.5rem 0rem;
               padding: 2rem 0.5rem 1rem;
+              width: var(--sidebar-width);
+              margin: -2rem -2rem 0rem;
+              padding: 2rem 2rem 1rem;
             `}
           >
             <Link
@@ -70,9 +83,24 @@ const MainLayout = ({ children, pageContext }) => {
               onClear={() => setSearchTerm('')}
               onChange={(e) => setSearchTerm(e.target.value)}
               value={searchTerm}
+              css={css`
+                svg {
+                  color: var(--primary-text-color);
+                }
+              `}
             />
           </div>
-          <Navigation searchTerm={searchTerm}>
+          <Navigation
+            css={css`
+              overflow-x: hidden;
+              -ms-overflow-style: none;
+              scrollbar-width: none;
+              &::-webkit-scrollbar {
+                display: none;
+              }
+            `}
+            searchTerm={searchTerm}
+          >
             {pages.map((page, idx) => (
               <NavItem key={idx} page={page} />
             ))}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2280,15 +2280,16 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@6.8.0":
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.8.0.tgz#1d2b85e095370b3e006551d911abdaf51767bdd7"
-  integrity sha512-9IEokhypUzNIK6UdP9LwhfVaHMGQlfZFyfySPbPgVKA7dohdj2zGpb5E7Lu8MSaTHEmMa8aeXvVk0TWDhRP2gA==
+"@newrelic/gatsby-theme-newrelic@6.13.7":
+  version "6.13.7"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.13.7.tgz#8df7507044eca1503c975a1e69d09061ed80100f"
+  integrity sha512-pZVis1wuM1FseTYeifvQW6ArEKuwbnjf/Uxz5RbgzpiHhQYxT8Oi67TG82KzrQPw59uRNoiPrePxyLrHBWfUHA==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"
     babel-plugin-prismjs "^2.0.1"
     date-fns "^2.21.0"
+    file-saver "^2.0.5"
     gatsby-plugin-emotion "^6.10.0"
     gatsby-plugin-layout "^2.10.0"
     gatsby-plugin-newrelic "^2.0.0"
@@ -2312,6 +2313,7 @@
     react-live "^2.2.3"
     react-middle-ellipsis "^1.1.0"
     react-query "^3.7.1"
+    react-scroll "1.8.7"
     react-simple-code-editor "^0.11.0"
     react-spring "^9.1.2"
     react-typist "^2.0.5"
@@ -7048,6 +7050,11 @@ file-loader@^6.2.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
+file-saver@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
+  integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
+
 file-type@^16.5.3:
   version "16.5.3"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-16.5.3.tgz#474b7e88c74724046abb505e9b8ed4db30c4fc06"
@@ -10819,6 +10826,11 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
+
 lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
@@ -13790,6 +13802,14 @@ react-refresh@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.9.0.tgz#71863337adc3e5c2f8a6bfddd12ae3bfe32aafbf"
   integrity sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==
+
+react-scroll@1.8.7:
+  version "1.8.7"
+  resolved "https://registry.yarnpkg.com/react-scroll/-/react-scroll-1.8.7.tgz#8020035329efad00f03964e18aff6822137de3aa"
+  integrity sha512-fBOIwweAlhicx8RqP9tQXn/Uhd+DTtVRjw+0VBsIn1Z+MjRYLhTZ0tMoTAU1vOD3dce8mI6copexI4yWII+Luw==
+  dependencies:
+    lodash.throttle "^4.1.1"
+    prop-types "^15.7.2"
 
 react-shadow@^18.6.1:
   version "18.6.2"


### PR DESCRIPTION
Theme bump to get the developer site up to date with the theme, added styles to make the side nav look the same as that of the docs site.