### PR TITLE
docs: Add note on valid characters for keys

### DIFF
--- a/src/markdown-pages/explore-docs/nerdstoragevault.mdx
+++ b/src/markdown-pages/explore-docs/nerdstoragevault.mdx
@@ -134,6 +134,7 @@ query {
 - A maximum of 10 secrets can be stored per ACTOR.
 - A secret value is limited to 5000 characters.
 - A key value is limited to 64 characters.
+- A key value must only include alphanumeric, '_' or '-' characters
 
 ### Permissions for working with NerdStorageVault
 


### PR DESCRIPTION
## Description

Adds a note on what characters are allowed in key values for the `nerd-storage-vault` service.

## Related Issue(s) / Ticket(s)

https://new-relic.atlassian.net/browse/NR-267056
