### PR TITLE
Modify Pulumi instructions to use pulumi config instead of env vars.

### DIFF
--- a/src/markdown-pages/pulumi/get-started-pulumi.mdx
+++ b/src/markdown-pages/pulumi/get-started-pulumi.mdx
@@ -55,6 +55,7 @@ Next, create a small web application and configure it for use with New Relic. In
 
 ```bash
 cd app
+npm init -y
 npm install express newrelic --save
 touch index.js
 ```
@@ -147,20 +148,25 @@ When the new-project wizard completes, you should be left with the following fol
 
 ## Install and configure the New Relic provider
 
-Still in the `infrastructure` folder, install the [`@pulumi/newrelic`](https://www.pulumi.com/registry/packages/newrelic) package from npm, then configure the New Relic [provider](https://www.pulumi.com/docs/intro/concepts/resources/providers/) with your New Relic [account ID](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id/) and [user key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/):
+Still in the `infrastructure` folder, install the [`@pulumi/newrelic`](https://www.pulumi.com/registry/packages/newrelic) package from npm: 
 
 ```bash
 npm install @pulumi/newrelic
-
-export NEW_RELIC_ACCOUNT_ID="your-account-id"
-export NEW_RELIC_API_KEY="your-user-api-key"
 ```
 
-<Callout variant="tip">
+Then configure the New Relic provider using Pulumi's configuration system, which has built-in support for encrypted secrets.:
 
-Alternatively, you can also configure the New Relic provider using Pulumi's own configuration system, which has built-in support for encrypted secrets. See the [New Relic provider docs](https://www.pulumi.com/registry/packages/newrelic/installation-configuration/) and [Pulumi configuration docs](https://www.pulumi.com/docs/intro/concepts/config/) for details.
+```bash
+pulumi config set newrelic:accountId 123456
+pulumi config set newrelic:apiKey NRAK-XXXXXXXXXXXXXXXXXXXXXXXXXXX --secret
+```
 
+<Callout variant="caution">
+Be sure to use the `--secret` flag when setting your New Relic API key. This will ensure that your API Key is encrypted both in transit and at rest, and that you may safely commit your stack's configuration file to version control.
 </Callout>
+
+
+See [Pulumi configuration docs](https://www.pulumi.com/docs/intro/concepts/config/) for details.
 
 </Step>
 


### PR DESCRIPTION
## Description

By pointing the user to use `pulumi config` instead of env vars, it demonstrates both stack config and Pulumi's encryption of secrets by default, which is one of its more compelling features.

## Reviewer Notes

If there are links or steps needed to test this work, add them here.

## Related Issue(s) / Ticket(s)

If there are any related [GitHub Issues](https://github.com/newrelic/developer-website/issues) or JIRA tickets, add links to them here.
* [issue]()

## Screenshot(s)

If relevant, add screenshots here.

## Use Conventional Commits

Please help the maintainers by leveraging the following [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
standards in your pull request title and commit messages.

## Use `chore`

* for minor changes / additions / corrections to content.
* for minor changes / additions / corrections to images.
* for minor non-functional changes / additions to github actions, github templates, package or config updates, etc

```bash
git commit -m "chore: adjusting config and content"
```

## Use `fix`

* for minor functional corrections to code.

```bash
git commit -m "fix: typo and prop error in the code of conduct"
```

## Use `feat`

* for major functional changes or additions to code.

```bash
git commit -m "feat(media): creating a video landing page"
```
