### PR TITLE
fix: Fix typo in "Set up your development environment" page

### DIFF
--- a/src/markdown-pages/build-apps/set-up-dev-env.mdx
+++ b/src/markdown-pages/build-apps/set-up-dev-env.mdx
@@ -98,7 +98,7 @@ This site is open source, and we want your input. Create a pull request if you s
 
 <Step>
 
-Fork the developer-website GithHub repo.
+Fork the developer-website GitHub repo.
 
 Forking the repo enables you to work on your own copy of the developer.newrelic.com files, and [build the site locally](https://github.com/newrelic/developer-website#developernewreliccom). It also enables us to more easily manage incomimg pull requests.
 


### PR DESCRIPTION
## Description

Changes "GithHub" -> "GitHub"

Very conveniently placed just below the contribution information :)