### PR TITLE
fix: replace broken CNCF incubator list link

### DIFF
--- a/src/markdown-pages/opentelemetry-masterclass/fundamentals/opentelemetry.mdx
+++ b/src/markdown-pages/opentelemetry-masterclass/fundamentals/opentelemetry.mdx
@@ -11,7 +11,7 @@ This lesson is a part of our OpenTelemetry masterclass. If you haven't already, 
 
 </Callout>
 
-[OpenTelemetry](https://opentelemetry.io) is an exciting new standard for open instrumentation, one that's supported by a large developer community composed of end users, cloud providers, and observability leaders (including New Relic). Like its predecessor, [OpenTracing](https://opentracing.io), it’s a CNCF project, currently in the [incubating](https://landscape.cncf.io/card-mode?project=incubating) phase of maturity.
+[OpenTelemetry](https://opentelemetry.io) is an exciting new standard for open instrumentation, one that's supported by a large developer community composed of end users, cloud providers, and observability leaders (including New Relic). Like its predecessor, [OpenTracing](https://opentracing.io), it’s a CNCF project, currently in the [incubating](https://landscape.cncf.io/?view-mode=card&classify=maturity&sort-by=name&sort-direction=asc&item=observability-and-analysis--observability--opentelemetry#maturity--incubating) phase of maturity.
 
 OpenTelemetry aims to:
 


### PR DESCRIPTION
## Description

- Current link ends in a 404. Based on the old URL it looks like it was pointing to the "card" list of CNCF incubator projects. I replaced it with a link that in addition also opens the OpenTelemetry "card" as that seemed appropriate given the context.

## Reviewer Notes

- Open link to verify that it behaves as described

## Screenshot

- Link should open the CNCF page in the following state
![image](https://github.com/newrelic/developer-website/assets/121687305/1de4d1b6-4c0e-4405-8bb7-9dd3101cda2c)