### PR TITLE
Tabatha/gh actions deprecations

### DIFF
--- a/.github/workflows/fetch-related-content.yml
+++ b/.github/workflows/fetch-related-content.yml
@@ -19,7 +19,7 @@ jobs:
           ref: main
 
       - name: Setup node.js
-        uses: actions/setup-nodev3
+        uses: actions/setup-node@v3
         with:
           node-version: 17
 

--- a/.github/workflows/fetch-related-content.yml
+++ b/.github/workflows/fetch-related-content.yml
@@ -19,7 +19,7 @@ jobs:
           ref: main
 
       - name: Setup node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-nodev3
         with:
           node-version: 17
 
@@ -27,7 +27,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/fetch-related-content.yml
+++ b/.github/workflows/fetch-related-content.yml
@@ -48,7 +48,7 @@ jobs:
           github-token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview
           script: |
-            const result = await github.repos.updateBranchProtection({
+            const result = await github.rest.repos.updateBranchProtection({
               owner: context.repo.owner,
               repo: context.repo.repo,
               branch: 'main',
@@ -86,7 +86,7 @@ jobs:
           github-token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview
           script: |
-            const result = await github.repos.updateBranchProtection({
+            const result = await github.rest.repos.updateBranchProtection({
               owner: context.repo.owner,
               repo: context.repo.repo,
               branch: 'main',

--- a/.github/workflows/fetch-related-content.yml
+++ b/.github/workflows/fetch-related-content.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v2
         id: yarn-cache
@@ -66,7 +66,7 @@ jobs:
           git config --local user.name "${{ env.BOT_NAME }}"
           git add ./src/data/related-pages.json
           git commit -m 'chore(related-content): updated related content data'
-          echo "::set-output name=commit::true"
+          echo "commit=true" >> $GITHUB_OUTPUT
 
       # Push directly to `main` branch because we want updates to the related
       # content to trigger a deploy. If we commit directly to the `develop`

--- a/.github/workflows/fetch-related-content.yml
+++ b/.github/workflows/fetch-related-content.yml
@@ -22,18 +22,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 17
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/fetch-related-content.yml
+++ b/.github/workflows/fetch-related-content.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: main
 

--- a/.github/workflows/fetch-related-content.yml
+++ b/.github/workflows/fetch-related-content.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Temporarily disable branch protection
         id: disable-branch-protection
-        uses: actions/github-script@v1
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview
@@ -81,7 +81,7 @@ jobs:
       - name: Re-enable branch protection
         id: enable-branch-protection
         if: always()
-        uses: actions/github-script@v1
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           github-token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview
           script: |
-            const result = await github.repos.updateBranchProtection({
+            const result = await github.rest.repos.updateBranchProtection({
               owner: context.repo.owner,
               repo: context.repo.repo,
               branch: 'develop',
@@ -105,7 +105,7 @@ jobs:
           github-token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview
           script: |
-            const result = await github.repos.updateBranchProtection({
+            const result = await github.rest.repos.updateBranchProtection({
               owner: context.repo.owner,
               repo: context.repo.repo,
               branch: 'develop',
@@ -144,7 +144,7 @@ jobs:
           github-token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview
           script: |
-            const result = await github.repos.updateBranchProtection({
+            const result = await github.rest.repos.updateBranchProtection({
               owner: context.repo.owner,
               repo: context.repo.repo,
               branch: 'develop',
@@ -174,7 +174,7 @@ jobs:
           github-token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview
           script: |
-            const result = await github.repos.updateBranchProtection({
+            const result = await github.rest.repos.updateBranchProtection({
               owner: context.repo.owner,
               repo: context.repo.repo,
               branch: 'develop',

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,18 +24,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 17
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       # Checkout fetch-depth: 2 because there's a check to see if package.json
       # was updated, and need at least 2 commits for the check to function properly
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
@@ -124,7 +124,7 @@ jobs:
     needs: [generate-third-party-notices]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Node.js
-        uses: actions/setup-nodev3
+        uses: actions/setup-node@v3
         with:
           node-version: 17
 
@@ -127,7 +127,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-nodev3
+        uses: actions/setup-node@v3
         with:
           # semantic-release requires >= 14
           node-version: 17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Temporarily disable "required_pull_request_reviews" branch protection
         id: disable-branch-protection
         if: always()
-        uses: actions/github-script@v1
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview
@@ -100,7 +100,7 @@ jobs:
       - name: Re-enable "required_pull_request_reviews" branch protection
         id: enable-branch-protection
         if: always()
-        uses: actions/github-script@v1
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview
@@ -139,7 +139,7 @@ jobs:
       - name: Temporarily disable "required_pull_request_reviews" branch protection
         id: disable-branch-protection
         if: always()
-        uses: actions/github-script@v1
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview
@@ -169,7 +169,7 @@ jobs:
       - name: Re-enable "required_pull_request_reviews" branch protection
         id: enable-branch-protection
         if: always()
-        uses: actions/github-script@v1
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
           previews: luke-cage-preview

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v2
         id: yarn-cache
@@ -66,7 +66,7 @@ jobs:
             git add third_party_manifest.json
             git add THIRD_PARTY_NOTICES.md
             git commit -m 'chore: update third-party manifest and notices [skip-cd]'
-            echo "::set-output name=commit::true"
+            echo "commit=true" >> $GITHUB_OUTPUT
           else
             echo "No change in package.json, not regenerating third-party notices"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-nodev3
         with:
           node-version: 17
 
@@ -29,7 +29,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "dir$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -127,7 +127,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-nodev3
         with:
           # semantic-release requires >= 14
           node-version: 17

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 17
 
@@ -38,10 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 17
 

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Cache dependencies
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
@@ -47,7 +47,7 @@ jobs:
 
       - name: Cache dependencies
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
two notable syntax changes here:

breaking changes to octokit in `github-script@v5`:
https://github.com/actions/github-script#breaking-changes-in-v5
https://octokit.github.io/rest.js/v19#repos-update-branch-protection
```
// old
 github.repos.updateBranchProtection
```
```
// new
 github.rest.repos.updateBranchProtection

```
`actions/setup-node@v3` now has build in cache features:
https://stackoverflow.com/a/62244232
https://github.com/actions/setup-node/blob/main/action.yml#L24

```
// old
with:
          node-version: 17

      - name: Get yarn cache directory path
        id: yarn-cache-dir-path
        run: echo "::set-output name=dir::$(yarn cache dir)"

      - uses: actions/cache@v2
        id: yarn-cache
        with:
          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
          restore-keys: |
            ${{ runner.os }}-yarn-
```
we are using this setup in many places within our workflows, but the `$(yarn cache dir)` syntax is what throws errors with the version update, so places with that usage are the only ones i've updated for now.
```
// new
with:
          node-version: 17
          cache: 'yarn'

```

testing here: https://github.com/newrelic/developer-website/pull/2232
from what i can tell, the workflows are running

- generate release https://github.com/newrelic/developer-website/actions/runs/4813477554/jobs/8570050321?pr=2232
  -  it's not publishing a release but i'm getting this message `This test run was triggered on the branch tabatha/trigger-workflow, while semantic-release is configured to only publish from develop, therefore a new version won’t be published.` So i think it's working
- validate-pr https://github.com/newrelic/developer-website/actions/runs/4813479957
- fetch-related-content https://github.com/newrelic/developer-website/actions/runs/4813533353/jobs/8570177716