### PR TITLE
Make sdk label dark mode responsive

### DIFF
--- a/src/components/ReferencePreview.js
+++ b/src/components/ReferencePreview.js
@@ -240,6 +240,10 @@ const EXAMPLE_CSS = `
   font-family: Open Sans,Segoe UI,Tahoma,sans-serif;
 }
 
+.nr1-ReferenceExample label {
+  color: var(--primary-text-color);
+}
+
 .nr1-ReferenceExample-ToastManager > div {
   position: fixed;
   top: 0;


### PR DESCRIPTION
This makes labels in sdk component doc previews a light color when in dark mode (check out the TextField component for an example)

### before
<img width="263" alt="Screen Shot 2022-12-19 at 9 23 18 AM" src="https://user-images.githubusercontent.com/39655074/208483901-e6597277-359b-4f47-875f-c825e0525e87.png">

### after
<img width="265" alt="Screen Shot 2022-12-19 at 1 29 56 PM" src="https://user-images.githubusercontent.com/39655074/208527825-1084f91b-d392-475d-86c6-91d45bad90e1.png">
