### PR TITLE
Update theme with codeblock fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^11.10.0",
     "@mdx-js/mdx": "^1.6.19",
     "@mdx-js/react": "^1.6.19",
-    "@newrelic/gatsby-theme-newrelic": "6.19.1",
+    "@newrelic/gatsby-theme-newrelic": "7.1.1",
     "@splitsoftware/splitio-react": "^1.2.0",
     "@xstate/react": "^1.0.2",
     "classnames": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2811,10 +2811,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@6.19.1":
-  version "6.19.1"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.19.1.tgz#272c95527d4b111a395e4851e70dea67c0f0d1b3"
-  integrity sha512-ZvL1LeDT+jsweWUIa4NhTCaBSJslrglfd5PBmXstdJ6eOVZHPAPjht6AsRcG6C28EiyvzVnI12GSaLiEwv/bbw==
+"@newrelic/gatsby-theme-newrelic@7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-7.1.1.tgz#9e28103c96dd43cc57377e913444bcc80ef93192"
+  integrity sha512-ZqZICwaWEAXVpJ5eJvbYUjuPdpF/MYy+8EWUC/krrMyt+CA8fKXTK2iq5Y+zolSkaziTTFC8+VxdH8NBZEQj7w==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
This updates the theme which includes a fix for codeblocks. nothing should change here (other than less errors in the console) but we wanna thoroughly check on codeblocks in the sdk docs

example docs: https://developerwebsitedevelop-lizupdatetheme16147.gatsbyjs.io/components/table