### PR TITLE
Update workshop-dotnet.mdx

### DIFF
--- a/src/markdown-pages/opentelemetry-masterclass/hands-on/workshop-dotnet.mdx
+++ b/src/markdown-pages/opentelemetry-masterclass/hands-on/workshop-dotnet.mdx
@@ -513,7 +513,7 @@ The OTLP exporter looks for these variables in the Docker container’s environm
 
 <Step>
 
-Get or create a [New Relic license key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key) for your account, and set it in an environment variable called `NEW_RELIC_API_KEY`:
+Get or create a [New Relic **ingest** license key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key) for your account, and set it in an environment variable called `NEW_RELIC_API_KEY`:
 
 <>
 


### PR DESCRIPTION
Making it more clear that an ingest license key should be used, and not a user API key