### PR TITLE
Update quickstart guide with changes for data sources and install plans

### DIFF
--- a/src/markdown-pages/contribute-to-quickstarts/build-a-quickstart/add-data-source.mdx
+++ b/src/markdown-pages/contribute-to-quickstarts/build-a-quickstart/add-data-source.mdx
@@ -76,9 +76,9 @@ description: |
     - low cache hit 
 icon: logo.svg
 install:
-  mode: link
-  destination: 
-    url: https://www.newrelic.com      
+  primary:
+    link:
+      url: https://www.newrelic.com
 keywords:
   - infrastructure
   - database

--- a/src/markdown-pages/contribute-to-quickstarts/build-a-quickstart/add-data-source.mdx
+++ b/src/markdown-pages/contribute-to-quickstarts/build-a-quickstart/add-data-source.mdx
@@ -76,9 +76,9 @@ description: |
     - low cache hit 
 icon: logo.svg
 install:
-  primary:
-    link:
-      url: https://www.newrelic.com
+  mode: link
+  destination: 
+    url: https://www.newrelic.com      
 keywords:
   - infrastructure
   - database

--- a/src/markdown-pages/contribute-to-quickstarts/build-a-quickstart/understand-quickstart.mdx
+++ b/src/markdown-pages/contribute-to-quickstarts/build-a-quickstart/understand-quickstart.mdx
@@ -42,10 +42,6 @@ data-sources/
         config.yml
         logo.svg
 
-install/
-    example-install-plan/
-        install.yml
-
 quickstarts/
     example-quickstart/
         config.yml


### PR DESCRIPTION
Updates for data sources:
* `install/` will be removed and use of install plans deprecated
