### PR TITLE
redirects

### DIFF
--- a/src/components/DevSiteSeo.js
+++ b/src/components/DevSiteSeo.js
@@ -18,27 +18,6 @@ function DevSiteSeo({ description, meta, title, tags, location, type }) {
     `
   );
 
-  const crazyEgg = (location) => {
-    const crazyEggPathnames = [
-      '/',
-      '/instant-observability/',
-      '/instant-observability/node-js/01fdea36-5a15-44b4-a864-c4c99866735b/',
-      '/instant-observability/php/475dec69-10c9-4bc6-8312-3caa266fb028/',
-      '/instant-observability/apache/ad5affab-545a-4355-ad48-cfd66e2fbf00/',
-      '/instant-observability/java/3ebfb315-d0a6-4b27-9f89-b16a9a1ada5f/',
-      '/instant-observability/dotnet/2dff13b6-0fac-43a6-abc6-57f0a3299639/',
-      '/instant-observability/codestream/29bd9a4a-1c19-4219-9694-0942f6411ce7/',
-    ];
-    if (crazyEggPathnames.includes(location.pathname))
-      return (
-        <script
-          type="text/javascript"
-          src="//script.crazyegg.com/pages/scripts/0045/9836.js"
-          async="async"
-        />
-      );
-  };
-
   const metaDescription = description || site.siteMetadata.description;
 
   const globalMetadata = [
@@ -99,7 +78,6 @@ function DevSiteSeo({ description, meta, title, tags, location, type }) {
 
   return (
     <SEO location={location} title={title} type={type}>
-      {crazyEgg(location)}
       {validMetadata.map((data, index) => (
         <meta key={`${data.name}-${index}`} {...data} />
       ))}

--- a/src/data/external-redirects.json
+++ b/src/data/external-redirects.json
@@ -28,12 +28,12 @@
     "paths": ["/terraform/get-started-terraform"]
   },
   {
-  "url": "https://docs.newrelic.com/docs/more-integrations/terraform/terraform-intro",
-  "paths": ["/automate-workflows/get-started-terraform"]
+    "url": "https://docs.newrelic.com/docs/more-integrations/terraform/terraform-intro",
+    "paths": ["/automate-workflows/get-started-terraform"]
   },
   {
     "url": "https://docs.newrelic.com/docs/more-integrations/terraform/terraform-modules",
-    "paths": ["/terraform/terraform-modules"] 
+    "paths": ["/terraform/terraform-modules"]
   },
   {
     "url": "https://docs.newrelic.com/docs/more-integrations/terraform/terragrunt",
@@ -42,6 +42,13 @@
   {
     "url": "https://docs.newrelic.com/docs/more-integrations/terraform/terraform-intro",
     "paths": ["/terraform"]
-  } 
+  },
+  {
+    "url": "https://docs.newrelic.com/docs/new-relic-solutions/tutorials/new-relic-cli",
+    "paths": ["/automate-workflows/get-started-new-relic-cli"]
+  },
+  {
+    "url": "https://docs.newrelic.com/docs/new-relic-solutions/tutorials/build-hello-world-app",
+    "paths": ["/build-apps/build-hello-world-app"]
+  }
 ]
-


### PR DESCRIPTION
- Adds redirects from developer path `build-apps/build-hello-world-app` and `automate-workflows/get-started-new-relic-cli/` to docs site to external-redirect.json to fix 404's. [This PR](https://github.com/newrelic/developer-website/pull/2241/files) migrated content to the docs site and added redirects, but they don't work when clicked within the dev site. 

- Also removes old crazyegg script.

example:
<img width="341" alt="Screenshot 2023-08-22 at 3 38 10 PM" src="https://github.com/newrelic/developer-website/assets/47728020/e79e789a-5b61-4e1b-913d-cfff0611eadb">

When clicking on 'Start the guide' from [developer.newrelic.com](https://developer.newrelic.com/) the link 404's

if you click in the [build preview](https://developerwebsitedevelop-tabatharedirects.gatsbyjs.io/) it works as expected


