### PR TITLE
docs: Remove secret limit note for service migration

### DIFF
--- a/src/markdown-pages/explore-docs/nerdstoragevault.mdx
+++ b/src/markdown-pages/explore-docs/nerdstoragevault.mdx
@@ -131,7 +131,6 @@ query {
 
 ### Limits
 
-- A maximum of 10 secrets can be stored per ACTOR.
 - A secret value is limited to 5000 characters.
 - A key value is limited to 64 characters.
 - A key value must only include alphanumeric, '_' or '-' characters


### PR DESCRIPTION
## Description

Once we switch `nerd-storage-vault` to use Customer Secrets Service instead of Synthetics Locker, the secret limit per actor will no longer apply. This PR removes that note from the doc, and should be merged after the switch is made.

## Related Issue(s) / Ticket(s)

https://new-relic.atlassian.net/browse/NR-267056
