### PR TITLE
Fix chapter num in opentelemetry-implementations.mdx

### DIFF
--- a/src/markdown-pages/opentelemetry-masterclass/fundamentals/opentelemetry-implementations.mdx
+++ b/src/markdown-pages/opentelemetry-masterclass/fundamentals/opentelemetry-implementations.mdx
@@ -71,6 +71,6 @@ In the next chapter, you walk through a practical example, using an OpenTelemetr
 
 <Callout variant="course">
 
-This lesson concludes chapter one of our OpenTelemetry masterclass. Continue on to [chapter three](/opentelemetry-masterclass/hands-on) where you get practical experience instrumenting an application with OpenTelemetry.
+This lesson concludes chapter two of our OpenTelemetry masterclass. Continue on to [chapter three](/opentelemetry-masterclass/hands-on) where you get practical experience instrumenting an application with OpenTelemetry.
 
 </Callout>


### PR DESCRIPTION
## Description

This doc concludes chapter _two_ of the OpenTelemetry Masterclass (which is correctly referenced elsewhere in the same doc). The end of the doc refers to the chapter as _one_ and this PR fixes that. 

## Reviewer Notes

N/A (I think)

## Related Issue(s) / Ticket(s)

N/A

## Screenshot(s)

N/A (it's just one word)

## Use Conventional Commits

I think I did this right, but open to feedback or amendments
