### PR TITLE
cleanup redirects

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -109,66 +109,6 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     isPermanent: true,
   });
 
-  createRedirect({
-    fromPath: `/instant-observability/`,
-    toPath: `https://newrelic.com/instant-observability`,
-    isPermanent: true,
-  });
-
-  createRedirect({
-    fromPath: `/instant-observability/*`,
-    toPath: `https://newrelic.com/instant-observability/*`,
-    isPermanent: true,
-  });
-
-  createRedirect({
-    fromPath: `/students/`,
-    toPath: `https://newrelic.com/social-impact/students`,
-    isPermanent: true,
-  });
-
-  createRedirect({
-    fromPath: `/collect-data/infra/`,
-    toPath: `https://docs.newrelic.com/docs/infrastructure/infrastructure-monitoring/get-started/identify-root-causes-guide`,
-    isPermanent: true,
-  });
-
-  createRedirect({
-    fromPath: `/collect-data/network-performance-monitoring/`,
-    toPath: `https://docs.newrelic.com/docs/network-performance-monitoring/get-started/network-performance-monitoring-guide`,
-    isPermanent: true,
-  });
-
-  createRedirect({
-    fromPath: `/collect-data/browser/`,
-    toPath: `https://docs.newrelic.com/docs/browser/new-relic-browser/lab/over-view`,
-    isPermanent: true,
-  });
-
-  createRedirect({
-    fromPath: `/collect-data/browser/*`,
-    toPath: `https://docs.newrelic.com/docs/browser/new-relic-browser/lab/over-view`,
-    isPermanent: true,
-  });
-
-  createRedirect({
-    fromPath: `/automate-workflows/get-started-new-relic-cli/`,
-    toPath: `https://docs.newrelic.com/docs/new-relic-solutions/tutorials/new-relic-cli`,
-    isPermanent: true,
-  });
-
-  createRedirect({
-    fromPath: `/build-apps/build-hello-world-app/`,
-    toPath: `https://docs.newrelic.com/docs/new-relic-solutions/tutorials/build-hello-world-app`,
-    isPermanent: true,
-  });
-
-  createRedirect({
-    fromPath: `/build-apps/build-react-hooks-app/`,
-    toPath: `https://docs.newrelic.com/docs/new-relic-solutions/tutorials/build-react-hooks-app`,
-    isPermanent: true,
-  });
-
   allMdx.edges.forEach(({ node }) => {
     const {
       frontmatter,

--- a/src/components/DevSiteSeo.js
+++ b/src/components/DevSiteSeo.js
@@ -18,27 +18,6 @@ function DevSiteSeo({ description, meta, title, tags, location, type }) {
     `
   );
 
-  const crazyEgg = (location) => {
-    const crazyEggPathnames = [
-      '/',
-      '/instant-observability/',
-      '/instant-observability/node-js/01fdea36-5a15-44b4-a864-c4c99866735b/',
-      '/instant-observability/php/475dec69-10c9-4bc6-8312-3caa266fb028/',
-      '/instant-observability/apache/ad5affab-545a-4355-ad48-cfd66e2fbf00/',
-      '/instant-observability/java/3ebfb315-d0a6-4b27-9f89-b16a9a1ada5f/',
-      '/instant-observability/dotnet/2dff13b6-0fac-43a6-abc6-57f0a3299639/',
-      '/instant-observability/codestream/29bd9a4a-1c19-4219-9694-0942f6411ce7/',
-    ];
-    if (crazyEggPathnames.includes(location.pathname))
-      return (
-        <script
-          type="text/javascript"
-          src="//script.crazyegg.com/pages/scripts/0045/9836.js"
-          async="async"
-        />
-      );
-  };
-
   const metaDescription = description || site.siteMetadata.description;
 
   const globalMetadata = [
@@ -99,7 +78,6 @@ function DevSiteSeo({ description, meta, title, tags, location, type }) {
 
   return (
     <SEO location={location} title={title} type={type}>
-      {crazyEgg(location)}
       {validMetadata.map((data, index) => (
         <meta key={`${data.name}-${index}`} {...data} />
       ))}

--- a/src/data/external-redirects.json
+++ b/src/data/external-redirects.json
@@ -28,12 +28,12 @@
     "paths": ["/terraform/get-started-terraform"]
   },
   {
-  "url": "https://docs.newrelic.com/docs/more-integrations/terraform/terraform-intro",
-  "paths": ["/automate-workflows/get-started-terraform"]
+    "url": "https://docs.newrelic.com/docs/more-integrations/terraform/terraform-intro",
+    "paths": ["/automate-workflows/get-started-terraform"]
   },
   {
     "url": "https://docs.newrelic.com/docs/more-integrations/terraform/terraform-modules",
-    "paths": ["/terraform/terraform-modules"] 
+    "paths": ["/terraform/terraform-modules"]
   },
   {
     "url": "https://docs.newrelic.com/docs/more-integrations/terraform/terragrunt",
@@ -42,6 +42,13 @@
   {
     "url": "https://docs.newrelic.com/docs/more-integrations/terraform/terraform-intro",
     "paths": ["/terraform"]
-  } 
+  },
+  {
+    "url": "https://docs.newrelic.com/docs/new-relic-solutions/tutorials/new-relic-cli",
+    "paths": ["/automate-workflows/get-started-new-relic-cli"]
+  },
+  {
+    "url": "https://docs.newrelic.com/docs/new-relic-solutions/tutorials/build-hello-world-app",
+    "paths": ["/build-apps/build-hello-world-app"]
+  }
 ]
-


### PR DESCRIPTION
- redirects outside of dev site were not working properly as they were defined in the gatsby-node. moved to external-redirects.json
- also removes redirects that are no longer relevant
- removes crazyegg script